### PR TITLE
Add duration to the after DiagnosticSource events in HostingApplication

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting/Internal/HostingApplication.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/HostingApplication.cs
@@ -40,7 +40,13 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             _logger.RequestStarting(httpContext);
             if (diagnoticsEnabled)
             {
-                _diagnosticSource.Write("Microsoft.AspNetCore.Hosting.BeginRequest", new { httpContext = httpContext, timestamp = startTimestamp });
+                _diagnosticSource.Write(
+                    "Microsoft.AspNetCore.Hosting.BeginRequest", 
+                    new
+                    {
+                        httpContext = httpContext,
+                        timestamp = startTimestamp
+                    });
             }
 
             return new Context
@@ -58,25 +64,52 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             if (exception == null)
             {
                 var diagnoticsEnabled = _diagnosticSource.IsEnabled("Microsoft.AspNetCore.Hosting.EndRequest");
-                var currentTimestamp = (diagnoticsEnabled || context.StartTimestamp != 0) ? Stopwatch.GetTimestamp() : 0;
+                var currentTimestamp = 0L;
+                var duration = 0L;
+                if (diagnoticsEnabled || context.StartTimestamp != 0)
+                {
+                    currentTimestamp = Stopwatch.GetTimestamp();
+                    duration = context.StartTimestamp - currentTimestamp;
+                }
 
                 _logger.RequestFinished(httpContext, context.StartTimestamp, currentTimestamp);
 
                 if (diagnoticsEnabled)
                 {
-                    _diagnosticSource.Write("Microsoft.AspNetCore.Hosting.EndRequest", new { httpContext = httpContext, timestamp = currentTimestamp });
+                    _diagnosticSource.Write(
+                        "Microsoft.AspNetCore.Hosting.EndRequest", 
+                        new
+                        {
+                            httpContext = httpContext,
+                            timestamp = currentTimestamp,
+                            duration = duration
+                        });
                 }
             }
             else
             {
                 var diagnoticsEnabled = _diagnosticSource.IsEnabled("Microsoft.AspNetCore.Hosting.UnhandledException");
-                var currentTimestamp = (diagnoticsEnabled || context.StartTimestamp != 0) ? Stopwatch.GetTimestamp() : 0;
+                var currentTimestamp = 0L;
+                var duration = 0L;
+                if (diagnoticsEnabled || context.StartTimestamp != 0)
+                {
+                    currentTimestamp = Stopwatch.GetTimestamp();
+                    duration = context.StartTimestamp - currentTimestamp;
+                }
 
                 _logger.RequestFinished(httpContext, context.StartTimestamp, currentTimestamp);
 
                 if (diagnoticsEnabled)
                 {
-                    _diagnosticSource.Write("Microsoft.AspNetCore.Hosting.UnhandledException", new { httpContext = httpContext, timestamp = currentTimestamp, exception = exception });
+                    _diagnosticSource.Write(
+                        "Microsoft.AspNetCore.Hosting.UnhandledException", 
+                        new
+                        {
+                            httpContext = httpContext,
+                            timestamp = currentTimestamp,
+                            duration = duration,
+                            exception = exception
+                        });
                 }
             }
 


### PR DESCRIPTION
This is a fairly minor change that adds duration to the end DiagnosticSource around begin/end request in `HostingApplication`. Doing this change will bring it inline with other DiagnosticSource events that include duration (see Middleware and EntityFramework). Given that this change is isolated to when an event is being listened to, impact to the main execution path has been isolated.

**Discussion Point**
One thing I would like to do before submitting this PR is to quickly discuss part of the way that we might be able to improve performance given whats likely the most common use case. Specifically, part of the reason adding `duration` to the end payloads is compelling is that it means that you don't have to listen to the begin and end events to determine how long the request too. This has tangible benefits as it means that people will be listening to less events on the request hot path. 

Assuming that we agree this is a good thing, the only downside is that currently we only capture the `startTimestamp` based on whether someone has logging enabled or is listening to the start DiagnosticSource event. Given the case where logging isn't enabled and the fact that we are saying for the most common DS scenario, you shouldn't have to listen to this begin event. 

Given this, in my mind the following possibilities are possible:

1. Alway capture the `startTimestamp` regardless of whether it is going to be used
     - This has the downside of `Stopwatch.GetTimestamp()` to be called on every request regardless of if its being used. Given this, the below might be a solution...
2. Check in the `CreateContext` whether the end listens are enabled, and if that as part of the criteria as to whether the `startTimestamp` should be capture
     - This has the downside that to remain performant, we should probably store the result of the end listeners check in the `Context` object so that we aren't performing the check again in the `DisposeContext`
         - Note, performing the check twice is likely more of a performance hit than just capturing the `startTimestamp` all the time.
     - Making the change to `Context` is probably acceptable given that the object is nested within `HostingApplication` which is within an internal namespace
3. We don't change anything and go get things working correctly, people need to subscribe to both the begin and end events anyway, its just documentation that they don't need to do anything inside of the begin callback
     - This is not nice, but a little better than we are now for the consumer as it means that they don't need to store state between the begin and end events

In my mind the second possibility is the most desirable, but I wanted to check in before making wider changes.

Note, I've also adjust how many cols that some of the DS events are taking up as @Eilon yelled at me last time about it ;) 

@Tratcher @Eilon @davidfowl @benaadams