### PR TITLE
Using 'nameof' operator instead of magic strings

### DIFF
--- a/src/Microsoft.AspNet.Hosting/Server/ServerLoader.cs
+++ b/src/Microsoft.AspNet.Hosting/Server/ServerLoader.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNet.Hosting.Server
         {
             if (string.IsNullOrEmpty(serverFactoryIdentifier))
             {
-                throw new ArgumentException(string.Empty, "serverFactoryIdentifier");
+                throw new ArgumentException(string.Empty, nameof(serverFactoryIdentifier));
             }
 
             var nameParts = HostingUtilities.SplitTypeName(serverFactoryIdentifier);

--- a/src/Microsoft.AspNet.Server.Testing/Common/DeploymentParameters.cs
+++ b/src/Microsoft.AspNet.Server.Testing/Common/DeploymentParameters.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNet.Server.Testing
         {
             if (string.IsNullOrEmpty(applicationPath))
             {
-                throw new ArgumentException("Value cannot be null.", "applicationPath");
+                throw new ArgumentException("Value cannot be null.", nameof(applicationPath));
             }
 
             if (!Directory.Exists(applicationPath))

--- a/src/Microsoft.AspNet.TestHost/ClientHandler.cs
+++ b/src/Microsoft.AspNet.TestHost/ClientHandler.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNet.TestHost
         {
             if (next == null)
             {
-                throw new ArgumentNullException("next");
+                throw new ArgumentNullException(nameof(next));
             }
 
             _next = next;
@@ -58,7 +58,7 @@ namespace Microsoft.AspNet.TestHost
         {
             if (request == null)
             {
-                throw new ArgumentNullException("request");
+                throw new ArgumentNullException(nameof(request));
             }
 
             var state = new RequestState(request, _pathBase, cancellationToken);

--- a/src/Microsoft.AspNet.TestHost/RequestBuilder.cs
+++ b/src/Microsoft.AspNet.TestHost/RequestBuilder.cs
@@ -30,7 +30,7 @@ namespace Microsoft.AspNet.TestHost
         {
             if (server == null)
             {
-                throw new ArgumentNullException("server");
+                throw new ArgumentNullException(nameof(server));
             }
 
             _server = server;
@@ -46,7 +46,7 @@ namespace Microsoft.AspNet.TestHost
         {
             if (configure == null)
             {
-                throw new ArgumentNullException("configure");
+                throw new ArgumentNullException(nameof(configure));
             }
 
             configure(_req);

--- a/src/Microsoft.AspNet.TestHost/ResponseStream.cs
+++ b/src/Microsoft.AspNet.TestHost/ResponseStream.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNet.TestHost
         {
             if (onFirstWrite == null)
             {
-                throw new ArgumentNullException("onFirstWrite");
+                throw new ArgumentNullException(nameof(onFirstWrite));
             }
             _onFirstWrite = onFirstWrite;
             _firstWrite = true;

--- a/src/Microsoft.AspNet.TestHost/TestServer.cs
+++ b/src/Microsoft.AspNet.TestHost/TestServer.cs
@@ -117,7 +117,7 @@ namespace Microsoft.AspNet.TestHost
         {
             if (!(serverInformation.GetType() == typeof(ServerInformation)))
             {
-                throw new ArgumentException(string.Format("The server must be {0}", ServerName), "serverInformation");
+                throw new ArgumentException(string.Format("The server must be {0}", ServerName), nameof(serverInformation));
             }
 
             _appDelegate = application;


### PR DESCRIPTION
Using the "nameof" operator instead of magic string will help us if the variable change in the future for whatever the reason