### PR TITLE
Create a logging scope having request id

### DIFF
--- a/src/Microsoft.AspNet.Hosting/DefaultRequestIdentifierFeature.cs
+++ b/src/Microsoft.AspNet.Hosting/DefaultRequestIdentifierFeature.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNet.Http;
+
+namespace Microsoft.AspNet.Hosting
+{
+    public class DefaultRequestIdentifierFeature : IRequestIdentifierFeature
+    {
+        public DefaultRequestIdentifierFeature()
+        {
+            TraceIdentifier = Guid.NewGuid();
+        }
+
+        public Guid TraceIdentifier { get; }
+    }
+}

--- a/test/Microsoft.AspNet.Hosting.Tests/project.json
+++ b/test/Microsoft.AspNet.Hosting.Tests/project.json
@@ -5,6 +5,7 @@
         "Microsoft.AspNet.Testing": "1.0.0-*",
         "Microsoft.Framework.OptionsModel": "1.0.0-*",
         "Microsoft.Framework.Runtime.Interfaces": "1.0.0-*",
+        "Moq": "4.2.1312.1622",
         "xunit.runner.aspnet": "2.0.0-aspnet-*"
     },
     "frameworks": {


### PR DESCRIPTION
Here we create a log scope per request so that any logs that get written fall into this scope giving a correlation. `SerilogLogger` is an example which logs the scope information for every log message that it writes.

I have verified this change in Weblistener and IIS but not in Kestrel though (will have to work with some other folks to test this).

Some integration points:
**Weblistener** 
https://github.com/aspnet/WebListener/blob/dev/src/Microsoft.AspNet.Server.WebListener/MessagePump.cs#L164

**Helios**
https://github.com/aspnet/Helios/blob/1f76783178e54d5e9c020a27a2cfbd6f2dda1d53/src/Microsoft.AspNet.Loader.IIS/RuntimeHttpApplication.cs#L113

**Kestrel**
https://github.com/aspnet/KestrelHttpServer/blob/cb3def56683cc9e0294b5e78fb70f686be4074ee/src/Kestrel/ServerFactory.cs#L50

Yes, doing this in hosting layer will cause the log messages written at specific hosts to not have this scope(this is still an open discussion and will revisit later).

**Please note**: This PR does not have any unit tests yet. I wanted to get this out to get some initial comments.

@davidfowl @Praburaj @rynowak @loudej 