### PR TITLE
React to moving web.config

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Testing/Deployers/ApplicationDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.Testing/Deployers/ApplicationDeployer.cs
@@ -79,7 +79,7 @@ namespace Microsoft.AspNetCore.Server.Testing
             DeploymentParameters.ApplicationPath =
                 (DeploymentParameters.ServerType == ServerType.IISExpress ||
                  DeploymentParameters.ServerType == ServerType.IIS) ?
-                Path.Combine(DeploymentParameters.PublishedApplicationRootPath, "wwwroot") :
+                DeploymentParameters.PublishedApplicationRootPath :
                 DeploymentParameters.ApplicationPath;
 
             Logger.LogInformation($"{DotnetCommandName} publish finished with exit code : {hostProcess.ExitCode}");

--- a/src/Microsoft.AspNetCore.Server.Testing/Deployers/IISExpressDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.Testing/Deployers/IISExpressDeployer.cs
@@ -65,14 +65,8 @@ namespace Microsoft.AspNetCore.Server.Testing
                 File.WriteAllText(DeploymentParameters.ServerConfigLocation, DeploymentParameters.ServerConfigTemplateContent);
             }
 
-            var webroot = DeploymentParameters.ApplicationPath;
-            if (!webroot.EndsWith("wwwroot"))
-            {
-                webroot = Path.Combine(webroot, "wwwroot");
-            }
-
             var parameters = string.IsNullOrWhiteSpace(DeploymentParameters.ServerConfigLocation) ?
-                            string.Format("/port:{0} /path:\"{1}\" /trace:error", uri.Port, webroot) :
+                            string.Format("/port:{0} /path:\"{1}\" /trace:error", uri.Port, DeploymentParameters.ApplicationPath) :
                             string.Format("/site:{0} /config:{1} /trace:error", DeploymentParameters.SiteName, DeploymentParameters.ServerConfigLocation);
 
             var iisExpressPath = GetIISExpressPath();


### PR DESCRIPTION
We need to update the IISExpress deployer to not  after moving `web.config` to the application root so that our sample apps can be tested.

cc @muratg @Eilon @DamianEdwards @Tratcher 