### PR TITLE
Move IStartupFilter to Hosting.Abstractions.

### DIFF
--- a/src/Microsoft.AspNet.Hosting.Abstractions/IStartupFilter.cs
+++ b/src/Microsoft.AspNet.Hosting.Abstractions/IStartupFilter.cs
@@ -4,7 +4,7 @@
 using System;
 using Microsoft.AspNet.Builder;
 
-namespace Microsoft.AspNet.Hosting.Startup
+namespace Microsoft.AspNet.Hosting
 {
     public interface IStartupFilter
     {


### PR DESCRIPTION
 #318 So it can be used by other packages without a hard Hosting dependency.
@davidfowl @JunTaoLuo 