### PR TITLE
Consistency fixes for XML docs

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/IApplicationLifetime.cs
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/IApplicationLifetime.cs
@@ -18,9 +18,8 @@ namespace Microsoft.AspNetCore.Hosting
 
         /// <summary>
         /// Triggered when the application host is performing a graceful shutdown.
-        /// Request may still be in flight. Shutdown will block until this event completes.
+        /// Requests may still be in flight. Shutdown will block until this event completes.
         /// </summary>
-        /// <returns></returns>
         CancellationToken ApplicationStopping { get; }
 
         /// <summary>
@@ -28,7 +27,6 @@ namespace Microsoft.AspNetCore.Hosting
         /// All requests should be complete at this point. Shutdown will block
         /// until this event completes.
         /// </summary>
-        /// <returns></returns>
         CancellationToken ApplicationStopped { get; }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/IHostingEnvironment.cs
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/IHostingEnvironment.cs
@@ -14,38 +14,32 @@ namespace Microsoft.AspNetCore.Hosting
         /// Gets or sets the name of the environment. This property is automatically set by the host to the value
         /// of the "Hosting:Environment" (on Windows) or "Hosting__Environment" (on Linux &amp; OS X) environment variable.
         /// </summary>
-        // This must be settable!
         string EnvironmentName { get; set; }
         
         /// <summary>
         /// Gets or sets the name of the application. This property is automatically set by the host to the assembly containing
         /// the application entry point.
         /// </summary>
-        // This must be settable!
         string ApplicationName { get; set; }
 
         /// <summary>
         /// Gets or sets the absolute path to the directory that contains the web-servable application content files.
         /// </summary>
-        // This must be settable!
         string WebRootPath { get; set; }
 
         /// <summary>
         /// Gets or sets an <see cref="IFileProvider"/> pointing at <see cref="WebRootPath"/>.
         /// </summary>
-        // This must be settable!
         IFileProvider WebRootFileProvider { get; set; }
 
         /// <summary>
         /// Gets or sets the absolute path to the directory that contains the application content files.
         /// </summary>
-        // This must be settable!
         string ContentRootPath { get; set; }
 
         /// <summary>
         /// Gets or sets an <see cref="IFileProvider"/> pointing at <see cref="ContentRootPath"/>.
         /// </summary>
-        // This must be settable!
         IFileProvider ContentRootFileProvider { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/IWebHost.cs
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/IWebHost.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Http.Features;
 namespace Microsoft.AspNetCore.Hosting
 {
     /// <summary>
-    /// Represents a configured web host
+    /// Represents a configured web host.
     /// </summary>
     public interface IWebHost : IDisposable
     {
@@ -24,7 +24,6 @@ namespace Microsoft.AspNetCore.Hosting
         /// <summary>
         /// Starts listening on the configured addresses.
         /// </summary>
-        /// <returns></returns>
         void Start();
     }
 }

--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/IWebHostBuilder.cs
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/IWebHostBuilder.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Microsoft.AspNetCore.Hosting
 {
     /// <summary>
-    /// A builder for <see cref="IWebHost"/>
+    /// A builder for <see cref="IWebHost"/>.
     /// </summary>
     public interface IWebHostBuilder
     {

--- a/src/Microsoft.AspNetCore.Hosting/Internal/ApplicationLifetime.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/ApplicationLifetime.cs
@@ -25,7 +25,6 @@ namespace Microsoft.AspNetCore.Hosting.Internal
         /// Triggered when the application host is performing a graceful shutdown.
         /// Request may still be in flight. Shutdown will block until this event completes.
         /// </summary>
-        /// <returns></returns>
         public CancellationToken ApplicationStopping => _stoppingSource.Token;
 
         /// <summary>
@@ -33,7 +32,6 @@ namespace Microsoft.AspNetCore.Hosting.Internal
         /// All requests should be complete at this point. Shutdown will block
         /// until this event completes.
         /// </summary>
-        /// <returns></returns>
         public CancellationToken ApplicationStopped => _stoppedSource.Token;
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.Hosting/WebHostExtensions.cs
+++ b/src/Microsoft.AspNetCore.Hosting/WebHostExtensions.cs
@@ -31,10 +31,10 @@ namespace Microsoft.AspNetCore.Hosting
         }
 
         /// <summary>
-        /// Runs a web application and block the calling thread until token is triggered or shutdown is triggered
+        /// Runs a web application and block the calling thread until token is triggered or shutdown is triggered.
         /// </summary>
         /// <param name="host"></param>
-        /// <param name="token">The token to trigger shutdown</param>
+        /// <param name="token">The token to trigger shutdown.</param>
         public static void Run(this IWebHost host, CancellationToken token)
         {
             host.Run(token, shutdownMessage: null);


### PR DESCRIPTION
* "Requests *" instead of "Request may still be in flight." (there could be multiple ones if I understand it correctly)
* adds missing . at the end of comments
* removes empty `<returns></returns>` blocks
* removes "This must be settable!" comments in IHostingEnvironment. This should be self-explanatory since the property is get;set; and the xml doc contains "Gets or sets"