### PR TITLE
Enable TestServer to populate the PathBase.

### DIFF
--- a/src/Microsoft.AspNet.TestHost/TestServer.cs
+++ b/src/Microsoft.AspNet.TestHost/TestServer.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNet.Builder;
 using Microsoft.AspNet.Hosting;
 using Microsoft.AspNet.Hosting.Server;
+using Microsoft.AspNet.Http;
 using Microsoft.Framework.ConfigurationModel;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.DependencyInjection.Fallback;
@@ -41,6 +42,8 @@ namespace Microsoft.AspNet.TestHost
             _appInstance = engine.Start(hostContext);
         }
 
+        public Uri BaseAddress { get; set; } = new Uri("http://localhost/");
+
         public static TestServer Create(Action<IApplicationBuilder> app)
         {
             return Create(provider: CallContextServiceLocator.Locator.ServiceProvider, app: app);
@@ -68,12 +71,13 @@ namespace Microsoft.AspNet.TestHost
 
         public HttpMessageHandler CreateHandler()
         {
-            return new ClientHandler(Invoke);
+            var pathBase = BaseAddress == null ? PathString.Empty : PathString.FromUriComponent(BaseAddress);
+            return new ClientHandler(Invoke, pathBase);
         }
 
         public HttpClient CreateClient()
         {
-            return new HttpClient(CreateHandler()) { BaseAddress = new Uri("http://localhost/") };
+            return new HttpClient(CreateHandler()) { BaseAddress = BaseAddress };
         }
 
         /// <summary>

--- a/test/Microsoft.AspNet.TestHost.Tests/ClientHandlerTests.cs
+++ b/test/Microsoft.AspNet.TestHost.Tests/ClientHandlerTests.cs
@@ -28,8 +28,8 @@ namespace Microsoft.AspNet.TestHost
                 Assert.Equal("HTTP/1.1", context.Request.Protocol);
                 Assert.Equal("GET", context.Request.Method);
                 Assert.Equal("https", context.Request.Scheme);
-                Assert.Equal(string.Empty, context.Request.PathBase.Value);
-                Assert.Equal("/A/Path/and/file.txt", context.Request.Path.Value);
+                Assert.Equal("/A/Path", context.Request.PathBase.Value);
+                Assert.Equal("/and/file.txt", context.Request.Path.Value);
                 Assert.Equal("?and=query", context.Request.QueryString.Value);
                 Assert.NotNull(context.Request.Body);
                 Assert.NotNull(context.Request.Headers);
@@ -40,7 +40,7 @@ namespace Microsoft.AspNet.TestHost
                 Assert.Equal("example.com", context.Request.Host.Value);
 
                 return Task.FromResult(0);
-            });
+            }, new PathString("/A/Path"));
             var httpClient = new HttpClient(handler);
             return httpClient.GetAsync("https://example.com/A/Path/and/file.txt?and=query");
         }
@@ -57,7 +57,7 @@ namespace Microsoft.AspNet.TestHost
 
                 context.Response.Headers["TestHeader"] = "TestValue:" + requestCount++;
                 return Task.FromResult(0);
-            });
+            }, PathString.Empty);
 
             HttpMessageInvoker invoker = new HttpMessageInvoker(handler);
             HttpRequestMessage message = new HttpRequestMessage(HttpMethod.Post, "https://example.com/");
@@ -79,7 +79,7 @@ namespace Microsoft.AspNet.TestHost
 
                 context.Response.Headers["TestHeader"] = "TestValue";
                 return Task.FromResult(0);
-            });
+            }, PathString.Empty);
             var httpClient = new HttpClient(handler);
             HttpResponseMessage response = await httpClient.GetAsync("https://example.com/");
             Assert.Equal("TestValue", response.Headers.GetValues("TestHeader").First());
@@ -93,7 +93,7 @@ namespace Microsoft.AspNet.TestHost
             {
                 block.WaitOne();
                 return Task.FromResult(0);
-            });
+            }, PathString.Empty);
             var httpClient = new HttpClient(handler);
             Task<HttpResponseMessage> task = httpClient.GetAsync("https://example.com/");
             Assert.False(task.IsCompleted);
@@ -113,7 +113,7 @@ namespace Microsoft.AspNet.TestHost
                 await context.Response.WriteAsync("BodyStarted,");
                 block.WaitOne();
                 await context.Response.WriteAsync("BodyFinished");
-            });
+            }, PathString.Empty);
             var httpClient = new HttpClient(handler);
             HttpResponseMessage response = await httpClient.GetAsync("https://example.com/",
                 HttpCompletionOption.ResponseHeadersRead);
@@ -133,7 +133,7 @@ namespace Microsoft.AspNet.TestHost
                 context.Response.Body.Flush();
                 block.WaitOne();
                 await context.Response.WriteAsync("BodyFinished");
-            });
+            }, PathString.Empty);
             var httpClient = new HttpClient(handler);
             HttpResponseMessage response = await httpClient.GetAsync("https://example.com/",
                 HttpCompletionOption.ResponseHeadersRead);
@@ -153,7 +153,7 @@ namespace Microsoft.AspNet.TestHost
                 context.Response.Body.Flush();
                 block.WaitOne();
                 return Task.FromResult(0);
-            });
+            }, PathString.Empty);
             var httpClient = new HttpClient(handler);
             HttpResponseMessage response = await httpClient.GetAsync("https://example.com/",
                 HttpCompletionOption.ResponseHeadersRead);
@@ -179,7 +179,7 @@ namespace Microsoft.AspNet.TestHost
                 context.Response.Body.Flush();
                 block.WaitOne();
                 return Task.FromResult(0);
-            });
+            }, PathString.Empty);
             var httpClient = new HttpClient(handler);
             HttpResponseMessage response = await httpClient.GetAsync("https://example.com/",
                 HttpCompletionOption.ResponseHeadersRead);
@@ -201,7 +201,7 @@ namespace Microsoft.AspNet.TestHost
             var handler = new ClientHandler(env =>
             {
                 throw new InvalidOperationException("Test Exception");
-            });
+            }, PathString.Empty);
             var httpClient = new HttpClient(handler);
             return Assert.ThrowsAsync<InvalidOperationException>(() => httpClient.GetAsync("https://example.com/",
                 HttpCompletionOption.ResponseHeadersRead));
@@ -218,7 +218,7 @@ namespace Microsoft.AspNet.TestHost
                 await context.Response.WriteAsync("BodyStarted");
                 block.WaitOne();
                 throw new InvalidOperationException("Test Exception");
-            });
+            }, PathString.Empty);
             var httpClient = new HttpClient(handler);
             HttpResponseMessage response = await httpClient.GetAsync("https://example.com/",
                 HttpCompletionOption.ResponseHeadersRead);


### PR DESCRIPTION
#78

The added BaseAddress property is used to set both HttpClient.BaseAddress and HttpRequest.PathBase.
This is needed to test https://github.com/aspnet/Security/issues/63.
