### PR TITLE
Adding some tests for the MapPath extension method

### DIFF
--- a/src/Microsoft.AspNet.Hosting.Interfaces/HostingEnvironmentExtensions.cs
+++ b/src/Microsoft.AspNet.Hosting.Interfaces/HostingEnvironmentExtensions.cs
@@ -40,6 +40,8 @@ namespace Microsoft.AspNet.Hosting
                 return hostingEnvironment.WebRootPath;
             }
 
+            // On windows replace / with \.
+            virtualPath = virtualPath.Replace('/', Path.DirectorySeparatorChar);
             return Path.Combine(hostingEnvironment.WebRootPath, virtualPath);
         }
     }

--- a/test/Microsoft.AspNet.Hosting.Tests/HostingEngineTests.cs
+++ b/test/Microsoft.AspNet.Hosting.Tests/HostingEngineTests.cs
@@ -131,6 +131,32 @@ namespace Microsoft.AspNet.Hosting
             }
         }
 
+        [Theory]
+        [InlineData(null, "")]
+        [InlineData("", "")]
+        [InlineData("/", "/")]
+        [InlineData(@"\", @"\")]
+        [InlineData("sub", "sub")]
+        [InlineData("sub/sub2/sub3", @"sub/sub2/sub3")]
+        [InlineData(@"sub/sub2\sub3\", @"sub/sub2/sub3/")]
+        public void MapPath_Facts(string virtualPath, string expectedSuffix)
+        {
+            var context = new HostingContext
+            {
+                ServerFactory = this
+            };
+
+            var engine = new HostingEngine();
+
+            using (engine.Start(context))
+            {
+                var env = context.ApplicationServices.GetRequiredService<IHostingEnvironment>();
+                var mappedPath = env.MapPath(virtualPath);
+                expectedSuffix = expectedSuffix.Replace('/', Path.DirectorySeparatorChar);
+                Assert.Equal(Path.Combine(env.WebRootPath, expectedSuffix), mappedPath);
+            }
+        }
+
         public void Initialize(IApplicationBuilder builder)
         {
 


### PR DESCRIPTION
And looks like I pushed the MapPath extension change too soon. I had to fix an issue in the path for forward and backward slash.

For example if an application tries to do MapPath("/resource") then this code does not work cross plat unless the directory separator characters are fixed appropriately.

Fixed it and also added some test coverage.

@muratg 