### PR TITLE
Add an ApplicationStarted event

### DIFF
--- a/src/Microsoft.AspNet.Hosting.Abstractions/IApplicationLifetime.cs
+++ b/src/Microsoft.AspNet.Hosting.Abstractions/IApplicationLifetime.cs
@@ -11,6 +11,12 @@ namespace Microsoft.AspNet.Hosting
     public interface IApplicationLifetime
     {
         /// <summary>
+        /// Triggered when the application host has fully started and is about to wait
+        /// for a graceful shutdown.
+        /// </summary>
+        CancellationToken ApplicationStarted { get; }
+
+        /// <summary>
         /// Triggered when the application host is performing a graceful shutdown.
         /// Request may still be in flight. Shutdown will block until this event completes.
         /// </summary>

--- a/src/Microsoft.AspNet.Hosting/ApplicationLifetime.cs
+++ b/src/Microsoft.AspNet.Hosting/ApplicationLifetime.cs
@@ -11,8 +11,18 @@ namespace Microsoft.AspNet.Hosting
     /// </summary>
     public class ApplicationLifetime : IApplicationLifetime
     {
+        private readonly CancellationTokenSource _startedSource = new CancellationTokenSource();
         private readonly CancellationTokenSource _stoppingSource = new CancellationTokenSource();
         private readonly CancellationTokenSource _stoppedSource = new CancellationTokenSource();
+
+        /// <summary>
+        /// Triggered when the application host has fully started and is about to wait
+        /// for a graceful shutdown.
+        /// </summary>
+        public CancellationToken ApplicationStarted
+        {
+            get { return _startedSource.Token; }
+        }
 
         /// <summary>
         /// Triggered when the application host is performing a graceful shutdown.
@@ -33,6 +43,21 @@ namespace Microsoft.AspNet.Hosting
         public CancellationToken ApplicationStopped
         {
             get { return _stoppedSource.Token; }
+        }
+
+        /// <summary>
+        /// Signals the ApplicationStarted event and blocks until it completes.
+        /// </summary>
+        public void NotifyStarted()
+        {
+            try
+            {
+                _startedSource.Cancel(throwOnFirstException: false);
+            }
+            catch (Exception)
+            {
+                // TODO: LOG
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.AspNet.Hosting/Internal/HostingEngine.cs
+++ b/src/Microsoft.AspNet.Hosting/Internal/HostingEngine.cs
@@ -79,6 +79,8 @@ namespace Microsoft.AspNet.Hosting.Internal
                     }
                 });
 
+            _applicationLifetime.NotifyStarted();
+
             return new Disposable(() =>
             {
                 _applicationLifetime.NotifyStopping();

--- a/test/Microsoft.AspNet.Hosting.Tests/HostingEngineTests.cs
+++ b/test/Microsoft.AspNet.Hosting.Tests/HostingEngineTests.cs
@@ -91,6 +91,21 @@ namespace Microsoft.AspNet.Hosting
         }
 
         [Fact]
+        public void HostingEngineNotifiesApplicationStarted()
+        {
+            var host = CreateBuilder()
+                .UseServer(this)
+                .Build();
+            var applicationLifetime = host.ApplicationServices.GetRequiredService<IApplicationLifetime>();
+
+            Assert.False(applicationLifetime.ApplicationStarted.IsCancellationRequested);
+            using (host.Start())
+            {
+                Assert.True(applicationLifetime.ApplicationStarted.IsCancellationRequested);
+            }
+        }
+
+        [Fact]
         public void HostingEngineInjectsHostingEnvironment()
         {
             var engine = CreateBuilder()


### PR DESCRIPTION
The discussion in #253 and my own experience show, that it would be great to have a notification once everything is up and running.

The canonical use case is the `Console.WriteLine("Started")` for console users. My own requirement is a notification for systemd that the process has completely finished starting up and that it's safe to start the web browser on my embedded device using [libsystemd](http://www.freedesktop.org/software/systemd/man/sd_notify.html):

```C#
public static class SystemdStartupNotifier
{
    public static void NotifySystemd(this IApplicationLifetime applicationLifetime)
    {
        applicationLifetime.ApplicationStarted.Register(handler);
    }

    private static void handler()
    {
        sd_notify(0, "READY=1");
    }

    [DllImport("libsystemd.so.0")]
    private static extern int sd_notify(int unset_environment, string state);
}
```