### PR TITLE
requestId ticks seed, reduced GenerateRequestId allocs

### DIFF
--- a/src/Microsoft.AspNet.Hosting/project.json
+++ b/src/Microsoft.AspNet.Hosting/project.json
@@ -5,7 +5,10 @@
         "type": "git",
         "url": "git://github.com/aspnet/hosting"
     },
-    "compilationOptions": { "warningsAsErrors": true },
+    "compilationOptions": {
+        "warningsAsErrors": true,
+        "allowUnsafe": true
+    },
     "dependencies": {
         "Microsoft.AspNet.FileProviders.Physical": "1.0.0-*",
         "Microsoft.AspNet.Hosting.Abstractions": "1.0.0-*",


### PR DESCRIPTION
Seed requestId with DateTime.UtcNow.Ticks rather than Random
Reduced allocs in GenerateRequestId

/cc @DamianEdwards 