### PR TITLE
Fixing deadlock hang in test when running in single threaded environment

### DIFF
--- a/src/Microsoft.AspNet.TestHost/ClientHandler.cs
+++ b/src/Microsoft.AspNet.TestHost/ClientHandler.cs
@@ -94,7 +94,7 @@ namespace Microsoft.AspNet.TestHost
                     }
                 });
 
-            return await state.ResponseTask;
+            return await state.ResponseTask.ConfigureAwait(false);
         }
 
         private class RequestState

--- a/test/Microsoft.AspNet.TestHost.Tests/TestServerTests.cs
+++ b/test/Microsoft.AspNet.TestHost.Tests/TestServerTests.cs
@@ -353,7 +353,7 @@ namespace Microsoft.AspNet.TestHost
 
         [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
-        public void CancelAborts()
+        public async Task CancelAborts()
         {
             TestServer server = TestServer.Create(app =>
             {
@@ -365,7 +365,7 @@ namespace Microsoft.AspNet.TestHost
                 });
             });
 
-            Assert.Throws<AggregateException>(() => { string result = server.CreateClient().GetStringAsync("/path").Result; });
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => { string result = await server.CreateClient().GetStringAsync("/path"); });
         }
 
         [ConditionalFact]


### PR DESCRIPTION
Found the issue for #422. The test hangs because we are mixing async code in TestServer and blocking code in the test. This will cause a deadlock scenario but only when there is a single threaded scenario so it was undetected until now. 