### PR TITLE
Make contentRootPath error give failed path

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting/Internal/HostingEnvironmentExtensions.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/HostingEnvironmentExtensions.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             }
             if (!Directory.Exists(contentRootPath))
             {
-                throw new ArgumentException("The provided content root does not exist.", nameof(contentRootPath));
+                throw new ArgumentException($"The content root '{contentRootPath}' does not exist.", nameof(contentRootPath));
             }
 
             hostingEnvironment.ApplicationName = applicationName;


### PR DESCRIPTION
Include the content root that doesn't exist in the error message for a missing content root to make debugging easier.

Fixes #707.