### PR TITLE
Remove non-essential platform services

### DIFF
--- a/src/Microsoft.AspNet.Hosting/WebHostBuilder.cs
+++ b/src/Microsoft.AspNet.Hosting/WebHostBuilder.cs
@@ -98,21 +98,6 @@ namespace Microsoft.AspNet.Hosting
                 services.TryAdd(ServiceDescriptor.Instance(PlatformServices.Default.Runtime));
             }
 
-            if (PlatformServices.Default?.AssemblyLoadContextAccessor != null)
-            {
-                services.TryAdd(ServiceDescriptor.Instance(PlatformServices.Default.AssemblyLoadContextAccessor));
-            }
-
-            if (PlatformServices.Default?.AssemblyLoaderContainer != null)
-            {
-                services.TryAdd(ServiceDescriptor.Instance(PlatformServices.Default.AssemblyLoaderContainer));
-            }
-
-            if (PlatformServices.Default?.LibraryManager != null)
-            {
-                services.TryAdd(ServiceDescriptor.Instance(PlatformServices.Default.LibraryManager));
-            }
-
             return services;
         }
 


### PR DESCRIPTION
- Remove services that can be registered by the application itself.
- These services use to come from the DNX but now they are stand alone
implementations that can be registered by applications if they choose.

MVC and glimpse will need to be updated to manually add the library manager

#501

/cc @pakrym @avanderhoorn 