### PR TITLE
Redirecting output for all process starts to see correlation in logs

### DIFF
--- a/src/Microsoft.AspNet.Server.Testing/Deployers/ApplicationDeployer.cs
+++ b/src/Microsoft.AspNet.Server.Testing/Deployers/ApplicationDeployer.cs
@@ -86,10 +86,17 @@ namespace Microsoft.AspNet.Server.Testing
                 FileName = dnuPath,
                 Arguments = parameters,
                 UseShellExecute = false,
-                CreateNoWindow = false
+                CreateNoWindow = true,
+                RedirectStandardError = true,
+                RedirectStandardOutput = true
             };
 
-            var hostProcess = Process.Start(startInfo);
+            var hostProcess = new Process() { StartInfo = startInfo };
+            hostProcess.ErrorDataReceived += (sender, dataArgs) => { Logger.LogError(dataArgs.Data); };
+            hostProcess.OutputDataReceived += (sender, dataArgs) => { Logger.LogInformation(dataArgs.Data); };
+            hostProcess.Start();
+            hostProcess.BeginErrorReadLine();
+            hostProcess.BeginOutputReadLine();
             hostProcess.WaitForExit();
 
             if (hostProcess.ExitCode != 0)

--- a/src/Microsoft.AspNet.Server.Testing/Deployers/SelfHostDeployer.cs
+++ b/src/Microsoft.AspNet.Server.Testing/Deployers/SelfHostDeployer.cs
@@ -58,7 +58,6 @@ namespace Microsoft.AspNet.Server.Testing
                 FileName = dnxPath,
                 Arguments = string.Format("\"{0}\" {1} --server.urls {2}", DeploymentParameters.ApplicationPath, commandName, DeploymentParameters.ApplicationBaseUriHint),
                 UseShellExecute = false,
-                // https://github.com/aspnet/Hosting/issues/140 causing host process to exit when this is made false.
                 CreateNoWindow = true,
                 RedirectStandardError = true,
                 RedirectStandardOutput = true
@@ -66,9 +65,7 @@ namespace Microsoft.AspNet.Server.Testing
 
             AddEnvironmentVariablesToProcess(startInfo);
 
-            _hostProcess = Process.Start(startInfo);
-            _hostProcess.BeginErrorReadLine();
-            _hostProcess.BeginOutputReadLine();
+            _hostProcess = new Process() { StartInfo = startInfo };
             _hostProcess.ErrorDataReceived += (sender, dataArgs) => { Logger.LogError(dataArgs.Data); };
             _hostProcess.OutputDataReceived += (sender, dataArgs) => { Logger.LogInformation(dataArgs.Data); };
             _hostProcess.EnableRaisingEvents = true;
@@ -77,6 +74,9 @@ namespace Microsoft.AspNet.Server.Testing
             {
                 TriggerHostShutdown(hostExitTokenSource);
             };
+            _hostProcess.Start();
+            _hostProcess.BeginErrorReadLine();
+            _hostProcess.BeginOutputReadLine();
 
             if (_hostProcess.HasExited)
             {


### PR DESCRIPTION
@Tratcher 