### PR TITLE
Keep the process alive long enough to shutdown gracefully.

### DIFF
--- a/src/Microsoft.AspNet.Hosting/Program.cs
+++ b/src/Microsoft.AspNet.Hosting/Program.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNet.Hosting
 
         public void Main(string[] args)
         {
-            // Allow the location of the ini file to be specfied via a --config command line arg
+            // Allow the location of the ini file to be specified via a --config command line arg
             var tempBuilder = new ConfigurationBuilder().AddCommandLine(args);
             var tempConfig = tempBuilder.Build();
             var configFilePath = tempConfig[ConfigFileKey] ?? HostingIniFile;
@@ -39,7 +39,12 @@ namespace Microsoft.AspNet.Hosting
             {
                 Console.WriteLine("Started");
                 var appShutdownService = host.ApplicationServices.GetRequiredService<IApplicationShutdown>();
-                Console.CancelKeyPress += delegate { appShutdownService.RequestShutdown(); };
+                Console.CancelKeyPress += (sender, eventArgs) =>
+                {
+                    appShutdownService.RequestShutdown();
+                    // Don't terminate the process immediately, wait for the Main thread to exit gracefully.
+                    eventArgs.Cancel = true;
+                };
                 appShutdownService.ShutdownRequested.WaitHandle.WaitOne();
             }
         }


### PR DESCRIPTION
#296 
Ctl+c from the command line kills the process as soon as the Console.CancelKeyPress event finishes, it doesn't wait for the Main method/thread to exit.
@muratg @davidfowl @jsacapdev @HaoK 