### PR TITLE
Remove DataProtectionOptions from the service collection.

### DIFF
--- a/src/Microsoft.AspNet.Hosting/HostingServices.cs
+++ b/src/Microsoft.AspNet.Hosting/HostingServices.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using Microsoft.AspNet.Hosting.Builder;
 using Microsoft.AspNet.Hosting.Server;
 using Microsoft.AspNet.Hosting.Startup;
-using Microsoft.AspNet.Security.DataProtection;
 using Microsoft.Framework.ConfigurationModel;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.Logging;
@@ -43,11 +42,6 @@ namespace Microsoft.AspNet.Hosting
             yield return describer.Scoped(typeof(IContextAccessor<>), typeof(ContextAccessor<>));
 
             foreach (var service in OptionsServices.GetDefaultServices())
-            {
-                yield return service;
-            }
-
-            foreach (var service in DataProtectionServices.GetDefaultServices())
             {
                 yield return service;
             }

--- a/src/Microsoft.AspNet.Hosting/Program.cs
+++ b/src/Microsoft.AspNet.Hosting/Program.cs
@@ -5,7 +5,6 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNet.Security.DataProtection;
 using Microsoft.Framework.ConfigurationModel;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.DependencyInjection.Fallback;
@@ -47,13 +46,6 @@ namespace Microsoft.AspNet.Hosting
             var serviceCollection = new ServiceCollection();
             serviceCollection.Add(HostingServices.GetDefaultServices(config));
             serviceCollection.AddInstance<IHostingEnvironment>(hostingEnv);
-            // The application name is a "good enough" mechanism to identify this application
-            // on the machine and to prevent subkeys from being shared across multiple applications
-            // by default.
-            serviceCollection.Configure<DataProtectionOptions>(options =>
-            {
-                options.ApplicationDiscriminator = appEnv.ApplicationName;
-            });
 
             var services = serviceCollection.BuildServiceProvider(_serviceProvider);
 

--- a/src/Microsoft.AspNet.Hosting/project.json
+++ b/src/Microsoft.AspNet.Hosting/project.json
@@ -3,7 +3,6 @@
     "description": "ASP.NET 5 core hosting infrastructure and startup logic for web applications.",
     "dependencies": {
         "Microsoft.AspNet.PipelineCore": "1.0.0-*",
-        "Microsoft.AspNet.Security.DataProtection": "1.0.0-*",
         "Microsoft.Framework.Logging": "1.0.0-*",
         "Microsoft.Framework.OptionsModel": "1.0.0-*",
         "Microsoft.Framework.Runtime.Interfaces": { "version": "1.0.0-*", "type": "build" },


### PR DESCRIPTION
#111

@lodejard @davidfowl 

This makes the entire Hosting repo no longer dependent on DataProtection so we'll want to update the CI.

I'll post a matching commit for Helios shortly.
