### PR TITLE
Fix test break caused by null ApplicationBaseUrlHint

### DIFF
--- a/src/Microsoft.AspNet.Server.Testing/Common/TestUriHelper.cs
+++ b/src/Microsoft.AspNet.Server.Testing/Common/TestUriHelper.cs
@@ -7,16 +7,29 @@ using System.Net.Sockets;
 
 namespace Microsoft.AspNet.Server.Testing.Common
 {
-    public static class FreePortHelper
+    public static class TestUriHelper
     {
-        public static Uri FindFreeUrl(string urlHint)
+        public static Uri BuildTestUri()
         {
-            var uriHint = new Uri(urlHint);
-            var builder = new UriBuilder(uriHint)
+            return new UriBuilder("http", "localhost", FindFreePort()).Uri;
+        }
+
+        public static Uri BuildTestUri(string hint)
+        {
+            if (string.IsNullOrEmpty(hint))
             {
-                Port = FindFreePort(uriHint.Port)
-            };
-            return builder.Uri;
+                return BuildTestUri();
+            }
+            else
+            {
+                var uriHint = new Uri(hint);
+                return new UriBuilder(uriHint) { Port = FindFreePort(uriHint.Port) }.Uri;
+            }
+        }
+
+        public static int FindFreePort()
+        {
+            return FindFreePort(0);
         }
 
         public static int FindFreePort(int initialPort)
@@ -31,6 +44,7 @@ namespace Microsoft.AspNet.Server.Testing.Common
                 {
                     socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
                 }
+
                 return ((IPEndPoint)socket.LocalEndPoint).Port;
             }
         }

--- a/src/Microsoft.AspNet.Server.Testing/Deployers/IISDeployer.cs
+++ b/src/Microsoft.AspNet.Server.Testing/Deployers/IISDeployer.cs
@@ -5,8 +5,6 @@
 
 using System;
 using System.Linq;
-using System.Net;
-using System.Net.Sockets;
 using System.Threading;
 using Microsoft.AspNet.Server.Testing.Common;
 using Microsoft.Extensions.Logging;
@@ -46,7 +44,7 @@ namespace Microsoft.AspNet.Server.Testing
             // Drop a json file instead of setting environment variable.
             SetAspEnvironmentWithJson();
 
-            var uri = FreePortHelper.FindFreeUrl(DeploymentParameters.ApplicationBaseUriHint);
+            var uri = TestUriHelper.BuildTestUri();
 
             lock (_syncObject)
             {

--- a/src/Microsoft.AspNet.Server.Testing/Deployers/IISExpressDeployer.cs
+++ b/src/Microsoft.AspNet.Server.Testing/Deployers/IISExpressDeployer.cs
@@ -36,7 +36,7 @@ namespace Microsoft.AspNet.Server.Testing
                 DnuPublish();
             }
 
-            var uri = FreePortHelper.FindFreeUrl(DeploymentParameters.ApplicationBaseUriHint);
+            var uri = TestUriHelper.BuildTestUri(DeploymentParameters.ApplicationBaseUriHint);
             // Launch the host process.
             var hostExitToken = StartIISExpress(uri);
 

--- a/src/Microsoft.AspNet.Server.Testing/Deployers/SelfHostDeployer.cs
+++ b/src/Microsoft.AspNet.Server.Testing/Deployers/SelfHostDeployer.cs
@@ -34,7 +34,7 @@ namespace Microsoft.AspNet.Server.Testing
                 DnuPublish();
             }
 
-            var uri = FreePortHelper.FindFreeUrl(DeploymentParameters.ApplicationBaseUriHint);
+            var uri = TestUriHelper.BuildTestUri(DeploymentParameters.ApplicationBaseUriHint);
             // Launch the host process.
             var hostExitToken = StartSelfHost(uri);
 


### PR DESCRIPTION
In addtion to the fix here are the changes to improve the helper:
1. Rename the helper to better represent its function;
2. Add overload to generate free port without hint;
3. Add overload to generate local test url;

/cc @pakrym @Tratcher 

I'll merge it soon to unblock performance test break.