### PR TITLE
Remove the ConfigureDelegate delegate

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting/Startup/ConfigureBuilder.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Startup/ConfigureBuilder.cs
@@ -8,9 +8,6 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Hosting.Startup
 {
-    // TODO: replace all Action<IApplicationBuilder> eventually with this
-    public delegate void ConfigureDelegate(IApplicationBuilder builder);
-
     public class ConfigureBuilder
     {
         public ConfigureBuilder(MethodInfo configure)


### PR DESCRIPTION
@davidfowl said in #665 that the ConfigureDelegate should be removed. This would be a PR for it. 

[Seems like it is not used anywhere](https://www.google.at/#q=%22ConfigureDelegate%22+site:github.com%2Faspnet) - although that's probably not the best way to find out ;)