### PR TITLE
Locate startup type by name or assembly.

### DIFF
--- a/src/Microsoft.AspNet.Hosting/Internal/HostingEngine.cs
+++ b/src/Microsoft.AspNet.Hosting/Internal/HostingEngine.cs
@@ -29,7 +29,7 @@ namespace Microsoft.AspNet.Hosting.Internal
         private IServiceProvider _applicationServices;
 
         // Only one of these should be set
-        internal string StartupAssemblyName { get; set; }
+        internal string StartupName { get; set; }
         internal StartupMethods Startup { get; set; }
         internal Type StartupType { get; set; }
 
@@ -110,12 +110,12 @@ namespace Microsoft.AspNet.Hosting.Internal
             if (StartupType == null)
             {
                 var diagnosticTypeMessages = new List<string>();
-                StartupType = _startupLoader.FindStartupType(StartupAssemblyName, diagnosticTypeMessages);
+                StartupType = _startupLoader.FindStartupType(StartupName, diagnosticTypeMessages);
                 if (StartupType == null)
                 {
                     throw new ArgumentException(
                         diagnosticTypeMessages.Aggregate("Failed to find a startup type for the web application.", (a, b) => a + "\r\n" + b),
-                        StartupAssemblyName);
+                        StartupName);
                 }
             }
 
@@ -125,7 +125,7 @@ namespace Microsoft.AspNet.Hosting.Internal
             {
                 throw new ArgumentException(
                     diagnosticMessages.Aggregate("Failed to find a startup entry point for the web application.", (a, b) => a + "\r\n" + b),
-                    StartupAssemblyName);
+                    StartupName);
             }
         }
 

--- a/src/Microsoft.AspNet.Hosting/Startup/IStartupLoader.cs
+++ b/src/Microsoft.AspNet.Hosting/Startup/IStartupLoader.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNet.Hosting.Startup
 {
     public interface IStartupLoader
     {
-        Type FindStartupType(string startupAssemblyName, IList<string> diagnosticMessages);
+        Type FindStartupType(string startupName, IList<string> diagnosticMessages);
 
         StartupMethods LoadMethods(Type startupType, IList<string> diagnosticMessages);
     }

--- a/src/Microsoft.AspNet.Hosting/WebHostBuilder.cs
+++ b/src/Microsoft.AspNet.Hosting/WebHostBuilder.cs
@@ -36,7 +36,7 @@ namespace Microsoft.AspNet.Hosting
         // Only one of these should be set
         private StartupMethods _startup;
         private Type _startupType;
-        private string _startupAssemblyName;
+        private string _startupName;
 
         // Only one of these should be set
         private string _serverFactoryLocation;
@@ -111,7 +111,7 @@ namespace Microsoft.AspNet.Hosting
             // Only one of these should be set, but they are used in priority
             engine.Startup = _startup;
             engine.StartupType = _startupType;
-            engine.StartupAssemblyName = _startupAssemblyName ?? _config.Get(ApplicationKey) ?? _config.Get(OldApplicationKey) ?? appEnvironment.ApplicationName;
+            engine.StartupName = _startupName ?? _config.Get(ApplicationKey) ?? _config.Get(OldApplicationKey) ?? appEnvironment.ApplicationName;
 
             return engine;
         }
@@ -140,13 +140,13 @@ namespace Microsoft.AspNet.Hosting
             return this;
         }
 
-        public WebHostBuilder UseStartup([NotNull] string startupAssemblyName)
+        public WebHostBuilder UseStartup([NotNull] string startupName)
         {
-            if (startupAssemblyName == null)
+            if (startupName == null)
             {
-                throw new ArgumentNullException(nameof(startupAssemblyName));
+                throw new ArgumentNullException(nameof(startupName));
             }
-            _startupAssemblyName = startupAssemblyName;
+            _startupName = startupName;
             return this;
         }
 

--- a/test/Microsoft.AspNet.Hosting.Tests/Fakes/NamedStartup.cs
+++ b/test/Microsoft.AspNet.Hosting.Tests/Fakes/NamedStartup.cs
@@ -1,0 +1,18 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Builder;
+
+namespace Microsoft.AspNet.Hosting.Fakes
+{
+    public class NamedStartup
+    {
+        public NamedStartup()
+        {
+        }
+
+        public void Configure(IApplicationBuilder builder)
+        {
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Hosting.Tests/Fakes/NamedStartupDev.cs
+++ b/test/Microsoft.AspNet.Hosting.Tests/Fakes/NamedStartupDev.cs
@@ -1,0 +1,18 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Builder;
+
+namespace Microsoft.AspNet.Hosting.Fakes
+{
+    public class NamedStartupDev
+    {
+        public NamedStartupDev()
+        {
+        }
+
+        public void Configure(IApplicationBuilder builder)
+        {
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Hosting.Tests/HostingEngineTests.cs
+++ b/test/Microsoft.AspNet.Hosting.Tests/HostingEngineTests.cs
@@ -423,7 +423,7 @@ namespace Microsoft.AspNet.Hosting
 
         private class TestLoader : IStartupLoader
         {
-            public Type FindStartupType(string startupAssemblyName, IList<string> diagnosticMessages)
+            public Type FindStartupType(string startupName, IList<string> diagnosticMessages)
             {
                 throw new NotImplementedException();
             }

--- a/test/Microsoft.AspNet.Hosting.Tests/StartupManagerTests.cs
+++ b/test/Microsoft.AspNet.Hosting.Tests/StartupManagerTests.cs
@@ -123,6 +123,34 @@ namespace Microsoft.AspNet.Hosting.Tests
         }
 
         [Fact]
+        public void StartupLoaderCanLoadByTypeName()
+        {
+            var serviceCollection = new ServiceCollection();
+            var services = serviceCollection.BuildServiceProvider();
+
+            var diagnosticMessages = new List<string>();
+            var hostingEnv = new HostingEnvironment();
+            var loader = new StartupLoader(services, hostingEnv);
+            var type = loader.FindStartupType("NamedStartup, Microsoft.AspNet.Hosting.Tests", diagnosticMessages);
+            Assert.Equal(typeof(NamedStartup), type);
+            var startup = loader.LoadMethods(type, diagnosticMessages);
+        }
+
+        [Fact]
+        public void StartupLoaderCanLoadByTypeNameWithEnvironment()
+        {
+            var serviceCollection = new ServiceCollection();
+            var services = serviceCollection.BuildServiceProvider();
+
+            var diagnosticMessages = new List<string>();
+            var hostingEnv = new HostingEnvironment { EnvironmentName = "Dev" };
+            var loader = new StartupLoader(services, hostingEnv);
+            var type = loader.FindStartupType("NamedStartup, Microsoft.AspNet.Hosting.Tests", diagnosticMessages);
+            Assert.Equal(typeof(NamedStartupDev), type);
+            var startup = loader.LoadMethods(type, diagnosticMessages);
+        }
+
+        [Fact]
         public void StartupLoaderCanLoadByType()
         {
             var serviceCollection = new ServiceCollection();

--- a/test/Microsoft.AspNet.Hosting.Tests/WebHostBuilderTests.cs
+++ b/test/Microsoft.AspNet.Hosting.Tests/WebHostBuilderTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNet.Hosting
 
             var engine = (HostingEngine)builder.Build();
 
-            Assert.Equal("Microsoft.AspNet.Hosting.Tests", engine.StartupAssemblyName);
+            Assert.Equal("Microsoft.AspNet.Hosting.Tests", engine.StartupName);
         }
 
         [Fact]
@@ -26,7 +26,7 @@ namespace Microsoft.AspNet.Hosting
 
             var engine = (HostingEngine)builder.UseStartup("MyStartupAssembly").Build();
 
-            Assert.Equal("MyStartupAssembly", engine.StartupAssemblyName);
+            Assert.Equal("MyStartupAssembly", engine.StartupName);
         }
 
         private WebHostBuilder CreateWebHostBuilder() => new WebHostBuilder(CallContextServiceLocator.Locator.ServiceProvider);


### PR DESCRIPTION
#254 
Previously you could use the config variable `Hosting:Application` or `app` to specify the assembly in which to find your Startup class.

I've expanded that field so that you can optionally specify a fully qualified type name, including the assembly. `MyType, MyAssembly...`. This also combines with your current dev/production environment  setting so that we will auto locate `MyTypeDev` if you ask for `MyType`.
@muratg @davidfowl @Matthew-Bonner