### PR TITLE
Fixing logger nullref when context created with no feature #532

### DIFF
--- a/src/Microsoft.AspNet.TestHost/ClientHandler.cs
+++ b/src/Microsoft.AspNet.TestHost/ClientHandler.cs
@@ -124,12 +124,13 @@ namespace Microsoft.AspNet.TestHost
                     request.Headers.Host = request.RequestUri.GetComponents(UriComponents.HostAndPort, UriFormat.UriEscaped);
                 }
 
-                Context = application.CreateContext(new FeatureCollection());
+                var contextFeatures = new FeatureCollection();
+                contextFeatures.Set<IHttpRequestFeature>(new RequestFeature());
+                _responseFeature = new ResponseFeature();
+                contextFeatures.Set<IHttpResponseFeature>(_responseFeature);
+                Context = application.CreateContext(contextFeatures);
                 var httpContext = Context.HttpContext;
 
-                httpContext.Features.Set<IHttpRequestFeature>(new RequestFeature());
-                _responseFeature = new ResponseFeature();
-                httpContext.Features.Set<IHttpResponseFeature>(_responseFeature);
                 var serverRequest = httpContext.Request;
                 serverRequest.Protocol = "HTTP/" + request.Version.ToString(2);
                 serverRequest.Scheme = request.RequestUri.Scheme;

--- a/src/Microsoft.AspNet.TestHost/WebSocketClient.cs
+++ b/src/Microsoft.AspNet.TestHost/WebSocketClient.cs
@@ -98,11 +98,13 @@ namespace Microsoft.AspNet.TestHost
                 _application = application;
 
                 // HttpContext
-                Context = _application.CreateContext(new FeatureCollection());
+                var contextFeatures = new FeatureCollection();
+                contextFeatures.Set<IHttpRequestFeature>(new RequestFeature());
+                contextFeatures.Set<IHttpResponseFeature>(new ResponseFeature());
+                Context = _application.CreateContext(contextFeatures);
                 var httpContext = Context.HttpContext;
 
                 // Request
-                httpContext.Features.Set<IHttpRequestFeature>(new RequestFeature());
                 var request = httpContext.Request;
                 request.Protocol = "HTTP/1.1";
                 var scheme = uri.Scheme;
@@ -130,7 +132,6 @@ namespace Microsoft.AspNet.TestHost
                 request.Body = Stream.Null;
 
                 // Response
-                httpContext.Features.Set<IHttpResponseFeature>(new ResponseFeature());
                 var response = httpContext.Response;
                 response.Body = Stream.Null;
                 response.StatusCode = 200;

--- a/test/Microsoft.AspNet.TestHost.Tests/TestServerTests.cs
+++ b/test/Microsoft.AspNet.TestHost.Tests/TestServerTests.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNet.Builder;
 using Microsoft.AspNet.Hosting;
 using Microsoft.AspNet.Http;
-using Microsoft.AspNet.Http.Features;
 using Microsoft.AspNet.Http.Features.Internal;
 using Microsoft.AspNet.Http.Internal;
 using Microsoft.AspNet.Testing.xunit;


### PR DESCRIPTION
Fixes #532. The issue there was that we were creating `HttpContext` with no `IHttpRequestFeature`. When creating the context, we try to log certain details about the request which null refs. The null logger added by MVC circumvents this since if the logger is not enabled, we don't try to access the information on the request. I will update MVC to remove the `NullLogger.Instance` after this is merged.