### PR TITLE
Eagerly initialize hosting environment

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting/WebHostBuilder.cs
+++ b/src/Microsoft.AspNetCore.Hosting/WebHostBuilder.cs
@@ -162,12 +162,6 @@ namespace Microsoft.AspNetCore.Hosting
             var appEnvironment = hostingContainer.GetRequiredService<IApplicationEnvironment>();
             var startupLoader = hostingContainer.GetRequiredService<IStartupLoader>();
 
-            var contentRootPath = ResolveContentRootPath(_options.ContentRootPath, appEnvironment.ApplicationBasePath);
-            var applicationName = ResolveApplicationName() ?? appEnvironment.ApplicationName;
-
-            // Initialize the hosting environment
-            _hostingEnvironment.Initialize(applicationName, contentRootPath, _options);
-
             var host = new WebHost(hostingServices, startupLoader, _options, _config);
 
             // Only one of these should be set, but they are used in priority
@@ -183,6 +177,14 @@ namespace Microsoft.AspNetCore.Hosting
         private IServiceCollection BuildHostingServices()
         {
             _options = new WebHostOptions(_config);
+
+            var defaultPlatformServices = PlatformServices.Default;
+            var appEnvironment = defaultPlatformServices.Application;
+            var contentRootPath = ResolveContentRootPath(_options.ContentRootPath, appEnvironment.ApplicationBasePath);
+            var applicationName = ResolveApplicationName() ?? appEnvironment.ApplicationName;
+
+            // Initialize the hosting environment
+            _hostingEnvironment.Initialize(applicationName, contentRootPath, _options);
 
             var services = new ServiceCollection();
             services.AddSingleton(_hostingEnvironment);
@@ -217,8 +219,6 @@ namespace Microsoft.AspNetCore.Hosting
 
             // Ensure object pooling is available everywhere.
             services.AddSingleton<ObjectPoolProvider, DefaultObjectPoolProvider>();
-
-            var defaultPlatformServices = PlatformServices.Default;
 
             services.AddSingleton(defaultPlatformServices.Application);
             services.AddSingleton(defaultPlatformServices.Runtime);


### PR DESCRIPTION
Eagerly initialize hosting environment to prevent an issue with IHostingEnvironment.ApplicationName being null when calling ConfigureServices with a lambda expression during startup.