### PR TITLE
Enable detailed startup errors by default

### DIFF
--- a/src/Microsoft.AspNet.Server.Testing/Common/DeploymentParameters.cs
+++ b/src/Microsoft.AspNet.Server.Testing/Common/DeploymentParameters.cs
@@ -39,6 +39,7 @@ namespace Microsoft.AspNet.Server.Testing
             ServerType = serverType;
             RuntimeFlavor = runtimeFlavor;
             RuntimeArchitecture = runtimeArchitecture;
+            EnvironmentVariables.Add(new KeyValuePair<string, string>("ASPNET_DETAILEDERRORS", "true"));
         }
 
         public ServerType ServerType { get; private set; }


### PR DESCRIPTION
@victorhurdugaci This should make music store test failures much easier to debug with just CI logs.