### PR TITLE
Pass existing LoggerFactory into WebHostBuilder

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/IWebHostBuilder.cs
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/IWebHostBuilder.cs
@@ -5,6 +5,7 @@ using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Hosting
 {
@@ -17,6 +18,13 @@ namespace Microsoft.AspNetCore.Hosting
         /// Builds an <see cref="IWebHost"/> which hosts a web application.
         /// </summary>
         IWebHost Build();
+
+        /// <summary>
+        /// Specify the <see cref="ILoggerFactory"/> to be used by the web host.
+        /// </summary>
+        /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to be used.</param>
+        /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
+        IWebHostBuilder UseLoggerFactory(ILoggerFactory loggerFactory);
 
         /// <summary>
         /// Specify the <see cref="IServerFactory"/> to be used by the web host.
@@ -45,6 +53,13 @@ namespace Microsoft.AspNetCore.Hosting
         /// <param name="configureApplication">The delegate that configures the <see cref="IApplicationBuilder"/>.</param>
         /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
         IWebHostBuilder Configure(Action<IApplicationBuilder> configureApplication);
+
+        /// <summary>
+        /// Adds a delegate for configuring the provided <see cref="ILoggerFactory"/>. This may be called multiple times.
+        /// </summary>
+        /// <param name="configureLogging">The delegate that configures the <see cref="ILoggerFactory"/>.</param>
+        /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
+        IWebHostBuilder ConfigureLogging(Action<ILoggerFactory> configureLogging);
 
         /// <summary>
         /// Add or replace a setting in the configuration.

--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/project.json
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/project.json
@@ -18,7 +18,8 @@
     "Microsoft.AspNetCore.Hosting.Server.Abstractions": "1.0.0-*",
     "Microsoft.Extensions.Configuration.Abstractions": "1.0.0-*",
     "Microsoft.Extensions.DependencyInjection.Abstractions": "1.0.0-*",
-    "Microsoft.Extensions.FileProviders.Abstractions": "1.0.0-*"
+    "Microsoft.Extensions.FileProviders.Abstractions": "1.0.0-*",
+    "Microsoft.Extensions.Logging.Abstractions": "1.0.0-*"
   },
   "frameworks": {
     "net451": {},

--- a/src/Microsoft.AspNetCore.Hosting/WebHostBuilder.cs
+++ b/src/Microsoft.AspNetCore.Hosting/WebHostBuilder.cs
@@ -27,10 +27,11 @@ namespace Microsoft.AspNetCore.Hosting
     public class WebHostBuilder : IWebHostBuilder
     {
         private readonly IHostingEnvironment _hostingEnvironment;
-        private readonly ILoggerFactory _loggerFactory;
         private readonly List<Action<IServiceCollection>> _configureServicesDelegates;
+        private readonly List<Action<ILoggerFactory>> _configureLoggingDelegates;
 
         private IConfiguration _config = new ConfigurationBuilder().AddInMemoryCollection().Build();
+        private ILoggerFactory _loggerFactory;
         private WebHostOptions _options;
 
         // Only one of these should be set
@@ -43,12 +44,11 @@ namespace Microsoft.AspNetCore.Hosting
         /// <summary>
         /// Initializes a new instance of the <see cref="WebHostBuilder"/> class.
         /// </summary>
-        /// <param name="loggerFactory">An existing <see cref="ILoggerFactory"/>. It will be available as a hosting service.</param>
-        public WebHostBuilder(ILoggerFactory loggerFactory = null)
+        public WebHostBuilder()
         {
             _hostingEnvironment = new HostingEnvironment();
-            _loggerFactory = loggerFactory ?? new LoggerFactory();
             _configureServicesDelegates = new List<Action<IServiceCollection>>();
+            _configureLoggingDelegates = new List<Action<ILoggerFactory>>();
         }
 
         /// <summary>
@@ -71,6 +71,22 @@ namespace Microsoft.AspNetCore.Hosting
         public string GetSetting(string key)
         {
             return _config[key];
+        }
+
+        /// <summary>
+        /// Specify the <see cref="ILoggerFactory"/> to be used by the web host.
+        /// </summary>
+        /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to be used.</param>
+        /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
+        public IWebHostBuilder UseLoggerFactory(ILoggerFactory loggerFactory)
+        {
+            if (loggerFactory == null)
+            {
+                throw new ArgumentNullException(nameof(loggerFactory));
+            }
+
+            _loggerFactory = loggerFactory;
+            return this;
         }
 
         /// <summary>
@@ -139,13 +155,18 @@ namespace Microsoft.AspNetCore.Hosting
         }
 
         /// <summary>
-        /// Configure the provided <see cref="ILoggerFactory"/> which will be available as a hosting service. 
+        /// Adds a delegate for configuring the provided <see cref="ILoggerFactory"/>. This may be called multiple times.
         /// </summary>
         /// <param name="configureLogging">The delegate that configures the <see cref="ILoggerFactory"/>.</param>
         /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
         public IWebHostBuilder ConfigureLogging(Action<ILoggerFactory> configureLogging)
         {
-            configureLogging(_loggerFactory);
+            if (configureLogging == null)
+            {
+                throw new ArgumentNullException(nameof(configureLogging));
+            }
+
+            _configureLoggingDelegates.Add(configureLogging);
             return this;
         }
 
@@ -188,14 +209,25 @@ namespace Microsoft.AspNetCore.Hosting
 
             var services = new ServiceCollection();
             services.AddSingleton(_hostingEnvironment);
+
+            if (_loggerFactory == null)
+            {
+                _loggerFactory = new LoggerFactory();
+            }
+
+            foreach (var configureLogging in _configureLoggingDelegates)
+            {
+                configureLogging(_loggerFactory);
+            }
+
             services.AddSingleton(_loggerFactory);
+            services.AddLogging();
 
             services.AddTransient<IStartupLoader, StartupLoader>();
 
             services.AddTransient<IServerLoader, ServerLoader>();
             services.AddTransient<IApplicationBuilderFactory, ApplicationBuilderFactory>();
             services.AddTransient<IHttpContextFactory, HttpContextFactory>();
-            services.AddLogging();
             services.AddOptions();
 
             var diagnosticSource = new DiagnosticListener("Microsoft.AspNetCore");

--- a/src/Microsoft.AspNetCore.Hosting/WebHostBuilder.cs
+++ b/src/Microsoft.AspNetCore.Hosting/WebHostBuilder.cs
@@ -40,10 +40,14 @@ namespace Microsoft.AspNetCore.Hosting
         // Only one of these should be set
         private IServerFactory _serverFactory;
 
-        public WebHostBuilder()
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WebHostBuilder"/> class.
+        /// </summary>
+        /// <param name="loggerFactory">An existing <see cref="ILoggerFactory"/>. It will be available as a hosting service.</param>
+        public WebHostBuilder(ILoggerFactory loggerFactory = null)
         {
             _hostingEnvironment = new HostingEnvironment();
-            _loggerFactory = new LoggerFactory();
+            _loggerFactory = loggerFactory ?? new LoggerFactory();
             _configureServicesDelegates = new List<Action<IServiceCollection>>();
         }
 

--- a/test/Microsoft.AspNetCore.Hosting.Tests/WebHostBuilderTests.cs
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/WebHostBuilderTests.cs
@@ -23,32 +23,6 @@ namespace Microsoft.AspNetCore.Hosting
     public class WebHostBuilderTests
     {
         [Fact]
-        public void CtorCreatesLoggerFactory()
-        {
-            var hostBuilder = new WebHostBuilder()
-                .UseServer(new TestServer())
-                .UseStartup<StartupNoServices>();
-
-            var host = (WebHost)hostBuilder.Build();
-
-            Assert.NotNull(host.Services.GetService<ILoggerFactory>());
-        }
-
-        [Fact]
-        public void CtorAcceptsLoggerFactory()
-        {
-            var loggerFactory = new LoggerFactory();
-
-            var hostBuilder = new WebHostBuilder(loggerFactory)
-                .UseServer(new TestServer())
-                .UseStartup<StartupNoServices>();
-
-            var host = (WebHost)hostBuilder.Build();
-
-            Assert.Same(loggerFactory, host.Services.GetService<ILoggerFactory>());
-        }
-
-        [Fact]
         public void Build_honors_UseStartup_with_string()
         {
             var builder = CreateWebHostBuilder().UseServer(new TestServer());
@@ -149,6 +123,33 @@ namespace Microsoft.AspNetCore.Hosting
                 host.Start();
                 await AssertResponseContains(server.RequestDelegate, "Exception from Configure");
             }
+        }
+
+        [Fact]
+        public void DefaultCreatesLoggerFactory()
+        {
+            var hostBuilder = new WebHostBuilder()
+                .UseServer(new TestServer())
+                .UseStartup<StartupNoServices>();
+
+            var host = (WebHost)hostBuilder.Build();
+
+            Assert.NotNull(host.Services.GetService<ILoggerFactory>());
+        }
+
+        [Fact]
+        public void UseLoggerFactoryHonored()
+        {
+            var loggerFactory = new LoggerFactory();
+
+            var hostBuilder = new WebHostBuilder()
+                .UseLoggerFactory(loggerFactory)
+                .UseServer(new TestServer())
+                .UseStartup<StartupNoServices>();
+
+            var host = (WebHost)hostBuilder.Build();
+
+            Assert.Same(loggerFactory, host.Services.GetService<ILoggerFactory>());
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Hosting.Tests/WebHostBuilderTests.cs
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/WebHostBuilderTests.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Http.Internal;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.PlatformAbstractions;
 using System.Reflection;
 using Xunit;
@@ -21,6 +22,32 @@ namespace Microsoft.AspNetCore.Hosting
 {
     public class WebHostBuilderTests
     {
+        [Fact]
+        public void CtorCreatesLoggerFactory()
+        {
+            var hostBuilder = new WebHostBuilder()
+                .UseServer(new TestServer())
+                .UseStartup<StartupNoServices>();
+
+            var host = (WebHost)hostBuilder.Build();
+
+            Assert.NotNull(host.Services.GetService<ILoggerFactory>());
+        }
+
+        [Fact]
+        public void CtorAcceptsLoggerFactory()
+        {
+            var loggerFactory = new LoggerFactory();
+
+            var hostBuilder = new WebHostBuilder(loggerFactory)
+                .UseServer(new TestServer())
+                .UseStartup<StartupNoServices>();
+
+            var host = (WebHost)hostBuilder.Build();
+
+            Assert.Same(loggerFactory, host.Services.GetService<ILoggerFactory>());
+        }
+
         [Fact]
         public void Build_honors_UseStartup_with_string()
         {


### PR DESCRIPTION
As described in #658 

I'm motivated so I couldn't wait for your answer. :) Feel free to reject it if you think this is not correct or if you want something changed.

It allows to pass an existing ILoggerFactory into the WebHostBuilder constructor. I think this is better than a `UseLoggerFactory` method because the LoggerFactory is already created in the constructor right now.

I also added two tests. One checks if the host can actually resolve an ILoggerFactory and the second checks if the LoggerFactory passed in gets resolved correctly.
I added the tests at the top of the file because they are related to the constructor - I hope that's ok?!

BTW: Supporting a way to pass a LoggerFactor into the WebHostBuilder is also discussed here: 
https://github.com/aspnet/Logging/issues/346 ( @davidfowl @lodejard )