### PR TITLE
Make the way configurable how hosting is kept alive

### DIFF
--- a/src/Microsoft.AspNet.Hosting.Abstractions/IHostingKeepAlive.cs
+++ b/src/Microsoft.AspNet.Hosting.Abstractions/IHostingKeepAlive.cs
@@ -1,5 +1,7 @@
 ﻿// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
+
 namespace Microsoft.AspNet.Hosting
 {
     /// <summary>
@@ -11,6 +13,6 @@ namespace Microsoft.AspNet.Hosting
         /// Called when the application should be kept running.
         /// When this returns, the application shuts down.
         /// </summary>
-        void Hold();
+        Task SetupAsync();
     }
 }

--- a/src/Microsoft.AspNet.Hosting.Abstractions/IHostingKeepAlive.cs
+++ b/src/Microsoft.AspNet.Hosting.Abstractions/IHostingKeepAlive.cs
@@ -1,0 +1,16 @@
+﻿// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNet.Hosting
+{
+    /// <summary>
+    /// Provide a way to keep the application running
+    /// </summary>
+    public interface IHostingKeepAlive
+    {
+        /// <summary>
+        /// Called when the application should be kept running.
+        /// When this returns, the application shuts down.
+        /// </summary>
+        void Hold();
+    }
+}

--- a/src/Microsoft.AspNet.Hosting/ConsoleHostingKeepAlive.cs
+++ b/src/Microsoft.AspNet.Hosting/ConsoleHostingKeepAlive.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Microsoft.AspNet.Hosting
+{
+    public class ConsoleHostingKeepAlive : IHostingKeepAlive
+    {
+        public void Hold()
+        {
+            Console.WriteLine("Started");
+            Console.ReadLine();
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Hosting/ConsoleHostingKeepAlive.cs
+++ b/src/Microsoft.AspNet.Hosting/ConsoleHostingKeepAlive.cs
@@ -1,13 +1,17 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 namespace Microsoft.AspNet.Hosting
 {
     public class ConsoleHostingKeepAlive : IHostingKeepAlive
     {
-        public void Hold()
+        public Task SetupAsync()
         {
-            Console.WriteLine("Started");
-            Console.ReadLine();
+            return Task.Run(()=>
+            {
+                Console.WriteLine("Started");
+                Console.ReadLine();
+            });
         }
     }
 }

--- a/src/Microsoft.AspNet.Hosting/Internal/HostingEngine.cs
+++ b/src/Microsoft.AspNet.Hosting/Internal/HostingEngine.cs
@@ -90,6 +90,7 @@ namespace Microsoft.AspNet.Hosting.Internal
         {
             EnsureStartup();
 
+            _applicationServiceCollection.AddSingleton<IHostingKeepAlive, ConsoleHostingKeepAlive>();
             _applicationServiceCollection.AddInstance<IApplicationLifetime>(_applicationLifetime);
 
             _applicationServices = Startup.ConfigureServicesDelegate(_applicationServiceCollection);

--- a/src/Microsoft.AspNet.Hosting/Program.cs
+++ b/src/Microsoft.AspNet.Hosting/Program.cs
@@ -38,6 +38,7 @@ namespace Microsoft.AspNet.Hosting
             var serverShutdown = host.Start();
             var loggerFactory = host.ApplicationServices.GetRequiredService<ILoggerFactory>();
             var appShutdownService = host.ApplicationServices.GetRequiredService<IApplicationShutdown>();
+            var hostingKeepAlive = host.ApplicationServices.GetRequiredService<IHostingKeepAlive>();
             var shutdownHandle = new ManualResetEvent(false);
 
             appShutdownService.ShutdownRequested.Register(() =>
@@ -56,8 +57,7 @@ namespace Microsoft.AspNet.Hosting
 
             var ignored = Task.Run(() =>
             {
-                Console.WriteLine("Started");
-                Console.ReadLine();
+                hostingKeepAlive.Hold();
                 appShutdownService.RequestShutdown();
             });
 

--- a/src/Microsoft.AspNet.Hosting/Program.cs
+++ b/src/Microsoft.AspNet.Hosting/Program.cs
@@ -39,29 +39,28 @@ namespace Microsoft.AspNet.Hosting
             var loggerFactory = host.ApplicationServices.GetRequiredService<ILoggerFactory>();
             var appShutdownService = host.ApplicationServices.GetRequiredService<IApplicationShutdown>();
             var hostingKeepAlive = host.ApplicationServices.GetRequiredService<IHostingKeepAlive>();
-            var shutdownHandle = new ManualResetEvent(false);
+
+            var hostingKeepAliveTask = hostingKeepAlive.SetupAsync();
+            var shutdownTcs = new TaskCompletionSource<int>();
+            var shutdownRequestedTask = shutdownTcs.Task;
 
             appShutdownService.ShutdownRequested.Register(() =>
             {
-                try
-                {
-                    serverShutdown.Dispose();
-                }
-                catch (Exception ex)
-                {
-                    var logger = loggerFactory.CreateLogger<Program>();
-                    logger.LogError("Dispose threw an exception.", ex);
-                }
-                shutdownHandle.Set();
+                shutdownTcs.SetResult(0);
             });
 
-            var ignored = Task.Run(() =>
+            try
             {
-                hostingKeepAlive.Hold();
-                appShutdownService.RequestShutdown();
-            });
-
-            shutdownHandle.WaitOne();
+                using (serverShutdown)
+                {
+                    Task.WaitAny(hostingKeepAliveTask, shutdownRequestedTask);
+                }
+            }
+            catch (Exception ex)
+            {
+                var logger = loggerFactory.CreateLogger<Program>();
+                logger.LogError("Dispose threw an exception.", ex);
+            }
         }
     }
 }


### PR DESCRIPTION
I'm currently trying to host on Linux and integrated into systemd as init system. The fixed default of Console.ReadLine() to keep the hosting running does not work well and I would like to change this in my application so I can react properly to SIGTERM on Linux. This PR adds an interface and the current default implementation to Hosting.

Within a web application, this default can be overridden by
```csharp
services.AddInstance<IHostingKeepAlive>(new MyHostingKeepAlive());
```