### PR TITLE
Add IsDevelopment and IsProduction extension methods

### DIFF
--- a/src/Microsoft.AspNet.Hosting.Interfaces/HostingEnvironmentExtensions.cs
+++ b/src/Microsoft.AspNet.Hosting.Interfaces/HostingEnvironmentExtensions.cs
@@ -9,6 +9,29 @@ namespace Microsoft.AspNet.Hosting
 {
     public static class HostingEnvironmentExtensions
     {
+        private const string DevelopmentEnvironmentName = "Development";
+        private const string ProductionEnvironmentName = "Production";
+
+        /// <summary>
+        /// Checks if the current hosting environment name is development.
+        /// </summary>
+        /// <param name="hostingEnvironment">An instance of <see cref="IHostingEnvironment"/> service.</param>
+        /// <returns>True if the environment name is Development, otherwise false.</returns>
+        public static bool IsDevelopment([NotNull]this IHostingEnvironment hostingEnvironment)
+        {
+            return hostingEnvironment.IsEnvironment(DevelopmentEnvironmentName);
+        }
+
+        /// <summary>
+        /// Checks if the current hosting environment name is Production.
+        /// </summary>
+        /// <param name="hostingEnvironment">An instance of <see cref="IHostingEnvironment"/> service.</param>
+        /// <returns>True if the environment name is Production, otherwise false.</returns>
+        public static bool IsProduction([NotNull]this IHostingEnvironment hostingEnvironment)
+        {
+            return hostingEnvironment.IsEnvironment(ProductionEnvironmentName);
+        }
+
         /// <summary>
         /// Compares the current hosting environment name against the specified value.
         /// </summary>


### PR DESCRIPTION
Production and Development are the two names that we will have baked into the stack. Development is what VS will set when running applications, and Production will be the default that the DNX sets.

We should provide these methods so I don't need to guess what I should put in there, or look up the docs, when I am starting a new application without the scaffolding.

I think it looks slightly nicer than IsEnvironment("Development") as well.