### PR TITLE
Sanitise loops

### DIFF
--- a/src/Microsoft.AspNet.Hosting/Startup/ConfigureDelegate.cs
+++ b/src/Microsoft.AspNet.Hosting/Startup/ConfigureDelegate.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNet.Hosting.Startup
             var serviceProvider = builder.ApplicationServices;
             var parameterInfos = MethodInfo.GetParameters();
             var parameters = new object[parameterInfos.Length];
-            for (var index = 0; index != parameterInfos.Length; ++index)
+            for (var index = 0; index < parameterInfos.Length; index++)
             {
                 var parameterInfo = parameterInfos[index];
                 if (parameterInfo.ParameterType == typeof(IApplicationBuilder))

--- a/src/Microsoft.AspNet.Hosting/Startup/StartupExceptionPage.cs
+++ b/src/Microsoft.AspNet.Hosting/Startup/StartupExceptionPage.cs
@@ -509,9 +509,10 @@ namespace Microsoft.AspNet.Hosting.Startup
         private static IEnumerable<Exception> FlattenAndReverseExceptionTree(Exception ex)
         {
             var list = new List<Exception>();
-            for (; ex != null; ex = ex.InnerException)
+            while (ex != null)
             {
                 list.Add(ex);
+                ex = ex.InnerException;
             }
             list.Reverse();
             return list;

--- a/src/Microsoft.AspNet.Server.Testing/Common/RetryHelper.cs
+++ b/src/Microsoft.AspNet.Server.Testing/Common/RetryHelper.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNet.Server.Testing
             CancellationToken cancellationToken = default(CancellationToken),
             int retryCount = 60)
         {
-            for (int retry = 0; retry < retryCount; retry++)
+            for (var retry = 0; retry < retryCount; retry++)
             {
                 if (cancellationToken.IsCancellationRequested)
                 {

--- a/test/Microsoft.AspNet.TestHost.Tests/TestClientTests.cs
+++ b/test/Microsoft.AspNet.TestHost.Tests/TestClientTests.cs
@@ -235,7 +235,7 @@ namespace Microsoft.AspNet.TestHost
 
             // Assert
             var buffer = new byte[1];
-            for (int i = 0; i < hello.Length; i++)
+            for (var i = 0; i < hello.Length; i++)
             {
                 bool last = i == (hello.Length - 1);
                 var result = await clientSocket.ReceiveAsync(new System.ArraySegment<byte>(buffer), CancellationToken.None);


### PR DESCRIPTION
Use jit recognised ```for (var i; i < a.length; i++)``` for bounds check elimination.