### PR TITLE
Add more logging while starting dnx.exe or dnu.cmd

### DIFF
--- a/src/Microsoft.AspNet.Server.Testing/Deployers/ApplicationDeployer.cs
+++ b/src/Microsoft.AspNet.Server.Testing/Deployers/ApplicationDeployer.cs
@@ -86,7 +86,7 @@ namespace Microsoft.AspNet.Server.Testing
                 FileName = dnuPath,
                 Arguments = parameters,
                 UseShellExecute = false,
-                CreateNoWindow = true
+                CreateNoWindow = false
             };
 
             var hostProcess = Process.Start(startInfo);

--- a/src/Microsoft.AspNet.Server.Testing/Deployers/SelfHostDeployer.cs
+++ b/src/Microsoft.AspNet.Server.Testing/Deployers/SelfHostDeployer.cs
@@ -58,7 +58,7 @@ namespace Microsoft.AspNet.Server.Testing
                 FileName = dnxPath,
                 Arguments = string.Format("\"{0}\" {1} --server.urls {2}", DeploymentParameters.ApplicationPath, commandName, DeploymentParameters.ApplicationBaseUriHint),
                 UseShellExecute = false,
-                CreateNoWindow = true
+                CreateNoWindow = false
             };
 
             AddEnvironmentVariablesToProcess(startInfo);


### PR DESCRIPTION
@Tratcher 

Previously there was a failure on CI on turning this on. Investigating the failure by changing the flag as there is no better way to debug. If this still fails will rollback. 