### PR TITLE
Set applicationServices on context explicitly

### DIFF
--- a/src/Microsoft.AspNet.Hosting/Internal/HostingEngine.cs
+++ b/src/Microsoft.AspNet.Hosting/Internal/HostingEngine.cs
@@ -71,6 +71,7 @@ namespace Microsoft.AspNet.Hosting.Internal
                 async features =>
                 {
                     var httpContext = contextFactory.CreateHttpContext(features);
+                    httpContext.ApplicationServices = _applicationServices;
                     var requestIdentifier = GetRequestIdentifier(httpContext);
 
                     using (logger.BeginScope("Request Id: {RequestId}", requestIdentifier))

--- a/test/Microsoft.AspNet.Hosting.Tests/Fakes/Startup.cs
+++ b/test/Microsoft.AspNet.Hosting.Tests/Fakes/Startup.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.AspNet.Builder;
 using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.OptionsModel;
 using System;
 
 namespace Microsoft.AspNet.Hosting.Fakes

--- a/test/Microsoft.AspNet.TestHost.Tests/TestServerTests.cs
+++ b/test/Microsoft.AspNet.TestHost.Tests/TestServerTests.cs
@@ -131,6 +131,29 @@ namespace Microsoft.AspNet.TestHost
             Assert.Equal("Found:True", result);
         }
 
+        public class EnsureApplicationServicesFilter : IStartupFilter
+        {
+            public Action<IApplicationBuilder> Configure(IApplicationBuilder app, Action<IApplicationBuilder> next)
+            {
+                return builder =>
+                {
+                    app.Run(context => {
+                        Assert.NotNull(context.ApplicationServices);
+                        return context.Response.WriteAsync("Done");
+                    });
+                };
+            }
+        }
+
+        [Fact]
+        public async Task ApplicationServicesShouldSetBeforeStatupFilters()
+        {
+            var server = TestServer.Create(app => { },
+                services => services.AddTransient<IStartupFilter, EnsureApplicationServicesFilter>());
+            string result = await server.CreateClient().GetStringAsync("/path");
+            Assert.Equal("Done", result);
+        }
+
 
         [Fact]
         public async Task CanAccessLogger()


### PR DESCRIPTION
We were relying on the RequestServices magic to set it before

Fixes https://github.com/aspnet/Hosting/issues/337

cc @Tratcher @davidfowl 