### PR TITLE
Resolve aspnet/Hosting#712

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting/WebHostBuilder.cs
+++ b/src/Microsoft.AspNetCore.Hosting/WebHostBuilder.cs
@@ -254,7 +254,7 @@ namespace Microsoft.AspNetCore.Hosting
         {
             if (_startup != null)
             {
-                return _startup.ConfigureDelegate.Target.GetType().GetTypeInfo().Assembly.GetName().Name;
+                return _startup.ConfigureDelegate.Method.DeclaringType.GetType().GetTypeInfo().Assembly.GetName().Name;
             }
             if (_startupType != null)
             {

--- a/src/Microsoft.AspNetCore.Hosting/WebHostBuilder.cs
+++ b/src/Microsoft.AspNetCore.Hosting/WebHostBuilder.cs
@@ -254,7 +254,7 @@ namespace Microsoft.AspNetCore.Hosting
         {
             if (_startup != null)
             {
-                return _startup.ConfigureDelegate.Method.DeclaringType.GetType().GetTypeInfo().Assembly.GetName().Name;
+                return _startup.ConfigureDelegate.GetMethodInfo().DeclaringType.GetType().GetTypeInfo().Assembly.GetName().Name;
             }
             if (_startupType != null)
             {

--- a/src/Microsoft.AspNetCore.Hosting/WebHostBuilder.cs
+++ b/src/Microsoft.AspNetCore.Hosting/WebHostBuilder.cs
@@ -254,7 +254,7 @@ namespace Microsoft.AspNetCore.Hosting
         {
             if (_startup != null)
             {
-                return _startup.ConfigureDelegate.GetMethodInfo().DeclaringType.GetType().GetTypeInfo().Assembly.GetName().Name;
+                return _startup.ConfigureDelegate.GetMethodInfo().DeclaringType.GetTypeInfo().Assembly.GetName().Name;
             }
             if (_startupType != null)
             {


### PR DESCRIPTION
[`WebHostBuilder.ResolveApplicationName`](https://github.com/aspnet/Hosting/blob/4e5fd908fd5eb33f55cf90f852f3328468e64e2a/src/Microsoft.AspNetCore.Hosting/WebHostBuilder.cs#L257) assumes `_startup.ConfigureDelegate.Target` is non-null. This assumption is invalid for static methods, resulting in applications crashing on startup. 

Instead, use `_startup.ConfigureDelegate.Method.DeclaringType` which is non-null for both static and instance methods.