### PR TITLE
Fix how processes are killed on Linux

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Testing/Deployers/ApplicationDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.Testing/Deployers/ApplicationDeployer.cs
@@ -27,7 +27,6 @@ namespace Microsoft.AspNetCore.Server.Testing
 
         private readonly Stopwatch _stopwatch = new Stopwatch();
 
-
         public ApplicationDeployer(DeploymentParameters deploymentParameters, ILogger logger)
         {
             DeploymentParameters = deploymentParameters;
@@ -127,26 +126,34 @@ namespace Microsoft.AspNetCore.Server.Testing
 
         private void KillProcess(int processId)
         {
-            ProcessStartInfo startInfo;
-
             if (IsWindows)
             {
-                startInfo = new ProcessStartInfo
+                var startInfo = new ProcessStartInfo
                 {
                     FileName = "taskkill",
                     Arguments = $"/T /F /PID {processId}",
                 };
+                var killProcess = Process.Start(startInfo);
+                killProcess.WaitForExit();
             }
             else
             {
-                startInfo = new ProcessStartInfo
+                var killSubProcessStartInfo = new ProcessStartInfo
                 {
                     FileName = "pkill",
                     Arguments = $"-TERM -P {processId}",
                 };
+                var killSubProcess = Process.Start(killSubProcessStartInfo);
+                killSubProcess.WaitForExit();
+                
+                var killProcessStartInfo = new ProcessStartInfo
+                {
+                    FileName = "kill",
+                    Arguments = $"-TERM {processId}",
+                };
+                var killProcess = Process.Start(killProcessStartInfo);
+                killProcess.WaitForExit();
             }
-            var killProcess = Process.Start(startInfo);
-            killProcess.WaitForExit();
         }
 
         protected void AddEnvironmentVariablesToProcess(ProcessStartInfo startInfo)


### PR DESCRIPTION
I'm seeing hangs when tests use deployers. We need to kill the process itself and not just its children. Tested this change with Entropy on Linux.

cc @moozzyk 