### PR TITLE
Johluo/387 more descriptive message for private configure

### DIFF
--- a/src/Microsoft.AspNet.Hosting/Startup/StartupLoader.cs
+++ b/src/Microsoft.AspNet.Hosting/Startup/StartupLoader.cs
@@ -126,7 +126,7 @@ namespace Microsoft.AspNet.Hosting.Startup
             {
                 if (required)
                 {
-                    throw new InvalidOperationException(string.Format("A method named '{0}' or '{1}' in the type '{2}' could not be found.",
+                    throw new InvalidOperationException(string.Format("A public method named '{0}' or '{1}' could not be found in the '{2}' type.",
                         methodNameWithEnv,
                         methodNameWithNoEnv,
                         startupType.FullName));

--- a/test/Microsoft.AspNet.Hosting.Tests/Fakes/StartupPrivateConfigure.cs
+++ b/test/Microsoft.AspNet.Hosting.Tests/Fakes/StartupPrivateConfigure.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Builder;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.AspNet.Hosting.Fakes
+{
+    public class StartupPrivateConfigure
+    {
+        public StartupPrivateConfigure()
+        {
+        }
+        
+        public void ConfigureServices(IServiceCollection services)
+        {
+
+        }
+
+        private void Configure(IApplicationBuilder builder)
+        {
+
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Hosting.Tests/StartupManagerTests.cs
+++ b/test/Microsoft.AspNet.Hosting.Tests/StartupManagerTests.cs
@@ -80,7 +80,7 @@ namespace Microsoft.AspNet.Hosting.Tests
             var type = loader.FindStartupType("Microsoft.AspNet.Hosting.Tests", diagnosticMessages);
 
             var ex = Assert.Throws<InvalidOperationException>(() => loader.LoadMethods(type, diagnosticMessages));
-            Assert.Equal("A method named 'ConfigureBoom' or 'Configure' in the type 'Microsoft.AspNet.Hosting.Fakes.StartupBoom' could not be found.", ex.Message);
+            Assert.Equal("A public method named 'ConfigureBoom' or 'Configure' could not be found in the 'Microsoft.AspNet.Hosting.Fakes.StartupBoom' type.", ex.Message);
         }
 
         [Fact]
@@ -97,6 +97,22 @@ namespace Microsoft.AspNet.Hosting.Tests
 
             var ex = Assert.Throws<InvalidOperationException>(() => loader.LoadMethods(type, diagnosticMessages));
             Assert.Equal("Having multiple overloads of method 'Configure' is not supported.", ex.Message);
+        }
+        
+        [Fact]
+        public void StartupWithPrivateConfiguresThrows()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddInstance<IFakeStartupCallback>(this);
+            var services = serviceCollection.BuildServiceProvider();
+
+            var diagnosticMessages = new List<string>();
+            var hostingEnv = new HostingEnvironment { EnvironmentName = "PrivateConfigure" };
+            var loader = new StartupLoader(services, hostingEnv);
+            var type = loader.FindStartupType("Microsoft.AspNet.Hosting.Tests", diagnosticMessages);
+
+            var ex = Assert.Throws<InvalidOperationException>(() => loader.LoadMethods(type, diagnosticMessages));
+            Assert.Equal("A public method named 'ConfigurePrivateConfigure' or 'Configure' could not be found in the 'Microsoft.AspNet.Hosting.Fakes.StartupPrivateConfigure' type.", ex.Message);
         }
 
         [Fact]


### PR DESCRIPTION
#387 I'm assuming that if `ConfigureServices` is set to private, we'll just silently ignore it, similar to how we currently handle `ConfigureServices` with incompatible return type.