### PR TITLE
Allocate the IServiceScopeFactory lazily and reuse it

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting/Internal/RequestServicesContainerMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/RequestServicesContainerMiddleware.cs
@@ -5,26 +5,27 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Hosting.Internal
 {
     public class RequestServicesContainerMiddleware
     {
         private readonly RequestDelegate _next;
-        private readonly IServiceProvider _services;
+        private IServiceScopeFactory _scopeFactory;
 
-        public RequestServicesContainerMiddleware(RequestDelegate next, IServiceProvider services)
+        public RequestServicesContainerMiddleware(RequestDelegate next, IServiceScopeFactory scopeFactory)
         {
             if (next == null)
             {
                 throw new ArgumentNullException(nameof(next));
             }
-            if (services == null)
+            if (scopeFactory == null)
             {
-                throw new ArgumentNullException(nameof(services));
+                throw new ArgumentNullException(nameof(scopeFactory));
             }
 
-            _services = services;
+            _scopeFactory = scopeFactory;
             _next = next;
         }
 
@@ -44,7 +45,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                 return;
             }
 
-            using (var feature = new RequestServicesFeature(_services))
+            using (var feature = new RequestServicesFeature(_scopeFactory))
             {
                 try
                 {

--- a/src/Microsoft.AspNetCore.Hosting/Internal/RequestServicesFeature.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/RequestServicesFeature.cs
@@ -9,19 +9,19 @@ namespace Microsoft.AspNetCore.Hosting.Internal
 {
     public class RequestServicesFeature : IServiceProvidersFeature, IDisposable
     {
-        private IServiceProvider _appServices;
+        private IServiceScopeFactory _scopeFactory;
         private IServiceProvider _requestServices;
         private IServiceScope _scope;
         private bool _requestServicesSet;
 
-        public RequestServicesFeature(IServiceProvider applicationServices)
+        public RequestServicesFeature(IServiceScopeFactory scopeFactory)
         {
-            if (applicationServices == null)
+            if (scopeFactory == null)
             {
-                throw new ArgumentNullException(nameof(applicationServices));
+                throw new ArgumentNullException(nameof(scopeFactory));
             }
 
-            _appServices = applicationServices;
+            _scopeFactory = scopeFactory;
         }
 
         public IServiceProvider RequestServices
@@ -30,7 +30,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             {
                 if (!_requestServicesSet)
                 {
-                    _scope = _appServices.GetRequiredService<IServiceScopeFactory>().CreateScope();
+                    _scope = _scopeFactory.CreateScope();
                     _requestServices = _scope.ServiceProvider;
                     _requestServicesSet = true;
                 }


### PR DESCRIPTION
- Since we resolve the IServiceProvider from the application container, it's should be safe to reuse it across requests without the extra lookup everytime.

#680

/cc @rynowak @Tratcher 