### PR TITLE
Add ILogger to hosting services manifest

### DIFF
--- a/src/Microsoft.AspNet.Hosting/HostingServices.cs
+++ b/src/Microsoft.AspNet.Hosting/HostingServices.cs
@@ -67,7 +67,7 @@ namespace Microsoft.AspNet.Hosting
         {
             public HostingManifest(IServiceCollection hostServices)
             {
-                Services = new Type[] { typeof(ITypeActivator), typeof(IHostingEnvironment), typeof(ILoggerFactory), typeof(IHttpContextAccessor) }
+                Services = new Type[] { typeof(ITypeActivator), typeof(IHostingEnvironment), typeof(ILoggerFactory), typeof(ILogger<>), typeof(IHttpContextAccessor) }
                     .Concat(hostServices.Select(s => s.ServiceType)).Distinct();
             }
 

--- a/test/Microsoft.AspNet.Hosting.Tests/UseRequestServicesFacts.cs
+++ b/test/Microsoft.AspNet.Hosting.Tests/UseRequestServicesFacts.cs
@@ -93,6 +93,7 @@ namespace Microsoft.AspNet.Hosting.Tests
         [InlineData(typeof(IApplicationLifetime))]
         [InlineData(typeof(ILoggerFactory))]
         [InlineData(typeof(IHttpContextAccessor))]
+        [InlineData(typeof(ILogger<IHostingEngine>))]
         public void UseRequestServicesHostingImportedServicesAreDefined(Type service)
         {
             var baseServiceProvider = HostingServices.Create().BuildServiceProvider();


### PR DESCRIPTION
Appears that my hosting changes exposed a bug where we weren't registering the new ILogger<> service in the hosting manifests, so the service wasn't being found in MVC Razor functionals

cc @pranavkm @DamianEdwards @davidfowl 