### PR TITLE
Diabling async TestHost.Tests on Mono #507

### DIFF
--- a/test/Microsoft.AspNet.TestHost.Tests/ClientHandlerTests.cs
+++ b/test/Microsoft.AspNet.TestHost.Tests/ClientHandlerTests.cs
@@ -59,7 +59,8 @@ namespace Microsoft.AspNet.TestHost
             return httpClient.GetAsync("https://example.com/");
         }
 
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
         public async Task ResubmitRequestWorks()
         {
             int requestCount = 1;
@@ -83,7 +84,8 @@ namespace Microsoft.AspNet.TestHost
             Assert.Equal("TestValue:2", response.Headers.GetValues("TestHeader").First());
         }
 
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
         public async Task MiddlewareOnlySetsHeaders()
         {
             var handler = new ClientHandler(PathString.Empty, new DummyApplication(context =>
@@ -96,7 +98,8 @@ namespace Microsoft.AspNet.TestHost
             Assert.Equal("TestValue", response.Headers.GetValues("TestHeader").First());
         }
 
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
         public async Task BlockingMiddlewareShouldNotBlockClient()
         {
             ManualResetEvent block = new ManualResetEvent(false);
@@ -113,7 +116,8 @@ namespace Microsoft.AspNet.TestHost
             HttpResponseMessage response = await task;
         }
 
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
         public async Task HeadersAvailableBeforeBodyFinished()
         {
             ManualResetEvent block = new ManualResetEvent(false);
@@ -132,7 +136,8 @@ namespace Microsoft.AspNet.TestHost
             Assert.Equal("BodyStarted,BodyFinished", await response.Content.ReadAsStringAsync());
         }
 
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
         public async Task FlushSendsHeaders()
         {
             ManualResetEvent block = new ManualResetEvent(false);
@@ -151,7 +156,8 @@ namespace Microsoft.AspNet.TestHost
             Assert.Equal("BodyFinished", await response.Content.ReadAsStringAsync());
         }
 
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
         public async Task ClientDisposalCloses()
         {
             ManualResetEvent block = new ManualResetEvent(false);
@@ -176,7 +182,8 @@ namespace Microsoft.AspNet.TestHost
             block.Set();
         }
 
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
         public async Task ClientCancellationAborts()
         {
             ManualResetEvent block = new ManualResetEvent(false);
@@ -215,7 +222,7 @@ namespace Microsoft.AspNet.TestHost
         }
 
         [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.Linux, SkipReason = "Hangs randomly (issue #422).")]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
         public async Task ExceptionAfterFirstWriteIsReported()
         {
             ManualResetEvent block = new ManualResetEvent(false);

--- a/test/Microsoft.AspNet.TestHost.Tests/TestClientTests.cs
+++ b/test/Microsoft.AspNet.TestHost.Tests/TestClientTests.cs
@@ -25,7 +25,8 @@ namespace Microsoft.AspNet.TestHost
             _server = TestServer.Create(app => app.Run(ctx => Task.FromResult(0)));
         }
 
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
         public async Task GetAsyncWorks()
         {
             // Arrange
@@ -42,7 +43,8 @@ namespace Microsoft.AspNet.TestHost
             Assert.Equal(expected, actual);
         }
 
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
         public async Task NoTrailingSlash_NoPathBase()
         {
             // Arrange
@@ -63,7 +65,8 @@ namespace Microsoft.AspNet.TestHost
             Assert.Equal(expected, actual);
         }
 
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
         public async Task SingleTrailingSlash_NoPathBase()
         {
             // Arrange
@@ -84,7 +87,8 @@ namespace Microsoft.AspNet.TestHost
             Assert.Equal(expected, actual);
         }
 
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
         public async Task PutAsyncWorks()
         {
             // Arrange
@@ -101,7 +105,8 @@ namespace Microsoft.AspNet.TestHost
             Assert.Equal("Hello world PUT Response", await response.Content.ReadAsStringAsync());
         }
 
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
         public async Task PostAsyncWorks()
         {
             // Arrange
@@ -118,7 +123,8 @@ namespace Microsoft.AspNet.TestHost
             Assert.Equal("Hello world POST Response", await response.Content.ReadAsStringAsync());
         }
 
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
         public async Task WebSocketWorks()
         {
             // Arrange
@@ -179,7 +185,8 @@ namespace Microsoft.AspNet.TestHost
             clientSocket.Dispose();
         }
 
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
         public async Task WebSocketDisposalThrowsOnPeer()
         {
             // Arrange
@@ -205,7 +212,8 @@ namespace Microsoft.AspNet.TestHost
             clientSocket.Dispose();
         }
 
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
         public async Task WebSocketTinyReceiveGeneratesEndOfMessage()
         {
             // Arrange
@@ -248,7 +256,8 @@ namespace Microsoft.AspNet.TestHost
             clientSocket.Dispose();
         }
 
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
         public async Task ClientDisposalAbortsRequest()
         {
             // Arrange
@@ -282,7 +291,7 @@ namespace Microsoft.AspNet.TestHost
         }
 
         [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.CoreCLR, SkipReason = "Hangs randomly (issue #422).")]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
         public async Task ClientCancellationAbortsRequest()
         {
             // Arrange

--- a/test/Microsoft.AspNet.TestHost.Tests/TestServerTests.cs
+++ b/test/Microsoft.AspNet.TestHost.Tests/TestServerTests.cs
@@ -31,7 +31,8 @@ namespace Microsoft.AspNet.TestHost
             TestServer.Create(app => { });
         }
 
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
         public async Task RequestServicesAutoCreated()
         {
             var server = TestServer.Create(app =>
@@ -66,7 +67,8 @@ namespace Microsoft.AspNet.TestHost
 
         }
 
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
         public async Task CustomServiceProviderSetsApplicationServices()
         {
             var server = new TestServer(TestServer.CreateBuilder().UseStartup<CustomContainerStartup>());
@@ -107,7 +109,8 @@ namespace Microsoft.AspNet.TestHost
             }
         }
 
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
         public async Task ExistingRequestServicesWillNotBeReplaced()
         {
             var server = TestServer.Create(app =>
@@ -123,7 +126,8 @@ namespace Microsoft.AspNet.TestHost
             Assert.Equal("Found:True", result);
         }
 
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
         public async Task CanSetCustomServiceProvider()
         {
             var server = TestServer.Create(app =>
@@ -169,7 +173,8 @@ namespace Microsoft.AspNet.TestHost
             }
         }
 
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
         public async Task ExistingServiceProviderFeatureWillNotBeReplaced()
         {
             var appServices = new ServiceCollection().BuildServiceProvider();
@@ -206,7 +211,8 @@ namespace Microsoft.AspNet.TestHost
             }
         }
 
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
         public async Task WillReplaceServiceProviderFeatureWithNullRequestServices()
         {
             var server = TestServer.Create(app =>
@@ -222,7 +228,8 @@ namespace Microsoft.AspNet.TestHost
             Assert.Equal("Success", result);
         }
 
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
         public async Task CanAccessLogger()
         {
             var server = TestServer.Create(app =>
@@ -238,7 +245,8 @@ namespace Microsoft.AspNet.TestHost
             Assert.Equal("FoundLogger:True", result);
         }
 
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
         public async Task CanAccessHttpContext()
         {
             Action<IServiceCollection> configureServices = services =>
@@ -268,7 +276,8 @@ namespace Microsoft.AspNet.TestHost
             public IHttpContextAccessor Accessor { get; set; }
         }
 
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
         public async Task CanAddNewHostServices()
         {
             Action<IServiceCollection> configureServices = services =>
@@ -289,7 +298,8 @@ namespace Microsoft.AspNet.TestHost
             Assert.Equal("HasContext:True", result);
         }
 
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
         public async Task CreateInvokesApp()
         {
             TestServer server = TestServer.Create(app =>
@@ -304,7 +314,8 @@ namespace Microsoft.AspNet.TestHost
             Assert.Equal("CreateInvokesApp", result);
         }
 
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
         public async Task DisposeStreamIgnored()
         {
             TestServer server = TestServer.Create(app =>
@@ -321,7 +332,8 @@ namespace Microsoft.AspNet.TestHost
             Assert.Equal("Response", await result.Content.ReadAsStringAsync());
         }
 
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
         public async Task DisposedServerThrows()
         {
             TestServer server = TestServer.Create(app =>
@@ -340,7 +352,7 @@ namespace Microsoft.AspNet.TestHost
         }
 
         [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.CoreCLR, SkipReason = "Hangs randomly (issue #422).")]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
         public void CancelAborts()
         {
             TestServer server = TestServer.Create(app =>
@@ -356,7 +368,8 @@ namespace Microsoft.AspNet.TestHost
             Assert.Throws<AggregateException>(() => { string result = server.CreateClient().GetStringAsync("/path").Result; });
         }
 
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
         public async Task CanCreateViaStartupType()
         {
             TestServer server = new TestServer(TestServer.CreateBuilder().UseStartup<TestStartup>());
@@ -365,7 +378,8 @@ namespace Microsoft.AspNet.TestHost
             Assert.Equal("FoundService:True", await result.Content.ReadAsStringAsync());
         }
 
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
         public async Task CanCreateViaStartupTypeAndSpecifyEnv()
         {
             TestServer server = new TestServer(TestServer.CreateBuilder()
@@ -375,8 +389,9 @@ namespace Microsoft.AspNet.TestHost
             Assert.Equal(HttpStatusCode.OK, result.StatusCode);
             Assert.Equal("FoundFoo:False", await result.Content.ReadAsStringAsync());
         }
-        
-        [Fact]
+
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
         public async Task BeginEndDiagnosticAvailable()
         {
             DiagnosticListener diagnosticListener = null;
@@ -401,7 +416,8 @@ namespace Microsoft.AspNet.TestHost
             Assert.Null(listener.UnhandledException);
         }
 
-        [Fact]
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
         public async Task ExceptionDiagnosticAvailable()
         {
             DiagnosticListener diagnosticListener = null;


### PR DESCRIPTION
As part of re-enabling hosting tests for CoreCLR in #422 on the CI. 

Disabling tests that can potentially hang on Mono since the CI always run tests on Mono.