### PR TITLE
Append .exe to executable when deploying published CLR applications

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Testing/Deployers/SelfHostDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.Testing/Deployers/SelfHostDeployer.cs
@@ -53,7 +53,8 @@ namespace Microsoft.AspNetCore.Server.Testing
             string executableArgs = string.Empty;
             if (DeploymentParameters.PublishApplicationBeforeDeployment)
             {
-                executableName = Path.Combine(DeploymentParameters.PublishedApplicationRootPath, new DirectoryInfo(DeploymentParameters.ApplicationPath).Name);
+                var executableExtension = DeploymentParameters.RuntimeFlavor == RuntimeFlavor.Clr ? ".exe" : "";
+                executableName = Path.Combine(DeploymentParameters.PublishedApplicationRootPath, new DirectoryInfo(DeploymentParameters.ApplicationPath).Name + executableExtension);
             }
             else
             {


### PR DESCRIPTION
I'm looking into Entropy test failures on Linux and I noticed that to deploy CLR projects, the .exe extension is still required. CoreCLR projects don't need the extension

cc @kichalla 