### PR TITLE
Removed builder arg parameter from IStartupFilter

### DIFF
--- a/src/Microsoft.AspNet.Hosting/Internal/AutoRequestServicesStartupFilter.cs
+++ b/src/Microsoft.AspNet.Hosting/Internal/AutoRequestServicesStartupFilter.cs
@@ -9,11 +9,11 @@ namespace Microsoft.AspNet.Hosting.Internal
 {
     public class AutoRequestServicesStartupFilter : IStartupFilter
     {
-        public Action<IApplicationBuilder> Configure(IApplicationBuilder app, Action<IApplicationBuilder> next)
+        public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
         {
             return builder =>
             {
-                app.UseMiddleware<RequestServicesContainerMiddleware>();
+                builder.UseMiddleware<RequestServicesContainerMiddleware>();
                 next(builder);
             };
         }

--- a/src/Microsoft.AspNet.Hosting/Internal/HostingEngine.cs
+++ b/src/Microsoft.AspNet.Hosting/Internal/HostingEngine.cs
@@ -151,7 +151,7 @@ namespace Microsoft.AspNet.Hosting.Internal
             var configure = Startup.ConfigureDelegate;
             foreach (var filter in startupFilters)
             {
-                configure = filter.Configure(builder, configure);
+                configure = filter.Configure(configure);
             }
 
             configure(builder);

--- a/src/Microsoft.AspNet.Hosting/Startup/IStartupFilter.cs
+++ b/src/Microsoft.AspNet.Hosting/Startup/IStartupFilter.cs
@@ -8,7 +8,6 @@ namespace Microsoft.AspNet.Hosting.Startup
 {
     public interface IStartupFilter
     {
-        // TODO: replace with ConfigureDelegate?
-        Action<IApplicationBuilder> Configure(IApplicationBuilder app, Action<IApplicationBuilder> next);
+        Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next);
     }
 }

--- a/test/Microsoft.AspNet.TestHost.Tests/TestServerTests.cs
+++ b/test/Microsoft.AspNet.TestHost.Tests/TestServerTests.cs
@@ -78,11 +78,11 @@ namespace Microsoft.AspNet.TestHost
 
         public class RequestServicesFilter : IStartupFilter
         {
-            public Action<IApplicationBuilder> Configure(IApplicationBuilder app, Action<IApplicationBuilder> next)
+            public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
             {
                 return builder =>
                 {
-                    app.UseMiddleware<TestRequestServiceMiddleware>();
+                    builder.UseMiddleware<TestRequestServiceMiddleware>();
                     next(builder);
                 };
             }


### PR DESCRIPTION
- It broke the composition model by allowing you to
reach out to the original app builder. This breaks
the ability to properly wrap and have all configure
methods see the wrapper.

/cc @HaoK @Tratcher @loudej