### PR TITLE
Revert ApplicationBasePath default resolution #641

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting/WebHostBuilder.cs
+++ b/src/Microsoft.AspNetCore.Hosting/WebHostBuilder.cs
@@ -230,23 +230,6 @@ namespace Microsoft.AspNetCore.Hosting
 
         private string ResolveApplicationBasePath(string applicationBasePath, string basePath)
         {
-            if (_startup != null)
-            {
-                var startupAssemblyLocation = _startup.ConfigureDelegate.Target.GetType().GetTypeInfo().Assembly.Location;
-                if (!string.IsNullOrEmpty(startupAssemblyLocation))
-                {
-                    return Path.GetDirectoryName(startupAssemblyLocation);
-                }
-            }
-            else if (_startupType != null)
-            {
-                var startupAssemblyLocation = _startupType.GetTypeInfo().Assembly.Location;
-                if (!string.IsNullOrEmpty(startupAssemblyLocation)) 
-                {
-                    return Path.GetDirectoryName(startupAssemblyLocation);
-                }
-            }
-
             if (string.IsNullOrEmpty(applicationBasePath))
             {
                 return basePath;

--- a/test/Microsoft.AspNetCore.Hosting.Tests/WebHostBuilderTests.cs
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/WebHostBuilderTests.cs
@@ -352,12 +352,10 @@ namespace Microsoft.AspNetCore.Hosting
             var host = new WebHostBuilder()
                 .UseServer(new TestServer())
                 .UseStartup("Microsoft.AspNetCore.Hosting.Tests")
-                .UseApplicationBasePath("/foo/bar")
                 .Build();
 
             var appEnv = host.Services.GetService<IApplicationEnvironment>();
             Assert.Equal("Microsoft.AspNetCore.Hosting.Tests", appEnv.ApplicationName);
-            Assert.Equal("/foo/bar", appEnv.ApplicationBasePath);
         }
 
         [Fact]
@@ -368,12 +366,10 @@ namespace Microsoft.AspNetCore.Hosting
                 .UseServer(new TestServer())
                 .UseStartup<StartupNoServices>()
                 .UseStartup("Microsoft.AspNetCore.Hosting.Tests.NonExistent")
-                .UseApplicationBasePath("/foo/bar")
                 .Build();
 
             var appEnv = host.Services.GetService<IApplicationEnvironment>();
             Assert.Equal("Microsoft.AspNetCore.Hosting.Tests", appEnv.ApplicationName);
-            Assert.Equal(Path.GetDirectoryName(typeof(WebHostBuilderTests).GetTypeInfo().Assembly.Location), appEnv.ApplicationBasePath);
         }
 
         [Fact]
@@ -384,12 +380,10 @@ namespace Microsoft.AspNetCore.Hosting
                 .UseServer(new TestServer())
                 .Configure(app => { })
                 .UseStartup("Microsoft.AspNetCore.Hosting.Tests.NonExistent")
-                .UseApplicationBasePath("/foo/bar")
                 .Build();
 
             var appEnv = host.Services.GetService<IApplicationEnvironment>();
             Assert.Equal("Microsoft.AspNetCore.Hosting.Tests", appEnv.ApplicationName);
-            Assert.Equal(Path.GetDirectoryName(typeof(WebHostBuilderTests).GetTypeInfo().Assembly.Location), appEnv.ApplicationBasePath);
         }
 
         private IWebHostBuilder CreateWebHostBuilder()


### PR DESCRIPTION
#641 This will revert to the previous behaviour which sets the ApplicationBasePath to the default ApplicationEnvironment provided by PlatformServices and the user configured options.