### PR TITLE
Adding IApplicationLifetime to the manifest

### DIFF
--- a/src/Microsoft.AspNet.Hosting/HostingServices.cs
+++ b/src/Microsoft.AspNet.Hosting/HostingServices.cs
@@ -49,6 +49,7 @@ namespace Microsoft.AspNet.Hosting
                     typeof(ITypeActivator),
                     typeof(IHostingEnvironment),
                     typeof(ILoggerFactory),
+                    typeof(ILogger<>),
                     typeof(IHttpContextAccessor),
                     typeof(IApplicationLifetime)
                 }.Concat(manifest.Services).Distinct();

--- a/src/Microsoft.AspNet.Hosting/HostingServices.cs
+++ b/src/Microsoft.AspNet.Hosting/HostingServices.cs
@@ -45,8 +45,13 @@ namespace Microsoft.AspNet.Hosting
             public HostingManifest(IServiceProvider fallback)
             {
                 var manifest = fallback.GetRequiredService<IServiceManifest>();
-                Services = new Type[] { typeof(ITypeActivator), typeof(IHostingEnvironment), typeof(ILoggerFactory), typeof(IHttpContextAccessor) }
-                    .Concat(manifest.Services).Distinct();
+                Services = new Type[] {
+                    typeof(ITypeActivator),
+                    typeof(IHostingEnvironment),
+                    typeof(ILoggerFactory),
+                    typeof(IHttpContextAccessor),
+                    typeof(IApplicationLifetime)
+                }.Concat(manifest.Services).Distinct();
             }
 
             public IEnumerable<Type> Services { get; private set; }

--- a/test/Microsoft.AspNet.Hosting.Tests/UseRequestServicesFacts.cs
+++ b/test/Microsoft.AspNet.Hosting.Tests/UseRequestServicesFacts.cs
@@ -82,6 +82,7 @@ namespace Microsoft.AspNet.Hosting.Tests
         [InlineData(typeof(ITypeActivator))]
         [InlineData(typeof(IHostingEnvironment))]
         [InlineData(typeof(ILoggerFactory))]
+        [InlineData(typeof(ILogger<IHostingEngine>))]
         [InlineData(typeof(IHttpContextAccessor))]
         [InlineData(typeof(IApplicationLifetime))]
         public void UseRequestServicesHostingImportedServicesAreDefined(Type service)

--- a/test/Microsoft.AspNet.Hosting.Tests/UseRequestServicesFacts.cs
+++ b/test/Microsoft.AspNet.Hosting.Tests/UseRequestServicesFacts.cs
@@ -3,8 +3,6 @@
 
 using System;
 using Microsoft.AspNet.Builder;
-using Microsoft.AspNet.Hosting.Builder;
-using Microsoft.AspNet.Hosting.Server;
 using Microsoft.AspNet.Http.Core;
 using Microsoft.AspNet.RequestContainer;
 using Microsoft.Framework.DependencyInjection;
@@ -81,14 +79,11 @@ namespace Microsoft.AspNet.Hosting.Tests
         }
 
         [Theory]
-        [InlineData(typeof(IHostingEngine))]
-        [InlineData(typeof(IServerLoader))]
-        [InlineData(typeof(IApplicationBuilderFactory))]
-        [InlineData(typeof(IHttpContextFactory))]
         [InlineData(typeof(ITypeActivator))]
-        [InlineData(typeof(IApplicationLifetime))]
+        [InlineData(typeof(IHostingEnvironment))]
         [InlineData(typeof(ILoggerFactory))]
         [InlineData(typeof(IHttpContextAccessor))]
+        [InlineData(typeof(IApplicationLifetime))]
         public void UseRequestServicesHostingImportedServicesAreDefined(Type service)
         {
             var baseServiceProvider = HostingServices.Create().BuildServiceProvider();
@@ -96,7 +91,10 @@ namespace Microsoft.AspNet.Hosting.Tests
 
             builder.UseRequestServices();
 
-            Assert.NotNull(builder.ApplicationServices.GetRequiredService(service));
+            var fromAppServices = builder.ApplicationServices.GetRequiredService(service);
+
+            Assert.NotNull(fromAppServices);
+            Assert.Equal(baseServiceProvider.GetRequiredService(service), fromAppServices);
         }
     }
 }


### PR DESCRIPTION
Since IApplicationLifetime is not added to the manifest, while calling HostingServices.Create() before invoking ConfigureServices() we end up creating a new instance of IApplicationLifetime. So the Cancellationtoken that hosting triggers on appshutdown is different from what the app is exposed.

Fixes: https://github.com/aspnet/Hosting/issues/151

@HaoK @davidfowl 