### PR TITLE
Add the DNX runtime to the path when lanching test processes.

### DIFF
--- a/src/Microsoft.AspNet.Server.Testing/Deployers/ApplicationDeployer.cs
+++ b/src/Microsoft.AspNet.Server.Testing/Deployers/ApplicationDeployer.cs
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -136,6 +136,10 @@ namespace Microsoft.AspNet.Server.Testing
             DeploymentParameters.DnxRuntime = ChosenRuntimeName;
 
             Logger.LogInformation($"Chosen runtime path is {ChosenRuntimePath}");
+
+            // Work around win7 search path issues.
+            var newPath = ChosenRuntimePath + Path.PathSeparator + Environment.GetEnvironmentVariable("PATH");
+            DeploymentParameters.EnvironmentVariables.Add(new KeyValuePair<string, string>("PATH", newPath));
 
             return ChosenRuntimeName;
         }


### PR DESCRIPTION
#481 @victorhurdugaci 
There appear to be DNX native dll search path issues on win7. When there's a different dnx on the path (e.g. the one we're using to run the parent test process), we can't load SNI. Add the correct DNX to the path.