### PR TITLE
Reduce overuse of null-conditional operator

### DIFF
--- a/src/Microsoft.AspNet.Hosting/WebHostBuilder.cs
+++ b/src/Microsoft.AspNet.Hosting/WebHostBuilder.cs
@@ -88,14 +88,18 @@ namespace Microsoft.AspNet.Hosting
                 _configureServices(services);
             }
 
-            if (PlatformServices.Default?.Application != null)
+            var defaultPlatformServices = PlatformServices.Default;
+            if (defaultPlatformServices != null)
             {
-                services.TryAdd(ServiceDescriptor.Instance(PlatformServices.Default.Application));
-            }
+                if (defaultPlatformServices.Application != null)
+                {
+                    services.TryAdd(ServiceDescriptor.Instance(defaultPlatformServices.Application));
+                }
 
-            if (PlatformServices.Default?.Runtime != null)
-            {
-                services.TryAdd(ServiceDescriptor.Instance(PlatformServices.Default.Runtime));
+                if (defaultPlatformServices.Runtime != null)
+                {
+                    services.TryAdd(ServiceDescriptor.Instance(defaultPlatformServices.Runtime));
+                }
             }
 
             return services;


### PR DESCRIPTION
I have noticed that the null-conditional operator is used multiple times on the `PlatformServices.Default` property. I did not check whether the compiler optimizes this by just adding one null check, but I would doubt it heavily, and this is a trivial change.