### PR TITLE
Set ContextAccessor before the BeginRequest event runs

### DIFF
--- a/src/Microsoft.AspNet.Hosting/Internal/HostingEngine.cs
+++ b/src/Microsoft.AspNet.Hosting/Internal/HostingEngine.cs
@@ -96,6 +96,7 @@ namespace Microsoft.AspNet.Hosting.Internal
                     var httpContext = contextFactory.CreateHttpContext(features);
                     httpContext.ApplicationServices = _applicationServices;
                     var requestIdentifier = GetRequestIdentifier(httpContext);
+                    contextAccessor.HttpContext = httpContext;
 
                     if (telemetrySource.IsEnabled("Microsoft.AspNet.Hosting.BeginRequest"))
                     {
@@ -106,7 +107,6 @@ namespace Microsoft.AspNet.Hosting.Internal
                     {
                         using (logger.BeginScope("Request Id: {RequestId}", requestIdentifier))
                         {
-                            contextAccessor.HttpContext = httpContext;
                             await application(httpContext);
                         }
                     }


### PR DESCRIPTION
Tools like Glimpse are expecting to have access to the ContextAccessor to determine if profiling should be turns on or not. The contextAccessor is key to being able to determine this and based of the code flow, it shouldn't have any side effect.  