### PR TITLE
Apply `configureHostServices` after the `fallbackProvider`

### DIFF
--- a/src/Microsoft.AspNet.Hosting/HostingServices.cs
+++ b/src/Microsoft.AspNet.Hosting/HostingServices.cs
@@ -17,16 +17,19 @@ namespace Microsoft.AspNet.Hosting
         private static IServiceCollection Import(IServiceProvider fallbackProvider, Action<IServiceCollection> configureHostServices)
         {
             var services = new ServiceCollection();
-            if (configureHostServices != null)
-            {
-                configureHostServices(services);
-            }
             var manifest = fallbackProvider.GetRequiredService<IServiceManifest>();
             foreach (var service in manifest.Services)
             {
                 services.AddTransient(service, sp => fallbackProvider.GetService(service));
             }
+
             services.AddSingleton<IServiceManifest>(sp => new HostingManifest(services));
+
+            if (configureHostServices != null)
+            {
+                configureHostServices(services);
+            }
+
             return services;
         }
 

--- a/src/Microsoft.AspNet.Hosting/HostingServices.cs
+++ b/src/Microsoft.AspNet.Hosting/HostingServices.cs
@@ -23,12 +23,12 @@ namespace Microsoft.AspNet.Hosting
                 services.AddTransient(service, sp => fallbackProvider.GetService(service));
             }
 
-            services.AddSingleton<IServiceManifest>(sp => new HostingManifest(services));
-
             if (configureHostServices != null)
             {
                 configureHostServices(services);
             }
+
+            services.AddSingleton<IServiceManifest>(sp => new HostingManifest(services));
 
             return services;
         }

--- a/test/Microsoft.AspNet.Hosting.Tests/HostingServicesFacts.cs
+++ b/test/Microsoft.AspNet.Hosting.Tests/HostingServicesFacts.cs
@@ -97,7 +97,7 @@ namespace Microsoft.AspNet.Hosting.Tests
         }
 
         [Fact]
-        public void CreateAdditionalServicesDoNotOverrideFallback()
+        public void CreateAdditionalServicesOverridesFallback()
         {
             // Arrange
             var fallbackServices = new ServiceCollection();
@@ -108,15 +108,15 @@ namespace Microsoft.AspNet.Hosting.Tests
                     typeof(IFakeService),
                 }));
 
-            var services = HostingServices.Create(fallbackServices.BuildServiceProvider(), 
+            var services = HostingServices.Create(fallbackServices.BuildServiceProvider(),
                 additionalHostServices => additionalHostServices.AddSingleton<IFakeService, FakeService>());
 
             // Act
             var provider = services.BuildServiceProvider();
-            var stillTransient = provider.GetRequiredService<IFakeService>();
+            var singleton = provider.GetRequiredService<IFakeService>();
 
             // Assert
-            Assert.NotSame(stillTransient, provider.GetRequiredService<IFakeService>());
+            Assert.Same(singleton, provider.GetRequiredService<IFakeService>());
         }
 
         [Fact]

--- a/test/Microsoft.AspNet.Hosting.Tests/HostingServicesFacts.cs
+++ b/test/Microsoft.AspNet.Hosting.Tests/HostingServicesFacts.cs
@@ -120,6 +120,33 @@ namespace Microsoft.AspNet.Hosting.Tests
         }
 
         [Fact]
+        public void CreateAdditionalServices_IncludesServicesInManifest()
+        {
+            // Arrange
+            var fallbackServices = new ServiceCollection();
+            fallbackServices.AddTransient<IFakeService, FakeService>();
+            fallbackServices.AddInstance<IServiceManifest>(new ServiceManifest(
+                new Type[] {
+                    typeof(IFakeService),
+                }));
+            var expectedInstance = new FakeService();
+            var services = HostingServices.Create(
+                fallbackServices.BuildServiceProvider(),
+                additionalHostServices => additionalHostServices.AddInstance<IFakeServiceInstance>(expectedInstance));
+
+            // Act
+            var provider = services.BuildServiceProvider();
+            var instance = provider.GetRequiredService<IFakeServiceInstance>();
+            var anotherInstance = provider.GetRequiredService<IFakeServiceInstance>();
+            var manifest = provider.GetRequiredService<IServiceManifest>();
+
+            // Assert
+            Assert.Same(expectedInstance, instance);
+            Assert.Same(expectedInstance, anotherInstance);
+            Assert.Contains(typeof(IFakeServiceInstance), manifest.Services);
+        }
+
+        [Fact]
         public void CanHideImportedServices()
         {
             // Arrange


### PR DESCRIPTION
- allows MVC to override `IApplicationEnvironment` in functional tests