### PR TITLE
Replaces Hosting:Environment with new values in docs

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/IHostingEnvironment.cs
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/IHostingEnvironment.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNetCore.Hosting
     {
         /// <summary>
         /// Gets or sets the name of the environment. This property is automatically set by the host to the value
-        /// of the "Hosting:Environment" (on Windows) or "Hosting__Environment" (on Linux &amp; OS X) environment variable.
+        /// of the "ASPNETCORE_ENVIRONMENT" environment variable.
         /// </summary>
         // This must be settable!
         string EnvironmentName { get; set; }

--- a/src/Microsoft.AspNetCore.Server.Testing/Deployers/IISDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.Testing/Deployers/IISDeployer.cs
@@ -87,10 +87,10 @@ namespace Microsoft.AspNetCore.Server.Testing
 
         private void SetAspEnvironmentWithJson()
         {
-            ////S Drop a hosting.json with Hosting:Environment information.
-            // Logger.LogInformation("Creating hosting.json file with Hosting:Environment.");
+            ////S Drop a hosting.json with environment information.
+            // Logger.LogInformation("Creating hosting.json file with environment information.");
             // var jsonFile = Path.Combine(DeploymentParameters.ApplicationPath, "hosting.json");
-            // File.WriteAllText(jsonFile, string.Format("{ \"Hosting:Environment\":\"{0}\" }", DeploymentParameters.EnvironmentName));
+            // File.WriteAllText(jsonFile, string.Format("{ \"environment\":\"{0}\" }", DeploymentParameters.EnvironmentName));
         }
 
         private class IISApplication


### PR DESCRIPTION
adjustments according to https://github.com/aspnet/Announcements/issues/108 and #640
* Xml docs in IHostingEnvironment still contained Hosting:Environment
* a commented out method in IISDeployer.cs still contained Hosting:Environment