### PR TITLE
Activator change requires TypeActivator to be singleton

### DIFF
--- a/src/Microsoft.AspNet.Hosting/HostingServices.cs
+++ b/src/Microsoft.AspNet.Hosting/HostingServices.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AspNet.Hosting
             yield return describer.Transient<IApplicationBuilderFactory, ApplicationBuilderFactory>();
             yield return describer.Transient<IHttpContextFactory, HttpContextFactory>();
 
-            yield return describer.Transient<ITypeActivator, TypeActivator>();
+            yield return describer.Singleton<ITypeActivator, TypeActivator>();
 
             yield return describer.Instance<IApplicationLifetime>(new ApplicationLifetime());
 


### PR DESCRIPTION
We now cache instance creation logic. This requires TypeActivator to be singleton.
