### PR TITLE
Disable two tests failing on Mono

### DIFF
--- a/test/Microsoft.AspNet.TestHost.Tests/ClientHandlerTests.cs
+++ b/test/Microsoft.AspNet.TestHost.Tests/ClientHandlerTests.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNet.FeatureModel;
 using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Http.Features;
 using Microsoft.AspNet.Http.Internal;
+using Microsoft.AspNet.Testing.xunit;
 using Xunit;
 
 namespace Microsoft.AspNet.TestHost
@@ -222,7 +223,8 @@ namespace Microsoft.AspNet.TestHost
                 HttpCompletionOption.ResponseHeadersRead));
         }
 
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public async Task ExceptionAfterFirstWriteIsReported()
         {
             ManualResetEvent block = new ManualResetEvent(false);

--- a/test/Microsoft.AspNet.TestHost.Tests/RequestBuilderTests.cs
+++ b/test/Microsoft.AspNet.TestHost.Tests/RequestBuilderTests.cs
@@ -1,13 +1,16 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.AspNet.Testing.xunit;
 using Xunit;
 
 namespace Microsoft.AspNet.TestHost
 {
     public class RequestBuilderTests
     {
-        [Fact]
+        // c.f. https://github.com/mono/mono/pull/1832
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public void AddRequestHeader()
         {
             var server = TestServer.Create(app => { });

--- a/test/Microsoft.AspNet.TestHost.Tests/project.json
+++ b/test/Microsoft.AspNet.TestHost.Tests/project.json
@@ -1,5 +1,6 @@
 {
     "dependencies": {
+        "Microsoft.AspNet.Testing": "1.0.0-*",
         "Microsoft.AspNet.TestHost": "1.0.0-*",
         "xunit.runner.aspnet": "2.0.0-aspnet-*"
     },


### PR DESCRIPTION
There are two tests regarding test host, that currently fail on Mono.

RequestBuilderTests.AddRequestHeader:
Mono's HttpHeaders implementation has a bug with regards to the Host header. See mono/mono#1832.

ClientHandlerTests.ExceptionAfterFirstWriteIsReported
Instead of the expected `InvalidOperationException`, the `IOException` from `ResponseStream.CheckAborted` reaches the test. I'm not sure if this is an expected outcome - async/await stack traces are not really fun to follow…