### PR TITLE
Create the wwwroot directory if it doesn't exist.

### DIFF
--- a/src/Microsoft.AspNet.Hosting/HostingEnvironmentExtensions.cs
+++ b/src/Microsoft.AspNet.Hosting/HostingEnvironmentExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.IO;
 using Microsoft.AspNet.FileProviders;
 using Microsoft.AspNet.Hosting.Internal;
 
@@ -11,6 +12,10 @@ namespace Microsoft.AspNet.Hosting
         public static void Initialize(this IHostingEnvironment hostingEnvironment, string applicationBasePath, string environmentName)
         {
             hostingEnvironment.WebRootPath = HostingUtilities.GetWebRoot(applicationBasePath);
+            if (!Directory.Exists(hostingEnvironment.WebRootPath))
+            {
+                Directory.CreateDirectory(hostingEnvironment.WebRootPath);
+            }
             hostingEnvironment.WebRootFileProvider = new PhysicalFileProvider(hostingEnvironment.WebRootPath);
             hostingEnvironment.EnvironmentName = environmentName ?? hostingEnvironment.EnvironmentName;
         }


### PR DESCRIPTION
#233 
`dnx . web` will now create the wwwroot directory rather than throwing a DirectoryNotFoundException. There's a tooling bug tracking the same for VS launches.
@muratg @davidfowl 