### PR TITLE
Update the self host deployer message so published application comman…

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Testing/Deployers/SelfHostDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.Testing/Deployers/SelfHostDeployer.cs
@@ -64,7 +64,7 @@ namespace Microsoft.AspNetCore.Server.Testing
             executableArgs += $" --server.urls {uri} "
             + $" --server {(DeploymentParameters.ServerType == ServerType.WebListener ? "Microsoft.AspNetCore.Server.WebListener" : "Microsoft.AspNetCore.Server.Kestrel")}";
 
-            Logger.LogInformation($"Executing {DotnetCommandName} {executableArgs}");
+            Logger.LogInformation($"Executing {executableName} {executableArgs}");
 
             var startInfo = new ProcessStartInfo
             {


### PR DESCRIPTION
…d is accurate

otherwise we get messages like 
![image](https://cloud.githubusercontent.com/assets/2030323/13338739/429650fe-dbd8-11e5-8dae-4638f9dd59ba.png)

cc @BrennanConroy @kichalla 