### PR TITLE
instruct how to shutdown

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="AspNetVNext" value="https://www.myget.org/F/aspnetvnext/api/v2" />
+    <clear />
+    <add key="AspNetVNext" value="https://www.myget.org/F/aspnetrelease/api/v2" />
     <add key="NuGet" value="https://nuget.org/api/v2/" />
   </packageSources>
 </configuration>

--- a/src/Microsoft.AspNet.Hosting/Program.cs
+++ b/src/Microsoft.AspNet.Hosting/Program.cs
@@ -38,6 +38,8 @@ namespace Microsoft.AspNet.Hosting
             using (host.Start())
             {
                 Console.WriteLine("Started");
+                Console.WriteLine("Press Ctrl+C to shutdown.");
+
                 var appShutdownService = host.ApplicationServices.GetRequiredService<IApplicationShutdown>();
                 Console.CancelKeyPress += (sender, eventArgs) =>
                 {


### PR DESCRIPTION
seems trivial but even the node based static-server does it. Could prevent future incorrect usages of "Ctrl-C" (or whatever, depending on the platform).