### PR TITLE
Improvements to ApplicationStartup.

### DIFF
--- a/src/Microsoft.AspNet.Hosting/Startup/ApplicationStartup.cs
+++ b/src/Microsoft.AspNet.Hosting/Startup/ApplicationStartup.cs
@@ -94,32 +94,51 @@ namespace Microsoft.AspNet.Hosting.Startup
         {
             var methodNameWithEnv = string.Format(CultureInfo.InvariantCulture, methodName, environmentName);
             var methodNameWithNoEnv = string.Format(CultureInfo.InvariantCulture, methodName, "");
-            var methodInfo = startupType.GetMethod(methodNameWithEnv, BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static)
-                ?? startupType.GetMethod(methodNameWithNoEnv, BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static);
-            if (methodInfo == null)
-            {
-                if (required)
-                {
-                    throw new InvalidOperationException(string.Format("A method named '{0}' or '{1}' in the type '{2}' could not be found.",
-                        methodNameWithEnv,
-                        methodNameWithNoEnv,
-                        startupType.FullName));
 
-                }
-                return null;
-            }
-            if (returnType != null && methodInfo.ReturnType != returnType)
-            {
-                if (required)
-                {
-                    throw new InvalidOperationException(string.Format("The '{0}' method in the type '{1}' must have a return type of '{2}'.",
-                        methodInfo.Name,
-                        startupType.FullName,
-                        returnType.Name));
-                }
-                return null;
-            }
-            return methodInfo;
+			try
+			{
+				var methodInfo = startupType.GetMethod(methodNameWithEnv, BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static)
+					?? startupType.GetMethod(methodNameWithNoEnv, BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static);
+
+				if (methodInfo == null)
+				{
+					if (required)
+					{
+						throw new InvalidOperationException(string.Format("A method named '{0}' or '{1}' in the type '{2}' could not be found.",
+							methodNameWithEnv,
+							methodNameWithNoEnv,
+							startupType.FullName));
+
+					}
+					return null;
+				}
+				if (returnType != null && methodInfo.ReturnType != returnType)
+				{
+					if (required)
+					{
+						throw new InvalidOperationException(string.Format("The '{0}' method in the type '{1}' must have a return type of '{2}'.",
+							methodInfo.Name,
+							startupType.FullName,
+							returnType.Name));
+					}
+					return null;
+				}
+				return methodInfo;
+			}
+			catch (AmbiguousMatchException ambMatchEx)
+			{
+				throw new NotSupportedException(
+					string.Format("The method '{0}' does not support overloading. Make sure only one occurence of the method '{0}' in type '{1}' is present", 
+					methodName,
+					startupType.FullName),
+					
+					innerException:  ambMatchEx
+				);
+			}
+			catch
+			{
+				throw;
+			}
         }
     }
 }

--- a/src/Microsoft.AspNet.Hosting/Startup/ApplicationStartup.cs
+++ b/src/Microsoft.AspNet.Hosting/Startup/ApplicationStartup.cs
@@ -95,50 +95,50 @@ namespace Microsoft.AspNet.Hosting.Startup
             var methodNameWithEnv = string.Format(CultureInfo.InvariantCulture, methodName, environmentName);
             var methodNameWithNoEnv = string.Format(CultureInfo.InvariantCulture, methodName, "");
 
-			try
-			{
-				var methodInfo = startupType.GetMethod(methodNameWithEnv, BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static)
-					?? startupType.GetMethod(methodNameWithNoEnv, BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static);
+            try
+            {
+                var methodInfo = startupType.GetMethod(methodNameWithEnv, BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static)
+                    ?? startupType.GetMethod(methodNameWithNoEnv, BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static);
 
-				if (methodInfo == null)
-				{
-					if (required)
-					{
-						throw new InvalidOperationException(string.Format("A method named '{0}' or '{1}' in the type '{2}' could not be found.",
-							methodNameWithEnv,
-							methodNameWithNoEnv,
-							startupType.FullName));
+                if (methodInfo == null)
+                {
+                    if (required)
+                    {
+                        throw new InvalidOperationException(string.Format("A method named '{0}' or '{1}' in the type '{2}' could not be found.",
+                            methodNameWithEnv,
+                            methodNameWithNoEnv,
+                            startupType.FullName));
 
-					}
-					return null;
-				}
-				if (returnType != null && methodInfo.ReturnType != returnType)
-				{
-					if (required)
-					{
-						throw new InvalidOperationException(string.Format("The '{0}' method in the type '{1}' must have a return type of '{2}'.",
-							methodInfo.Name,
-							startupType.FullName,
-							returnType.Name));
-					}
-					return null;
-				}
-				return methodInfo;
-			}
-			catch (AmbiguousMatchException ambMatchEx)
-			{
-				throw new NotSupportedException(
-					string.Format("The method '{0}' does not support overloading. Make sure only one occurence of the method '{0}' in type '{1}' is present", 
-					methodName,
-					startupType.FullName),
-					
-					innerException:  ambMatchEx
-				);
-			}
-			catch
-			{
-				throw;
-			}
+                    }
+                    return null;
+                }
+                if (returnType != null && methodInfo.ReturnType != returnType)
+                {
+                    if (required)
+                    {
+                        throw new InvalidOperationException(string.Format("The '{0}' method in the type '{1}' must have a return type of '{2}'.",
+                            methodInfo.Name,
+                            startupType.FullName,
+                            returnType.Name));
+                    }
+                    return null;
+                }
+                return methodInfo;
+            }
+            catch (AmbiguousMatchException ambMatchEx)
+            {
+                throw new NotSupportedException(
+                    string.Format("The method '{0}' does not support overloading. Make sure only one occurence of the method '{0}' in type '{1}' is present",
+                    methodName,
+                    startupType.FullName),
+
+                    innerException: ambMatchEx
+                );
+            }
+            catch
+            {
+                throw;
+            }
         }
     }
 }


### PR DESCRIPTION
Added a try-catch block to "FindMethod" which will allow further error-handling.

Also catching AmbiguousMatchException which occurs when multiple occurences of "Configure" (of example) are present. This will solve issue #212