### PR TITLE
PR feedback on IsEnvironment extension

### DIFF
--- a/src/Microsoft.AspNet.Hosting.Interfaces/HostingEnvironmentExtensions.cs
+++ b/src/Microsoft.AspNet.Hosting.Interfaces/HostingEnvironmentExtensions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNet.Hosting
         /// <returns>True if the specified name is same as the current environment.</returns>
         public static bool IsEnvironment(
             [NotNull]this IHostingEnvironment hostingEnvironment,
-            [NotNull]string environmentName)
+            string environmentName)
         {
             return string.Equals(
                 hostingEnvironment.EnvironmentName,


### PR DESCRIPTION
removing [NotNull] on environmentName parameter. String.Equals is expected to handle this appropriately.

@Eilon 