### PR TITLE
Generalize PathBase logic

### DIFF
--- a/src/Microsoft.AspNet.TestHost/ClientHandler.cs
+++ b/src/Microsoft.AspNet.TestHost/ClientHandler.cs
@@ -38,6 +38,12 @@ namespace Microsoft.AspNet.TestHost
             }
 
             _next = next;
+
+            // PathString.StartsWithSegments that we use below requires the base path to not end in a slash.
+            if (pathBase.HasValue && pathBase.Value.EndsWith("/"))
+            {
+                pathBase = new PathString(pathBase.Value.Substring(0, pathBase.Value.Length - 1));
+            }
             _pathBase = pathBase;
         }
 

--- a/src/Microsoft.AspNet.TestHost/TestServer.cs
+++ b/src/Microsoft.AspNet.TestHost/TestServer.cs
@@ -62,11 +62,6 @@ namespace Microsoft.AspNet.TestHost
         public HttpMessageHandler CreateHandler()
         {
             var pathBase = BaseAddress == null ? PathString.Empty : PathString.FromUriComponent(BaseAddress);
-            if (pathBase.Equals(new PathString("/")))
-            {
-                // When we just have http://host/ the trailing slash is really part of the Path, not the PathBase.
-                pathBase = PathString.Empty;
-            }
             return new ClientHandler(Invoke, pathBase);
         }
 

--- a/test/Microsoft.AspNet.TestHost.Tests/ClientHandlerTests.cs
+++ b/test/Microsoft.AspNet.TestHost.Tests/ClientHandlerTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNet.TestHost
                 Assert.Equal("example.com", context.Request.Host.Value);
 
                 return Task.FromResult(0);
-            }, new PathString("/A/Path"));
+            }, new PathString("/A/Path/"));
             var httpClient = new HttpClient(handler);
             return httpClient.GetAsync("https://example.com/A/Path/and/file.txt?and=query");
         }


### PR DESCRIPTION
Some of the original path base logic in TestHost was too specific. For base addresses with an empty path it ensured that the `/` was part of the Path, not PathBase.  However it didn't correctly handle `/PathBase/` ending in a `/`, which needs to be stripped off for StartsWithSegments to work.

@Praburaj @muratg 
