### PR TITLE
Remove diagnostic messages from IStartupLoader API

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting/Internal/WebHost.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/WebHost.cs
@@ -129,23 +129,17 @@ namespace Microsoft.AspNetCore.Hosting.Internal
 
             if (StartupType == null)
             {
-                var diagnosticTypeMessages = new List<string>();
-                StartupType = _startupLoader.FindStartupType(StartupAssemblyName, diagnosticTypeMessages);
+                StartupType = _startupLoader.FindStartupType(StartupAssemblyName);
                 if (StartupType == null)
                 {
-                    throw new ArgumentException(
-                        diagnosticTypeMessages.Aggregate("Failed to find a startup type for the web application.", (a, b) => a + "\r\n" + b),
-                        StartupAssemblyName);
+                    throw new ArgumentException("Failed to find a startup type for the web application.", StartupAssemblyName);
                 }
             }
 
-            var diagnosticMessages = new List<string>();
-            Startup = _startupLoader.LoadMethods(StartupType, diagnosticMessages);
+            Startup = _startupLoader.LoadMethods(StartupType);
             if (Startup == null)
             {
-                throw new ArgumentException(
-                    diagnosticMessages.Aggregate("Failed to find a startup entry point for the web application.", (a, b) => a + "\r\n" + b),
-                    StartupAssemblyName);
+                throw new ArgumentException("Failed to find a startup entry point for the web application.", StartupAssemblyName);
             }
         }
 

--- a/src/Microsoft.AspNetCore.Hosting/Startup/IStartupLoader.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Startup/IStartupLoader.cs
@@ -2,14 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 
 namespace Microsoft.AspNetCore.Hosting.Startup
 {
     public interface IStartupLoader
     {
-        Type FindStartupType(string startupAssemblyName, IList<string> diagnosticMessages);
+        Type FindStartupType(string startupAssemblyName);
 
-        StartupMethods LoadMethods(Type startupType, IList<string> diagnosticMessages);
+        StartupMethods LoadMethods(Type startupType);
     }
 }

--- a/src/Microsoft.AspNetCore.Hosting/Startup/StartupLoader.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Startup/StartupLoader.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
@@ -21,9 +20,7 @@ namespace Microsoft.AspNetCore.Hosting.Startup
             _hostingEnv = hostingEnv;
         }
 
-        public StartupMethods LoadMethods(
-            Type startupType,
-            IList<string> diagnosticMessages)
+        public StartupMethods LoadMethods(Type startupType)
         {
             var environmentName = _hostingEnv.EnvironmentName;
             var configureMethod = FindConfigureDelegate(startupType, environmentName);
@@ -38,7 +35,7 @@ namespace Microsoft.AspNetCore.Hosting.Startup
             return new StartupMethods(configureMethod.Build(instance), servicesMethod?.Build(instance));
         }
 
-        public Type FindStartupType(string startupAssemblyName, IList<string> diagnosticMessages)
+        public Type FindStartupType(string startupAssemblyName)
         {
             var environmentName = _hostingEnv.EnvironmentName;
             if (string.IsNullOrEmpty(startupAssemblyName))

--- a/test/Microsoft.AspNetCore.Hosting.Tests/StartupManagerTests.cs
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/StartupManagerTests.cs
@@ -26,11 +26,10 @@ namespace Microsoft.AspNetCore.Hosting.Tests
             serviceCollection.AddSingleton<IFakeStartupCallback>(this);
             var services = serviceCollection.BuildServiceProvider();
 
-            var diagnosticMessages = new List<string>();
             var hostingEnv = new HostingEnvironment { EnvironmentName = "WithServices" };
             var loader = new StartupLoader(services, hostingEnv);
-            var type = loader.FindStartupType("Microsoft.AspNetCore.Hosting.Tests", diagnosticMessages);
-            var startup = loader.LoadMethods(type, diagnosticMessages);
+            var type = loader.FindStartupType("Microsoft.AspNetCore.Hosting.Tests");
+            var startup = loader.LoadMethods(type);
 
             var app = new ApplicationBuilder(services);
             app.ApplicationServices = startup.ConfigureServicesDelegate(serviceCollection);
@@ -52,11 +51,10 @@ namespace Microsoft.AspNetCore.Hosting.Tests
         {
             var services = new ServiceCollection().BuildServiceProvider();
 
-            var diagnosticMessages = new List<string>();
             var hostingEnv = new HostingEnvironment { EnvironmentName = environment };
             var loader = new StartupLoader(services, hostingEnv);
-            var type = loader.FindStartupType("Microsoft.AspNetCore.Hosting.Tests", diagnosticMessages);
-            var startup = loader.LoadMethods(type, diagnosticMessages);
+            var type = loader.FindStartupType("Microsoft.AspNetCore.Hosting.Tests");
+            var startup = loader.LoadMethods(type);
 
             var app = new ApplicationBuilder(services);
             app.ApplicationServices = startup.ConfigureServicesDelegate(new ServiceCollection());
@@ -75,12 +73,11 @@ namespace Microsoft.AspNetCore.Hosting.Tests
             serviceCollection.AddSingleton<IFakeStartupCallback>(this);
             var services = serviceCollection.BuildServiceProvider();
 
-            var diagnosticMessages = new List<string>();
             var hostingEnv = new HostingEnvironment { EnvironmentName = "Boom" };
             var loader = new StartupLoader(services, hostingEnv);
-            var type = loader.FindStartupType("Microsoft.AspNetCore.Hosting.Tests", diagnosticMessages);
+            var type = loader.FindStartupType("Microsoft.AspNetCore.Hosting.Tests");
 
-            var ex = Assert.Throws<InvalidOperationException>(() => loader.LoadMethods(type, diagnosticMessages));
+            var ex = Assert.Throws<InvalidOperationException>(() => loader.LoadMethods(type));
             Assert.Equal("A public method named 'ConfigureBoom' or 'Configure' could not be found in the 'Microsoft.AspNetCore.Hosting.Fakes.StartupBoom' type.", ex.Message);
         }
 
@@ -91,12 +88,11 @@ namespace Microsoft.AspNetCore.Hosting.Tests
             serviceCollection.AddSingleton<IFakeStartupCallback>(this);
             var services = serviceCollection.BuildServiceProvider();
 
-            var diagnosticMessages = new List<string>();
             var hostingEnv = new HostingEnvironment { EnvironmentName = "TwoConfigures" };
             var loader = new StartupLoader(services, hostingEnv);
-            var type = loader.FindStartupType("Microsoft.AspNetCore.Hosting.Tests", diagnosticMessages);
+            var type = loader.FindStartupType("Microsoft.AspNetCore.Hosting.Tests");
 
-            var ex = Assert.Throws<InvalidOperationException>(() => loader.LoadMethods(type, diagnosticMessages));
+            var ex = Assert.Throws<InvalidOperationException>(() => loader.LoadMethods(type));
             Assert.Equal("Having multiple overloads of method 'Configure' is not supported.", ex.Message);
         }
         
@@ -107,12 +103,11 @@ namespace Microsoft.AspNetCore.Hosting.Tests
             serviceCollection.AddSingleton<IFakeStartupCallback>(this);
             var services = serviceCollection.BuildServiceProvider();
 
-            var diagnosticMessages = new List<string>();
             var hostingEnv = new HostingEnvironment { EnvironmentName = "PrivateConfigure" };
             var loader = new StartupLoader(services, hostingEnv);
-            var type = loader.FindStartupType("Microsoft.AspNetCore.Hosting.Tests", diagnosticMessages);
+            var type = loader.FindStartupType("Microsoft.AspNetCore.Hosting.Tests");
 
-            var ex = Assert.Throws<InvalidOperationException>(() => loader.LoadMethods(type, diagnosticMessages));
+            var ex = Assert.Throws<InvalidOperationException>(() => loader.LoadMethods(type));
             Assert.Equal("A public method named 'ConfigurePrivateConfigure' or 'Configure' could not be found in the 'Microsoft.AspNetCore.Hosting.Fakes.StartupPrivateConfigure' type.", ex.Message);
         }
 
@@ -123,12 +118,11 @@ namespace Microsoft.AspNetCore.Hosting.Tests
             serviceCollection.AddSingleton<IFakeStartupCallback>(this);
             var services = serviceCollection.BuildServiceProvider();
 
-            var diagnosticMessages = new List<string>();
             var hostingEnv = new HostingEnvironment { EnvironmentName = "TwoConfigureServices" };
             var loader = new StartupLoader(services, hostingEnv);
-            var type = loader.FindStartupType("Microsoft.AspNetCore.Hosting.Tests", diagnosticMessages);
+            var type = loader.FindStartupType("Microsoft.AspNetCore.Hosting.Tests");
 
-            var ex = Assert.Throws<InvalidOperationException>(() => loader.LoadMethods(type, diagnosticMessages));
+            var ex = Assert.Throws<InvalidOperationException>(() => loader.LoadMethods(type));
             Assert.Equal("Having multiple overloads of method 'ConfigureServices' is not supported.", ex.Message);
         }
 
@@ -138,11 +132,10 @@ namespace Microsoft.AspNetCore.Hosting.Tests
             var serviceCollection = new ServiceCollection();
             var services = serviceCollection.BuildServiceProvider();
 
-            var diagnosticMessages = new List<string>();
             var hostingEnv = new HostingEnvironment { EnvironmentName = "WithNullConfigureServices" };
             var loader = new StartupLoader(services, hostingEnv);
-            var type = loader.FindStartupType("Microsoft.AspNetCore.Hosting.Tests", diagnosticMessages);
-            var startup = loader.LoadMethods(type, diagnosticMessages);
+            var type = loader.FindStartupType("Microsoft.AspNetCore.Hosting.Tests");
+            var startup = loader.LoadMethods(type);
 
             var app = new ApplicationBuilder(services);
             app.ApplicationServices = startup.ConfigureServicesDelegate(new ServiceCollection());
@@ -157,11 +150,10 @@ namespace Microsoft.AspNetCore.Hosting.Tests
             var serviceCollection = new ServiceCollection();
             var services = serviceCollection.BuildServiceProvider();
 
-            var diagnosticMessages = new List<string>();
             var hostingEnv = new HostingEnvironment { EnvironmentName = "WithConfigureServices" };
             var loader = new StartupLoader(services, hostingEnv);
-            var type = loader.FindStartupType("Microsoft.AspNetCore.Hosting.Tests", diagnosticMessages);
-            var startup = loader.LoadMethods(type, diagnosticMessages);
+            var type = loader.FindStartupType("Microsoft.AspNetCore.Hosting.Tests");
+            var startup = loader.LoadMethods(type);
 
             var app = new ApplicationBuilder(services);
             app.ApplicationServices = startup.ConfigureServicesDelegate(serviceCollection);
@@ -177,10 +169,9 @@ namespace Microsoft.AspNetCore.Hosting.Tests
             var serviceCollection = new ServiceCollection();
             var services = serviceCollection.BuildServiceProvider();
 
-            var diagnosticMessages = new List<string>();
             var hostingEnv = new HostingEnvironment();
             var loader = new StartupLoader(services, hostingEnv);
-            var startup = loader.LoadMethods(typeof(TestStartup), diagnosticMessages);
+            var startup = loader.LoadMethods(typeof(TestStartup));
 
             var app = new ApplicationBuilder(services);
             app.ApplicationServices = startup.ConfigureServicesDelegate(serviceCollection);
@@ -196,10 +187,9 @@ namespace Microsoft.AspNetCore.Hosting.Tests
             var serviceCollection = new ServiceCollection();
             var services = serviceCollection.BuildServiceProvider();
 
-            var diagnosticMessages = new List<string>();
             var hostingEnv = new HostingEnvironment { EnvironmentName = "No" };
             var loader = new StartupLoader(services, hostingEnv);
-            var startup = loader.LoadMethods(typeof(TestStartup), diagnosticMessages);
+            var startup = loader.LoadMethods(typeof(TestStartup));
 
             var app = new ApplicationBuilder(services);
             app.ApplicationServices = startup.ConfigureServicesDelegate(serviceCollection);

--- a/test/Microsoft.AspNetCore.Hosting.Tests/WebHostTests.cs
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/WebHostTests.cs
@@ -498,12 +498,12 @@ namespace Microsoft.AspNetCore.Hosting
 
         private class TestLoader : IStartupLoader
         {
-            public Type FindStartupType(string startupAssemblyName, IList<string> diagnosticMessages)
+            public Type FindStartupType(string startupAssemblyName)
             {
                 throw new NotImplementedException();
             }
 
-            public StartupMethods LoadMethods(Type startupType, IList<string> diagnosticMessages)
+            public StartupMethods LoadMethods(Type startupType)
             {
                 throw new NotImplementedException();
             }


### PR DESCRIPTION
- This is left over from katana where the hosting layer had more of a pipeline. It's not required of used right now.

/cc @Tratcher 