### PR TITLE
Convert TFM to net451 to allow custom test discovery

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Testing/Deployers/ApplicationDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.Testing/Deployers/ApplicationDeployer.cs
@@ -126,7 +126,7 @@ namespace Microsoft.AspNetCore.Server.Testing
         protected void AddEnvironmentVariablesToProcess(ProcessStartInfo startInfo)
         {
             var environment =
-#if DNX451
+#if NET451
                 startInfo.EnvironmentVariables;
 #elif DNXCORE50
                 startInfo.Environment;
@@ -140,7 +140,7 @@ namespace Microsoft.AspNetCore.Server.Testing
             }
         }
 
-#if DNX451
+#if NET451
         protected void SetEnvironmentVariable(System.Collections.Specialized.StringDictionary environment, string name, string value)
         {
 #elif DNXCORE50

--- a/src/Microsoft.AspNetCore.Server.Testing/Deployers/IISDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.Testing/Deployers/IISDeployer.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if DNX451
+#if NET451
 
 using System;
 using System.Linq;

--- a/src/Microsoft.AspNetCore.Server.Testing/Deployers/IISExpressDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.Testing/Deployers/IISExpressDeployer.cs
@@ -95,10 +95,10 @@ namespace Microsoft.AspNetCore.Server.Testing
 
             // IIS express figures out the DNX from %PATH%.
 #if NET451
-            SetEnvironmentVariable(startInfo.EnvironmentVariables, "PATH", ChosenRuntimePath + ";" + startInfo.EnvironmentVariables["PATH"]);
+            SetEnvironmentVariable(startInfo.EnvironmentVariables, "PATH", startInfo.EnvironmentVariables["PATH"]);
             SetEnvironmentVariable(startInfo.EnvironmentVariables, "DNX_APPBASE", DeploymentParameters.ApplicationPath);
 #elif DOTNET5_4
-            SetEnvironmentVariable(startInfo.Environment, "PATH", ChosenRuntimePath + ";" + startInfo.Environment["PATH"]);
+            SetEnvironmentVariable(startInfo.Environment, "PATH", startInfo.Environment["PATH"]);
             SetEnvironmentVariable(startInfo.Environment, "DNX_APPBASE", DeploymentParameters.ApplicationPath);
 #endif
 

--- a/src/Microsoft.AspNetCore.Server.Testing/project.json
+++ b/src/Microsoft.AspNetCore.Server.Testing/project.json
@@ -16,13 +16,12 @@
     "Microsoft.NETCore.Platforms": "1.0.1-*"
   },
   "frameworks": {
-    "dnx451": {
+    "net451": {
       "dependencies": {
         "Microsoft.Web.Administration": "7.0.0"
       },
       "frameworkAssemblies": {
         "System.Net.Http": "",
-        "System.Xml": ""
       }
     },
     "dnxcore50": {


### PR DESCRIPTION
This will be required for tests downstream that have a dependency on Microsoft.AspNetCore.Server.Testing.