### PR TITLE
Rename environment variables to ASPNETCORE_. 

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/WebHostDefaults.cs
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/WebHostDefaults.cs
@@ -15,6 +15,6 @@ namespace Microsoft.AspNetCore.Hosting
         public static readonly string ApplicationBaseKey = "applicationBase";
 
         public static readonly string HostingJsonFile = "hosting.json";
-        public static readonly string EnvironmentVariablesPrefix = "ASPNET_";
+        public static readonly string EnvironmentVariablesPrefix = "ASPNETCORE_";
     }
 }

--- a/src/Microsoft.AspNetCore.Hosting/Internal/WebHostConfiguration.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/WebHostConfiguration.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             };
 
             // Setup the default locations for finding hosting configuration options
-            // hosting.json, ASPNET_ prefixed env variables and command line arguments
+            // hosting.json, ASPNETCORE_ prefixed env variables and command line arguments
             var configBuilder = new ConfigurationBuilder()
                 .AddInMemoryCollection(defaultSettings)
                 .AddJsonFile(WebHostDefaults.HostingJsonFile, optional: true)

--- a/src/Microsoft.AspNetCore.Hosting/Internal/WebHostOptions.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/WebHostOptions.cs
@@ -8,8 +8,6 @@ namespace Microsoft.AspNetCore.Hosting.Internal
 {
     public class WebHostOptions
     {
-        private const string OldEnvironmentKey = "ENV";
-
         public WebHostOptions()
         {
         }
@@ -24,7 +22,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             Application = configuration[WebHostDefaults.ApplicationKey];
             DetailedErrors = ParseBool(configuration, WebHostDefaults.DetailedErrorsKey);
             CaptureStartupErrors = ParseBool(configuration, WebHostDefaults.CaptureStartupErrorsKey);
-            Environment = configuration[WebHostDefaults.EnvironmentKey] ?? configuration[OldEnvironmentKey];
+            Environment = configuration[WebHostDefaults.EnvironmentKey];
             ServerFactoryLocation = configuration[WebHostDefaults.ServerKey];
             WebRoot = configuration[WebHostDefaults.WebRootKey];
             ApplicationBasePath = configuration[WebHostDefaults.ApplicationBaseKey];

--- a/src/Microsoft.AspNetCore.Server.Testing/Common/DeploymentParameters.cs
+++ b/src/Microsoft.AspNetCore.Server.Testing/Common/DeploymentParameters.cs
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.Server.Testing
             ApplicationPath = applicationPath;
             ServerType = serverType;
             RuntimeFlavor = runtimeFlavor;
-            EnvironmentVariables.Add(new KeyValuePair<string, string>("ASPNET_DETAILEDERRORS", "true"));
+            EnvironmentVariables.Add(new KeyValuePair<string, string>("ASPNETCORE_DETAILEDERRORS", "true"));
         }
 
         public ServerType ServerType { get; }

--- a/src/Microsoft.AspNetCore.Server.Testing/Deployers/ApplicationDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.Testing/Deployers/ApplicationDeployer.cs
@@ -161,7 +161,7 @@ namespace Microsoft.AspNetCore.Server.Testing
                 startInfo.Environment;
 #endif
 
-            SetEnvironmentVariable(environment, "ASPNET_ENV", DeploymentParameters.EnvironmentName);
+            SetEnvironmentVariable(environment, "ASPNETCORE_ENVIRONMENT", DeploymentParameters.EnvironmentName);
 
             foreach (var environmentVariable in DeploymentParameters.EnvironmentVariables)
             {

--- a/test/Microsoft.AspNetCore.Hosting.Tests/WebHostConfigurationsTests.cs
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/WebHostConfigurationsTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.AspNetCore.Hosting.Tests
         [Fact]
         public void ReadsOldEnvKey()
         {
-            var parameters = new Dictionary<string, string>() { { "ENV", "Development" } };
+            var parameters = new Dictionary<string, string>() { { "ENVIRONMENT", "Development" } };
             var config = new WebHostOptions(new ConfigurationBuilder().AddInMemoryCollection(parameters).Build());
 
             Assert.Equal("Development", config.Environment);

--- a/test/Microsoft.AspNetCore.Hosting.Tests/WebHostTests.cs
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/WebHostTests.cs
@@ -282,9 +282,7 @@ namespace Microsoft.AspNetCore.Hosting
         {
             var vals = new Dictionary<string, string>
             {
-                // Old key is actualy ASPNET_ENV but WebHostConfiguration expects environment
-                // variable names stripped from ASPNET_ prefix so using just ENV here
-                { "ENV", "Staging" }
+                { "environment", "Staging" }
             };
 
             var builder = new ConfigurationBuilder()


### PR DESCRIPTION
Also remove the legacy ENV abbreviation.
@DamianEdwards @davidfowl @muratg @JunTaoLuo @BillHiebert 