### PR TITLE
Cleanup ServerLoader logic

### DIFF
--- a/src/Microsoft.AspNet.Hosting/Internal/HostingUtilities.cs
+++ b/src/Microsoft.AspNet.Hosting/Internal/HostingUtilities.cs
@@ -10,19 +10,6 @@ namespace Microsoft.AspNet.Hosting.Internal
 {
     public static class HostingUtilities
     {
-        internal static Tuple<string, string> SplitTypeName(string identifier)
-        {
-            string typeName = null;
-            var assemblyName = identifier.Trim();
-            var parts = identifier.Split(new[] { ',' }, 2);
-            if (parts.Length == 2)
-            {
-                typeName = parts[0].Trim();
-                assemblyName = parts[1].Trim();
-            }
-            return new Tuple<string, string>(typeName, assemblyName);
-        }
-
         public static string GetWebRoot(string applicationBasePath)
         {
             var webroot = applicationBasePath;

--- a/src/Microsoft.AspNet.Hosting/Server/ServerLoader.cs
+++ b/src/Microsoft.AspNet.Hosting/Server/ServerLoader.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNet.Hosting.Server
                 throw new InvalidOperationException($"No server type found that implements IServerFactory in assembly: {assemblyName}.");
             }
 
-            return (IServerFactory)ActivatorUtilities.GetServiceOrCreateInstance(_services, serverType);
+            return (IServerFactory)ActivatorUtilities.GetServiceOrCreateInstance(_services, serverType.AsType());
         }
     }
 }

--- a/src/Microsoft.AspNet.Hosting/Server/ServerLoader.cs
+++ b/src/Microsoft.AspNet.Hosting/Server/ServerLoader.cs
@@ -4,8 +4,8 @@
 using System;
 using System.Linq;
 using System.Reflection;
-using Microsoft.AspNet.Hosting.Internal;
 using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.Internal;
 
 namespace Microsoft.AspNet.Hosting.Server
 {
@@ -18,16 +18,12 @@ namespace Microsoft.AspNet.Hosting.Server
             _services = services;
         }
 
-        public IServerFactory LoadServerFactory(string serverFactoryIdentifier)
+        public IServerFactory LoadServerFactory([NotNull] string assemblyName)
         {
-            if (string.IsNullOrEmpty(serverFactoryIdentifier))
+            if (string.IsNullOrEmpty(assemblyName))
             {
-                throw new ArgumentException(string.Empty, nameof(serverFactoryIdentifier));
+                throw new ArgumentException(string.Empty, nameof(assemblyName));
             }
-
-            var nameParts = HostingUtilities.SplitTypeName(serverFactoryIdentifier);
-            var typeName = nameParts.Item1;
-            var assemblyName = nameParts.Item2;
 
             var assembly = Assembly.Load(new AssemblyName(assemblyName));
             if (assembly == null)
@@ -35,42 +31,16 @@ namespace Microsoft.AspNet.Hosting.Server
                 throw new Exception(string.Format("The assembly {0} failed to load.", assemblyName));
             }
 
-            Type type = null;
-            Type interfaceInfo;
-            if (string.IsNullOrEmpty(typeName))
+            var serverType = assembly.DefinedTypes.Where(
+                t => t.ImplementedInterfaces.FirstOrDefault(interf => interf.Equals(typeof(IServerFactory))) != null)
+                .FirstOrDefault();
+
+            if (serverType == null)
             {
-                foreach (var typeInfo in assembly.DefinedTypes)
-                {
-                    interfaceInfo = typeInfo.ImplementedInterfaces.FirstOrDefault(interf => interf.Equals(typeof(IServerFactory)));
-                    if (interfaceInfo != null)
-                    {
-                        type = typeInfo.AsType();
-                    }
-                }
-
-                if (type == null)
-                {
-                    throw new Exception(string.Format("The type {0} failed to load.", typeName ?? "<null>"));
-                }
-            }
-            else
-            {
-                type = assembly.GetType(typeName);
-
-                if (type == null)
-                {
-                    throw new Exception(String.Format("The type {0} failed to load.", typeName ?? "<null>"));
-                }
-
-                interfaceInfo = type.GetTypeInfo().ImplementedInterfaces.FirstOrDefault(interf => interf.Equals(typeof(IServerFactory)));
-
-                if (interfaceInfo == null)
-                {
-                    throw new Exception(string.Format("The type '{0}' does not implement the '{1}' interface.", type, typeof(IServerFactory).FullName));
-                }
+                throw new InvalidOperationException($"No server type found that implements IServerFactory in assembly: {assemblyName}.");
             }
 
-            return (IServerFactory)ActivatorUtilities.GetServiceOrCreateInstance(_services, type);
+            return (IServerFactory)ActivatorUtilities.GetServiceOrCreateInstance(_services, serverType);
         }
     }
 }

--- a/src/Microsoft.AspNet.Hosting/Server/ServerLoader.cs
+++ b/src/Microsoft.AspNet.Hosting/Server/ServerLoader.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using Microsoft.Framework.DependencyInjection;
@@ -31,16 +32,16 @@ namespace Microsoft.AspNet.Hosting.Server
                 throw new Exception(string.Format("The assembly {0} failed to load.", assemblyName));
             }
 
-            var serverType = assembly.DefinedTypes.Where(
+            var serverTypeInfo = assembly.DefinedTypes.Where(
                 t => t.ImplementedInterfaces.FirstOrDefault(interf => interf.Equals(typeof(IServerFactory))) != null)
                 .FirstOrDefault();
 
-            if (serverType == null)
+            if (serverTypeInfo == null)
             {
                 throw new InvalidOperationException($"No server type found that implements IServerFactory in assembly: {assemblyName}.");
             }
 
-            return (IServerFactory)ActivatorUtilities.GetServiceOrCreateInstance(_services, serverType.AsType());
+            return (IServerFactory)ActivatorUtilities.GetServiceOrCreateInstance(_services, serverTypeInfo.AsType());
         }
     }
 }

--- a/src/Microsoft.AspNet.Hosting/Server/ServerLoader.cs
+++ b/src/Microsoft.AspNet.Hosting/Server/ServerLoader.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using Microsoft.Framework.DependencyInjection;


### PR DESCRIPTION
Fixes https://github.com/aspnet/Hosting/issues/214

Note looks like the old code was doing a weird (finding all IServerLoaders and the last one wins).  Now we just select the first one (I'm not sure that edge case matters, but we could throw possibly instead and use SingleOrDefault?)

cc @Tratcher @davidfowl 