### PR TITLE
Use ConfigureDelegate instead of Action<IApplicationBuilder>

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/ConfigureDelegate.cs
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/ConfigureDelegate.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Builder;
+
+namespace Microsoft.AspNetCore.Hosting
+{
+    public delegate void ConfigureDelegate(IApplicationBuilder builder);
+}

--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/IStartupFilter.cs
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/IStartupFilter.cs
@@ -1,13 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using Microsoft.AspNetCore.Builder;
-
 namespace Microsoft.AspNetCore.Hosting
 {
     public interface IStartupFilter
     {
-        Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next);
+        ConfigureDelegate Configure(ConfigureDelegate next);
     }
 }

--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/IWebHostBuilder.cs
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/IWebHostBuilder.cs
@@ -44,7 +44,7 @@ namespace Microsoft.AspNetCore.Hosting
         /// </summary>
         /// <param name="configureApplication">The delegate that configures the <see cref="IApplicationBuilder"/>.</param>
         /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
-        IWebHostBuilder Configure(Action<IApplicationBuilder> configureApplication);
+        IWebHostBuilder Configure(ConfigureDelegate configureApplication);
 
         /// <summary>
         /// Add or replace a setting in the configuration.

--- a/src/Microsoft.AspNetCore.Hosting/Internal/AutoRequestServicesStartupFilter.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/AutoRequestServicesStartupFilter.cs
@@ -1,15 +1,13 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting.Startup;
 
 namespace Microsoft.AspNetCore.Hosting.Internal
 {
     public class AutoRequestServicesStartupFilter : IStartupFilter
     {
-        public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
+        public ConfigureDelegate Configure(ConfigureDelegate next)
         {
             return builder =>
             {

--- a/src/Microsoft.AspNetCore.Hosting/Startup/ConfigureDelegate.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Startup/ConfigureDelegate.cs
@@ -8,9 +8,6 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Hosting.Startup
 {
-    // TODO: replace all Action<IApplicationBuilder> eventually with this
-    public delegate void ConfigureDelegate(IApplicationBuilder builder);
-
     public class ConfigureBuilder
     {
         public ConfigureBuilder(MethodInfo configure)
@@ -20,7 +17,7 @@ namespace Microsoft.AspNetCore.Hosting.Startup
 
         public MethodInfo MethodInfo { get; }
 
-        public Action<IApplicationBuilder> Build(object instance) => builder => Invoke(instance, builder);
+        public ConfigureDelegate Build(object instance) => builder => Invoke(instance, builder);
 
         private void Invoke(object instance, IApplicationBuilder builder)
         {

--- a/src/Microsoft.AspNetCore.Hosting/Startup/StartupMethods.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Startup/StartupMethods.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Hosting.Startup
@@ -11,19 +10,19 @@ namespace Microsoft.AspNetCore.Hosting.Startup
     {
         internal static Func<IServiceCollection, IServiceProvider> DefaultBuildServiceProvider = s => s.BuildServiceProvider();
 
-        public StartupMethods(Action<IApplicationBuilder> configure)
+        public StartupMethods(ConfigureDelegate configure)
             : this(configure, configureServices: null)
         {
         }
 
-        public StartupMethods(Action<IApplicationBuilder> configure, Func<IServiceCollection, IServiceProvider> configureServices)
+        public StartupMethods(ConfigureDelegate configure, Func<IServiceCollection, IServiceProvider> configureServices)
         {
             ConfigureDelegate = configure;
             ConfigureServicesDelegate = configureServices ?? DefaultBuildServiceProvider;
         }
 
         public Func<IServiceCollection, IServiceProvider> ConfigureServicesDelegate { get; }
-        public Action<IApplicationBuilder> ConfigureDelegate { get; }
+        public ConfigureDelegate ConfigureDelegate { get; }
 
     }
 }

--- a/src/Microsoft.AspNetCore.Hosting/WebHostBuilder.cs
+++ b/src/Microsoft.AspNetCore.Hosting/WebHostBuilder.cs
@@ -123,7 +123,7 @@ namespace Microsoft.AspNetCore.Hosting
         /// </summary>
         /// <param name="configureApp">The delegate that configures the <see cref="IApplicationBuilder"/>.</param>
         /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
-        public IWebHostBuilder Configure(Action<IApplicationBuilder> configureApp)
+        public IWebHostBuilder Configure(ConfigureDelegate configureApp)
         {
             if (configureApp == null)
             {

--- a/test/Microsoft.AspNetCore.TestHost.Tests/TestServerTests.cs
+++ b/test/Microsoft.AspNetCore.TestHost.Tests/TestServerTests.cs
@@ -143,7 +143,7 @@ namespace Microsoft.AspNetCore.TestHost
 
         public class RequestServicesFilter : IStartupFilter
         {
-            public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
+            public ConfigureDelegate Configure(ConfigureDelegate next)
             {
                 return builder =>
                 {
@@ -210,7 +210,7 @@ namespace Microsoft.AspNetCore.TestHost
 
             public IServiceProvider RequestServices { get; set; }
 
-            public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
+            public ConfigureDelegate Configure(ConfigureDelegate next)
             {
                 return app =>
                 {
@@ -253,7 +253,7 @@ namespace Microsoft.AspNetCore.TestHost
 
             public IServiceProvider RequestServices { get; set; }
 
-            public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
+            public ConfigureDelegate Configure(ConfigureDelegate next)
             {
                 return app =>
                 {


### PR DESCRIPTION
This fixes the open TODO `replace all Action<IApplicationBuilder> eventually with this` in ConfigureDelegate.cs. Since I'm trying to learn the codebase I thought I could give it a try.

* I moved the `ConfigureDelegate` to the Abstractions project because the signature was used there as well. I thought this was ok because it is similar to e.g. `RequestDelegate` from the HttpAbstractions package.
* I changed the namespace from `Microsoft.AspNetCore.Hosting.Startup` to `Microsoft.AspNetCore.Hosting` because that's the namespace of all other types in that package. This would be a small breaking change but it seems like `ConfigureDelegate` wasn't used so far. (I checked it on google with this query: "ConfigureDelegate site:github.com/aspnet")
* I did not rename the existing ConfigureDelegate.cs file to ConfigureBuilder.cs because there is a separate pull request for this.
* Some classes still need the namespace Microsoft.AspNetCore.Builder because some xml docs refer to it. I didn't want to update the comments because I'm not a native english speaker.

All in all, I'm not 100% sure that these delegate types are a good thing because you loose help from IntelliSense. `Action<IApplicationBuilder>` was very easy to understand and IntelliSense made clear how to use it and how many parameters there are. With `ConfigureDelegate` however (or other similar types like `RequestDelegate`), you might have to F12 into it to see the signature or do some trial & error.