### PR TITLE
TestServer should not capture startup errors by default

### DIFF
--- a/src/Microsoft.AspNet.Hosting.Abstractions/IWebApplicationBuilder.cs
+++ b/src/Microsoft.AspNet.Hosting.Abstractions/IWebApplicationBuilder.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.AspNet.Builder;
 using Microsoft.AspNet.Hosting.Server;
 using Microsoft.Extensions.Configuration;
@@ -12,6 +13,8 @@ namespace Microsoft.AspNet.Hosting
     public interface IWebApplicationBuilder
     {
         IWebApplication Build();
+
+        IDictionary<string, string> Settings { get; }
 
         IWebApplicationBuilder UseConfiguration(IConfiguration configuration);
 

--- a/src/Microsoft.AspNet.Hosting/WebApplicationBuilder.cs
+++ b/src/Microsoft.AspNet.Hosting/WebApplicationBuilder.cs
@@ -17,7 +17,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.PlatformAbstractions;
-using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.AspNet.Hosting
 {
@@ -38,12 +37,20 @@ namespace Microsoft.AspNet.Hosting
         // Only one of these should be set
         private IServerFactory _serverFactory;
 
-        private Dictionary<string, string> _settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        private IDictionary<string, string> _settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
         public WebApplicationBuilder()
         {
             _hostingEnvironment = new HostingEnvironment();
             _loggerFactory = new LoggerFactory();
+        }
+
+        public IDictionary<string, string> Settings
+        {
+            get
+            {
+                return _settings;
+            }
         }
 
         public IWebApplicationBuilder UseSetting(string key, string value)

--- a/src/Microsoft.AspNet.TestHost/TestServer.cs
+++ b/src/Microsoft.AspNet.TestHost/TestServer.cs
@@ -22,6 +22,11 @@ namespace Microsoft.AspNet.TestHost
 
         public TestServer(IWebApplicationBuilder builder)
         {
+            if (!builder.Settings.ContainsKey(WebApplicationDefaults.CaptureStartupErrorsKey))
+            {
+                builder.UseCaptureStartupErrors(false);
+            }
+
             var application = builder.UseServer(this).Build();
             application.Start();
             _appInstance = application;

--- a/test/Microsoft.AspNet.TestHost.Tests/TestServerTests.cs
+++ b/test/Microsoft.AspNet.TestHost.Tests/TestServerTests.cs
@@ -30,6 +30,34 @@ namespace Microsoft.AspNet.TestHost
             new TestServer(new WebApplicationBuilder().Configure(app => { }));
         }
 
+
+        [Fact]
+        public void DoesNotCaptureStartupErrorsByDefault()
+        {
+            var builder = new WebApplicationBuilder()
+                .Configure(app =>
+                {
+                    throw new InvalidOperationException();
+                });
+
+            Assert.Throws<InvalidOperationException>(() => new TestServer(builder));
+        }
+
+
+        [Fact]
+        public void CaptureStartupErrorsSettingPreserved()
+        {
+            var builder = new WebApplicationBuilder()
+                .UseCaptureStartupErrors(true)
+                .Configure(app =>
+                {
+                    throw new InvalidOperationException();
+                });
+
+            // Does not throw
+            new TestServer(builder);
+        }
+
         [Fact]
         public void ApplicationServicesAvailableFromTestServer()
         {


### PR DESCRIPTION
TestServer should not capture startup errors by default. I have verified that this resolves the test failure in Session.

cc @Tratcher @cesarbs