### PR TITLE
Provide access to IApplicationShutdown's RequestShutdown through IApplicationLifetime

### DIFF
--- a/src/Microsoft.AspNet.Hosting.Abstractions/IApplicationLifetime.cs
+++ b/src/Microsoft.AspNet.Hosting.Abstractions/IApplicationLifetime.cs
@@ -17,6 +17,11 @@ namespace Microsoft.AspNet.Hosting
         CancellationToken ApplicationStarted { get; }
 
         /// <summary>
+        /// Terminates the application
+        /// </summary>
+        void StopApplication();
+
+        /// <summary>
         /// Triggered when the application host is performing a graceful shutdown.
         /// Request may still be in flight. Shutdown will block until this event completes.
         /// </summary>

--- a/src/Microsoft.AspNet.Hosting/ApplicationLifetime.cs
+++ b/src/Microsoft.AspNet.Hosting/ApplicationLifetime.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading;
+using Microsoft.Framework.Runtime;
 
 namespace Microsoft.AspNet.Hosting
 {
@@ -11,9 +12,15 @@ namespace Microsoft.AspNet.Hosting
     /// </summary>
     public class ApplicationLifetime : IApplicationLifetime
     {
+        private readonly IApplicationShutdown _applicationShutdown;
         private readonly CancellationTokenSource _startedSource = new CancellationTokenSource();
         private readonly CancellationTokenSource _stoppingSource = new CancellationTokenSource();
         private readonly CancellationTokenSource _stoppedSource = new CancellationTokenSource();
+
+        public ApplicationLifetime(IApplicationShutdown applicationShutdown)
+        {
+            _applicationShutdown = applicationShutdown;
+        }
 
         /// <summary>
         /// Triggered when the application host has fully started and is about to wait
@@ -23,6 +30,11 @@ namespace Microsoft.AspNet.Hosting
         {
             get { return _startedSource.Token; }
         }
+
+        /// <summary>
+        /// Terminates the application
+        /// </summary>
+        public void StopApplication() => _applicationShutdown.RequestShutdown();
 
         /// <summary>
         /// Triggered when the application host is performing a graceful shutdown.

--- a/src/Microsoft.AspNet.Hosting/Internal/HostingEngine.cs
+++ b/src/Microsoft.AspNet.Hosting/Internal/HostingEngine.cs
@@ -15,6 +15,7 @@ using Microsoft.Framework.ConfigurationModel;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.Internal;
 using Microsoft.Framework.Logging;
+using Microsoft.Framework.Runtime;
 
 namespace Microsoft.AspNet.Hosting.Internal
 {
@@ -40,12 +41,13 @@ namespace Microsoft.AspNet.Hosting.Internal
         public HostingEngine(
             [NotNull] IServiceCollection appServices, 
             [NotNull] IStartupLoader startupLoader, 
-            [NotNull] IConfiguration config)
+            [NotNull] IConfiguration config,
+            [NotNull] IApplicationShutdown applicationShutdown)
         {
             _config = config;
             _applicationServiceCollection = appServices;
             _startupLoader = startupLoader;
-            _applicationLifetime = new ApplicationLifetime();
+            _applicationLifetime = new ApplicationLifetime(applicationShutdown);
         }
 
         public IServiceProvider ApplicationServices

--- a/src/Microsoft.AspNet.Hosting/WebHostBuilder.cs
+++ b/src/Microsoft.AspNet.Hosting/WebHostBuilder.cs
@@ -96,10 +96,11 @@ namespace Microsoft.AspNet.Hosting
 
             var appEnvironment = hostingContainer.GetRequiredService<IApplicationEnvironment>();
             var startupLoader = hostingContainer.GetRequiredService<IStartupLoader>();
+            var applicationShutdown = hostingContainer.GetRequiredService<IApplicationShutdown>();
 
             _hostingEnvironment.Initialize(appEnvironment.ApplicationBasePath, _config?[EnvironmentKey] ?? _config?[OldEnvironmentKey]);
 
-            var engine = new HostingEngine(hostingServices, startupLoader, _config);
+            var engine = new HostingEngine(hostingServices, startupLoader, _config, applicationShutdown);
 
             // Only one of these should be set, but they are used in priority
             engine.ServerFactory = _serverFactory;


### PR DESCRIPTION
Currently you have to work with two interfaces if you want to control application lifetime entirely. This change extends `IApplicationLifetime` with the ability to initiate application shutdown by forwarding it to `IApplicationShutdown`, so consumers of Hosting need only one interface for application lifetime purposes.