### PR TITLE
Merge IApplicationShutdown and IApplicationLifetime

### DIFF
--- a/src/Microsoft.AspNet.Hosting.Abstractions/IApplicationLifetime.cs
+++ b/src/Microsoft.AspNet.Hosting.Abstractions/IApplicationLifetime.cs
@@ -30,5 +30,15 @@ namespace Microsoft.AspNet.Hosting
         /// </summary>
         /// <returns></returns>
         CancellationToken ApplicationStopped { get; }
+        
+        /// <summary>
+        /// Gets a <see cref="CancellationToken"/> that is signaled when application shutdown is requested.
+        /// </summary>
+        CancellationToken ShutdownRequested { get; }
+
+        /// <summary>
+        /// Requests termination the current application.
+        /// </summary>
+        void RequestShutdown();
     }
 }

--- a/src/Microsoft.AspNet.Hosting.Abstractions/IApplicationLifetime.cs
+++ b/src/Microsoft.AspNet.Hosting.Abstractions/IApplicationLifetime.cs
@@ -30,15 +30,10 @@ namespace Microsoft.AspNet.Hosting
         /// </summary>
         /// <returns></returns>
         CancellationToken ApplicationStopped { get; }
-        
-        /// <summary>
-        /// Gets a <see cref="CancellationToken"/> that is signaled when application shutdown is requested.
-        /// </summary>
-        CancellationToken ShutdownRequested { get; }
 
         /// <summary>
         /// Requests termination the current application.
         /// </summary>
-        void RequestShutdown();
+        void StopApplication();
     }
 }

--- a/src/Microsoft.AspNet.Hosting/ApplicationLifetime.cs
+++ b/src/Microsoft.AspNet.Hosting/ApplicationLifetime.cs
@@ -38,9 +38,19 @@ namespace Microsoft.AspNet.Hosting
         public CancellationToken ApplicationStopped => _stoppedSource.Token;
 
         /// <summary>
-        /// Gets a <see cref="CancellationToken"/> that is signaled when application shutdown is requested.
+        /// Signals the ApplicationStopping event and blocks until it completes.
         /// </summary>
-        public CancellationToken ShutdownRequested => _shutdownSource.Token;
+        public void StopApplication()
+        {
+            try
+            {
+                _stoppingSource.Cancel(throwOnFirstException: false);
+            }
+            catch (Exception)
+            {
+                // TODO: LOG
+            }
+        }
 
         /// <summary>
         /// Signals the ApplicationStarted event and blocks until it completes.
@@ -50,21 +60,6 @@ namespace Microsoft.AspNet.Hosting
             try
             {
                 _startedSource.Cancel(throwOnFirstException: false);
-            }
-            catch (Exception)
-            {
-                // TODO: LOG
-            }
-        }
-
-        /// <summary>
-        /// Signals the ApplicationStopping event and blocks until it completes.
-        /// </summary>
-        public void NotifyStopping()
-        {
-            try
-            {
-                _stoppingSource.Cancel(throwOnFirstException: false);
             }
             catch (Exception)
             {
@@ -84,21 +79,6 @@ namespace Microsoft.AspNet.Hosting
             catch (Exception)
             {
                 // TODO: LOG
-            }
-        }
-
-        /// <summary>
-        /// Requests termination the current application.
-        /// </summary>
-        public void RequestShutdown()
-        {
-            try
-            {
-                _shutdownSource.Cancel(throwOnFirstException: false);
-            }
-            catch (Exception)
-            {
-                // TODO: Log
             }
         }
     }

--- a/src/Microsoft.AspNet.Hosting/ApplicationLifetime.cs
+++ b/src/Microsoft.AspNet.Hosting/ApplicationLifetime.cs
@@ -14,7 +14,6 @@ namespace Microsoft.AspNet.Hosting
         private readonly CancellationTokenSource _startedSource = new CancellationTokenSource();
         private readonly CancellationTokenSource _stoppingSource = new CancellationTokenSource();
         private readonly CancellationTokenSource _stoppedSource = new CancellationTokenSource();
-        private readonly CancellationTokenSource _shutdownSource = new CancellationTokenSource();
 
         /// <summary>
         /// Triggered when the application host has fully started and is about to wait

--- a/src/Microsoft.AspNet.Hosting/ApplicationLifetime.cs
+++ b/src/Microsoft.AspNet.Hosting/ApplicationLifetime.cs
@@ -14,25 +14,20 @@ namespace Microsoft.AspNet.Hosting
         private readonly CancellationTokenSource _startedSource = new CancellationTokenSource();
         private readonly CancellationTokenSource _stoppingSource = new CancellationTokenSource();
         private readonly CancellationTokenSource _stoppedSource = new CancellationTokenSource();
+        private readonly CancellationTokenSource _shutdownSource = new CancellationTokenSource();
 
         /// <summary>
         /// Triggered when the application host has fully started and is about to wait
         /// for a graceful shutdown.
         /// </summary>
-        public CancellationToken ApplicationStarted
-        {
-            get { return _startedSource.Token; }
-        }
+        public CancellationToken ApplicationStarted => _startedSource.Token;
 
         /// <summary>
         /// Triggered when the application host is performing a graceful shutdown.
         /// Request may still be in flight. Shutdown will block until this event completes.
         /// </summary>
         /// <returns></returns>
-        public CancellationToken ApplicationStopping
-        {
-            get { return _stoppingSource.Token; }
-        }
+        public CancellationToken ApplicationStopping => _stoppingSource.Token;
 
         /// <summary>
         /// Triggered when the application host is performing a graceful shutdown.
@@ -40,10 +35,12 @@ namespace Microsoft.AspNet.Hosting
         /// until this event completes.
         /// </summary>
         /// <returns></returns>
-        public CancellationToken ApplicationStopped
-        {
-            get { return _stoppedSource.Token; }
-        }
+        public CancellationToken ApplicationStopped => _stoppedSource.Token;
+
+        /// <summary>
+        /// Gets a <see cref="CancellationToken"/> that is signaled when application shutdown is requested.
+        /// </summary>
+        public CancellationToken ShutdownRequested => _shutdownSource.Token;
 
         /// <summary>
         /// Signals the ApplicationStarted event and blocks until it completes.
@@ -87,6 +84,21 @@ namespace Microsoft.AspNet.Hosting
             catch (Exception)
             {
                 // TODO: LOG
+            }
+        }
+
+        /// <summary>
+        /// Requests termination the current application.
+        /// </summary>
+        public void RequestShutdown()
+        {
+            try
+            {
+                _shutdownSource.Cancel(throwOnFirstException: false);
+            }
+            catch (Exception)
+            {
+                // TODO: Log
             }
         }
     }

--- a/src/Microsoft.AspNet.Hosting/Internal/HostingEngine.cs
+++ b/src/Microsoft.AspNet.Hosting/Internal/HostingEngine.cs
@@ -135,7 +135,7 @@ namespace Microsoft.AspNet.Hosting.Internal
 
             return new Application(ApplicationServices, _serverInstance, new Disposable(() =>
             {
-                _applicationLifetime.NotifyStopping();
+                _applicationLifetime.StopApplication();
                 server.Dispose();
                 _applicationLifetime.NotifyStopped();
                 (_applicationServices as IDisposable)?.Dispose();

--- a/src/Microsoft.AspNet.Hosting/Program.cs
+++ b/src/Microsoft.AspNet.Hosting/Program.cs
@@ -58,12 +58,12 @@ namespace Microsoft.AspNet.Hosting
 
                 Console.CancelKeyPress += (sender, eventArgs) =>
                 {
-                    appLifetime.RequestShutdown();
+                    appLifetime.StopApplication();
                     // Don't terminate the process immediately, wait for the Main thread to exit gracefully.
                     eventArgs.Cancel = true;
                 };
 
-                appLifetime.ShutdownRequested.WaitHandle.WaitOne();
+                appLifetime.ApplicationStopping.WaitHandle.WaitOne();
             }
         }
     }

--- a/src/Microsoft.AspNet.Hosting/Program.cs
+++ b/src/Microsoft.AspNet.Hosting/Program.cs
@@ -54,14 +54,16 @@ namespace Microsoft.AspNet.Hosting
 
                 Console.WriteLine("Application started. Press Ctrl+C to shut down.");
 
-                var appShutdownService = app.Services.GetRequiredService<IApplicationShutdown>();
+                var appLifetime = app.Services.GetRequiredService<IApplicationLifetime>();
+
                 Console.CancelKeyPress += (sender, eventArgs) =>
                 {
-                    appShutdownService.RequestShutdown();
+                    appLifetime.RequestShutdown();
                     // Don't terminate the process immediately, wait for the Main thread to exit gracefully.
                     eventArgs.Cancel = true;
                 };
-                appShutdownService.ShutdownRequested.WaitHandle.WaitOne();
+
+                appLifetime.ShutdownRequested.WaitHandle.WaitOne();
             }
         }
     }


### PR DESCRIPTION
- Moved RequestShutdown and ShutdownRequested to IApplicationLifetime
since IApplicationShutdown will be obsoleted.

Related to https://github.com/aspnet/dnx/issues/2683

Reaction https://github.com/aspnet/KestrelHttpServer/commit/fc665dfa724c53e0b4b7270adb815f94cb34903b

/cc @Tratcher @halter73 