### PR TITLE
React to HttpAbstractions change: No features in `.Internal` namespace

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting/Internal/RequestServicesContainerFeature.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/RequestServicesContainerFeature.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.AspNetCore.Http.Features.Internal;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Hosting.Internal

--- a/test/Microsoft.AspNetCore.TestHost.Tests/TestServerTests.cs
+++ b/test/Microsoft.AspNetCore.TestHost.Tests/TestServerTests.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Features.Internal;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Http.Internal;
 using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.DependencyInjection;


### PR DESCRIPTION
- see issue aspnet/HttpAbstractions#561 and pull aspnet/HttpAbstractions#589