### PR TITLE
Implement `ILogValues` on `HostingRequestFinished`

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting/Internal/HostingLoggerExtensions.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/HostingLoggerExtensions.cs
@@ -169,7 +169,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             }
         }
 
-        private class HostingRequestFinished
+        private class HostingRequestFinished : ILogValues
         {
             internal static readonly Func<object, Exception, string> Callback = (state, exception) => ((HostingRequestFinished)state).ToString();
 


### PR DESCRIPTION
While the `HostingRequestFinished` event implements the `GetValues()` method from `ILogValues`, the interface itself is missing from the class declaration. It is present on `HostingRequestStarting`.

Missing the interface here makes it hard for logging providers to pull the structured data from the event.