### PR TITLE
Making application services available from TestServer #519

### DIFF
--- a/src/Microsoft.AspNet.TestHost/TestServer.cs
+++ b/src/Microsoft.AspNet.TestHost/TestServer.cs
@@ -29,6 +29,14 @@ namespace Microsoft.AspNet.TestHost
 
         public Uri BaseAddress { get; set; } = new Uri("http://localhost/");
 
+        public IWebApplication Application
+        {
+            get
+            {
+                return _appInstance;
+            }
+        }
+
         IFeatureCollection IServer.Features { get; }
 
         public HttpMessageHandler CreateHandler()

--- a/test/Microsoft.AspNet.TestHost.Tests/TestServerTests.cs
+++ b/test/Microsoft.AspNet.TestHost.Tests/TestServerTests.cs
@@ -31,6 +31,21 @@ namespace Microsoft.AspNet.TestHost
             new TestServer(new WebApplicationBuilder().Configure(app => { }));
         }
 
+        [Fact]
+        public void ApplicationServicesAvailableFromTestServer()
+        {
+            var testService = new TestService();
+            var builder = new WebApplicationBuilder()
+                .Configure(app => { })
+                .ConfigureServices(services =>
+                {
+                    services.AddSingleton(testService);
+                });
+            var server = new TestServer(builder);
+
+            Assert.Equal(testService, server.Application.Services.GetRequiredService<TestService>());
+        }
+
         [ConditionalFact]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
         public async Task RequestServicesAutoCreated()


### PR DESCRIPTION
#519 This will allow DBContexts added to services by the builder available from the TestServer in unit tests.