### PR TITLE
Add method to WebHostBuilder to allow configure IServiceProvider

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/IWebHostBuilder.cs
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/IWebHostBuilder.cs
@@ -63,6 +63,14 @@ namespace Microsoft.AspNetCore.Hosting
         IWebHostBuilder Configure(Action<IApplicationBuilder> configureApplication);
 
         /// <summary>
+        /// Specify the startup method to be used to configure the web application and the delegate that is used to configure the services of the web application. 
+        /// </summary>
+        /// <param name="configureApplication">The delegate that configures the <see cref="IApplicationBuilder"/>.</param>
+        /// <param name="configureServices">The delegate that configures the <see cref="IServiceCollection"/>.</param>
+        /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
+        IWebHostBuilder Configure(Action<IApplicationBuilder> configureApp, Func<IServiceCollection, IServiceProvider> configureServices);
+
+        /// <summary>
         /// Add or replace a setting in <see cref="Settings"/>.
         /// </summary>
         /// <param name="key">The key of the setting to add or replace.</param>

--- a/src/Microsoft.AspNetCore.Hosting/WebHostBuilder.cs
+++ b/src/Microsoft.AspNetCore.Hosting/WebHostBuilder.cs
@@ -144,6 +144,28 @@ namespace Microsoft.AspNetCore.Hosting
         }
 
         /// <summary>
+        /// Specify the startup method to be used to configure the web application and the delegate that is used to configure the services of the web application. 
+        /// </summary>
+        /// <param name="configureApplication">The delegate that configures the <see cref="IApplicationBuilder"/>.</param>
+        /// <param name="configureServices">The delegate that configures the <see cref="IServiceCollection"/>.</param>
+        /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
+        public IWebHostBuilder Configure(Action<IApplicationBuilder> configureApp, Func<IServiceCollection, IServiceProvider> configureServices)
+        {
+            if (configureApp == null)
+            {
+                throw new ArgumentNullException(nameof(configureApp));
+            }
+
+            if (configureServices == null)
+            {
+                throw new ArgumentNullException(nameof(configureServices));
+            }
+
+            _startup = new StartupMethods(configureApp, configureServices);
+            return this;
+        }
+
+        /// <summary>
         /// Configure the provided <see cref="ILoggerFactory"/> which will be available as a hosting service. 
         /// </summary>
         /// <param name="configureLogging">The delegate that configures the <see cref="ILoggerFactory"/>.</param>


### PR DESCRIPTION
Added a method to allow setting the ConfigureServicesDelegate in StartupMethods, in order to allow using a custom ServiceProvider. 
If not, in scenarios like this one: 

    var testServer = new TestServer(new WebHostBuilder().
      Configure(ConfigureTestServerMethod).
      ConfigureServices(ConfigureTestServerServicesMethod));

it is not possible to return a custom IServiceProvider loaded from your DI framework of choice. That can be done using the "UseStartup" way.

Example of usage (structuremap): 

     var testServer = new TestServer(
       new WebHostBuilder().
       Configure(app => { ...},
                (services, serviceProvider) => 
                           var container = new Container();
                           container.Configure(....);
                           container.Populate(services);
                           return container.GetInstance<IServiceProvider>(); )));
