### PR TITLE
Expose HostingEngine.CreateApplicationServices

### DIFF
--- a/src/Microsoft.AspNet.Hosting/HostingContext.cs
+++ b/src/Microsoft.AspNet.Hosting/HostingContext.cs
@@ -17,7 +17,9 @@ namespace Microsoft.AspNet.Hosting
         public IApplicationBuilder Builder { get; set; }
 
         public string ApplicationName { get; set; }
-        public string WebRootPath { get; set; }
+        // REVIEW: BasePath and WebRootPath are basically setting same thing?
+        public string ApplicationBasePath { get; set; }
+        //public string WebRootPath { get; set; }
         public string EnvironmentName { get; set; }
         public StartupMethods StartupMethods { get; set; }
         public RequestDelegate ApplicationDelegate { get; set; }

--- a/src/Microsoft.AspNet.Hosting/HostingEngine.cs
+++ b/src/Microsoft.AspNet.Hosting/HostingEngine.cs
@@ -38,9 +38,20 @@ namespace Microsoft.AspNet.Hosting
             _fallbackServices = new WrappingServiceProvider(_fallbackServices, _hostingEnvironment, _appLifetime);
         }
 
+        public static IServiceProvider CreateApplicationServices(HostingContext context)
+        {
+            return CreateApplicationServices(context, fallbackServices: null);
+        }
+
+        public static IServiceProvider CreateApplicationServices(HostingContext context, IServiceProvider fallbackServices)
+        {
+            var engine = new HostingEngine(fallbackServices);
+            engine.EnsureApplicationServices(context);
+            return context.ApplicationServices;
+        }
+
         public IDisposable Start(HostingContext context)
         {
-            EnsureContextDefaults(context);
             EnsureApplicationServices(context);
             EnsureBuilder(context);
             EnsureServerFactory(context);
@@ -87,6 +98,8 @@ namespace Microsoft.AspNet.Hosting
 
         private void EnsureApplicationServices(HostingContext context)
         {
+            EnsureContextDefaults(context);
+
             if (context.ApplicationServices != null)
             {
                 return;

--- a/src/Microsoft.AspNet.Hosting/HostingEngine.cs
+++ b/src/Microsoft.AspNet.Hosting/HostingEngine.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+using System.Runtime.Versioning;
 using System.Threading;
 using Microsoft.AspNet.Hosting.Builder;
 using Microsoft.AspNet.Hosting.Internal;
@@ -21,7 +23,7 @@ namespace Microsoft.AspNet.Hosting
 
         private readonly IServiceProvider _fallbackServices;
         private readonly ApplicationLifetime _appLifetime;
-        private readonly IApplicationEnvironment _applicationEnvironment;
+        private readonly IApplicationEnvironment _appEnv;
         private readonly HostingEnvironment _hostingEnvironment;
 
         private IServerLoader _serverLoader;
@@ -29,12 +31,15 @@ namespace Microsoft.AspNet.Hosting
 
         public HostingEngine() : this(fallbackServices: null) { }
 
-        public HostingEngine(IServiceProvider fallbackServices)
+        public HostingEngine(IServiceProvider fallbackServices) : this(fallbackServices, applicationName: null, applicationPath: null) { }
+
+        public HostingEngine(IServiceProvider fallbackServices, string applicationName, string applicationPath)
         {
             _fallbackServices = fallbackServices ?? CallContextServiceLocator.Locator.ServiceProvider;
             _appLifetime = new ApplicationLifetime();
-            _applicationEnvironment = _fallbackServices.GetRequiredService<IApplicationEnvironment>();
-            _hostingEnvironment = new HostingEnvironment(_applicationEnvironment);
+            var appEnv = _fallbackServices.GetRequiredService<IApplicationEnvironment>();
+            _appEnv = new HostingApplicationEnvironment(appEnv, applicationPath, applicationName);
+            _hostingEnvironment = new HostingEnvironment(_appEnv);
             _fallbackServices = new WrappingServiceProvider(_fallbackServices, _hostingEnvironment, _appLifetime);
         }
 
@@ -43,14 +48,15 @@ namespace Microsoft.AspNet.Hosting
             return CreateApplicationServices(context, fallbackServices: null);
         }
 
+        // REVIEW: so ugly ApplicationName used here as input
         public static IServiceProvider CreateApplicationServices(HostingContext context, IServiceProvider fallbackServices)
         {
-            var engine = new HostingEngine(fallbackServices);
+            var engine = new HostingEngine(fallbackServices, context.ApplicationName, context.ApplicationBasePath);
 
             // Default to no-op startup if not specified in context
             if (context.StartupMethods == null)
             {
-                context.StartupMethods = new StartupMethods(_ => { }, configureServices: null);
+                context.StartupMethods = new StartupMethods(_ => { });
             }
             engine.EnsureApplicationServices(context);
             return context.ApplicationServices;
@@ -86,7 +92,7 @@ namespace Microsoft.AspNet.Hosting
         {
             if (context.ApplicationName == null)
             {
-                context.ApplicationName = _applicationEnvironment.ApplicationName;
+                context.ApplicationName = _appEnv.ApplicationName;
             }
 
             if (context.EnvironmentName == null)
@@ -95,11 +101,6 @@ namespace Microsoft.AspNet.Hosting
             }
 
             _hostingEnvironment.EnvironmentName = context.EnvironmentName;
-
-            if (context.WebRootPath != null)
-            {
-                _hostingEnvironment.WebRootPath = context.WebRootPath;
-            }
         }
 
         private void EnsureApplicationServices(HostingContext context)
@@ -198,9 +199,10 @@ namespace Microsoft.AspNet.Hosting
             // Apply user services
             services.Add(context.Services);
 
-            // Jamming in app lifetime and hosting env since these must not be replaceable
+            // Jamming in app lifetime, app env, and hosting env since these must not be replaceable
             services.AddInstance<IApplicationLifetime>(_appLifetime);
             services.AddInstance<IHostingEnvironment>(_hostingEnvironment);
+            services.AddInstance(_appEnv);
 
             // Conjure up a RequestServices
             services.AddTransient<IStartupFilter, AutoRequestServicesStartupFilter>();
@@ -268,6 +270,51 @@ namespace Microsoft.AspNet.Hosting
                 }
 
                 return _sp.GetService(serviceType);
+            }
+        }
+
+        // Represents an application environment that overrides the base path of the original
+        // application environment in order to make it point to the test application folder.
+        private class HostingApplicationEnvironment : IApplicationEnvironment
+        {
+            private readonly IApplicationEnvironment _originalAppEnvironment;
+            private readonly string _appName;
+            private readonly string _appPath;
+
+            public HostingApplicationEnvironment(
+                IApplicationEnvironment originalAppEnvironment,
+                string appPath,
+                string appName)
+            {
+                _originalAppEnvironment = originalAppEnvironment;
+                _appPath = appPath;
+                _appName = appName;
+            }
+
+            public string ApplicationName
+            {
+                get { return _appName ?? _originalAppEnvironment.ApplicationName; }
+            }
+
+            public string Version
+            {
+                get { return _originalAppEnvironment.Version; }
+            }
+
+            public string ApplicationBasePath
+            {
+                get { return _appPath ?? _originalAppEnvironment.ApplicationBasePath; }
+            }
+
+            public string Configuration
+            {
+                get
+                { return _originalAppEnvironment.Configuration; }
+            }
+
+            public FrameworkName RuntimeFramework
+            {
+                get { return _originalAppEnvironment.RuntimeFramework; }
             }
         }
 

--- a/src/Microsoft.AspNet.Hosting/HostingEngine.cs
+++ b/src/Microsoft.AspNet.Hosting/HostingEngine.cs
@@ -46,6 +46,12 @@ namespace Microsoft.AspNet.Hosting
         public static IServiceProvider CreateApplicationServices(HostingContext context, IServiceProvider fallbackServices)
         {
             var engine = new HostingEngine(fallbackServices);
+
+            // Default to no-op startup if not specified in context
+            if (context.StartupMethods == null)
+            {
+                context.StartupMethods = new StartupMethods(_ => { }, configureServices: null);
+            }
             engine.EnsureApplicationServices(context);
             return context.ApplicationServices;
         }

--- a/src/Microsoft.AspNet.Hosting/Startup/ApplicationStartup.cs
+++ b/src/Microsoft.AspNet.Hosting/Startup/ApplicationStartup.cs
@@ -76,7 +76,6 @@ namespace Microsoft.AspNet.Hosting.Startup
             return new StartupMethods(configureMethod.Build(instance), servicesMethod?.Build(instance));
         }
 
-
         public static ConfigureBuilder FindConfigureDelegate(Type startupType, string environmentName)
         {
             var configureMethod = FindMethod(startupType, "Configure{0}", environmentName, typeof(void), required: true);

--- a/src/Microsoft.AspNet.Hosting/Startup/StartupMethods.cs
+++ b/src/Microsoft.AspNet.Hosting/Startup/StartupMethods.cs
@@ -8,6 +8,9 @@ namespace Microsoft.AspNet.Hosting.Startup
 {
     public class StartupMethods
     {
+        public StartupMethods(Action<IApplicationBuilder> configure) 
+            : this(configure, configureServices: null) { }
+
         // TODO: switch to ConfigureDelegate eventually
         public StartupMethods(Action<IApplicationBuilder> configure, ConfigureServicesDelegate configureServices)
         {

--- a/test/Microsoft.AspNet.Hosting.Tests/HostingEngineTests.cs
+++ b/test/Microsoft.AspNet.Hosting.Tests/HostingEngineTests.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNet.FeatureModel;
 using Microsoft.AspNet.Hosting.Server;
 using Microsoft.Framework.ConfigurationModel;
 using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.OptionsModel;
 using Xunit;
 
 namespace Microsoft.AspNet.Hosting
@@ -36,6 +37,15 @@ namespace Microsoft.AspNet.Hosting
             engineStart.Dispose();
 
             Assert.Equal(1, _startInstances[0].DisposeCalls);
+        }
+
+        [Fact]
+        public void CanCreateApplicationServicesWithDefaultHostingContext()
+        {
+            var context = new HostingContext();
+            context.Services.AddOptions();
+            var appServices = HostingEngine.CreateApplicationServices(context);
+            Assert.NotNull(appServices.GetRequiredService<IOptions<object>>());
         }
 
         [Fact]
@@ -129,11 +139,6 @@ namespace Microsoft.AspNet.Hosting
                 Assert.True(env.IsEnvironment("Development"));
                 Assert.True(env.IsEnvironment("developMent"));
             }
-        }
-
-        public void Initialize(IApplicationBuilder builder)
-        {
-
         }
 
         public IServerInformation Initialize(IConfiguration configuration)


### PR DESCRIPTION
@davidfowl @divega Thoughts?  Basically this will be the replacement for the old HostingServices.Create for how to create ApplicationServices without having to go through the whole HostingEngine/context setup.  This eliminates the need for implementing IServerFactory just to create an ApplicationServices.