### PR TITLE
Change default environment to "Development"

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting/Internal/HostingEnvironment.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/HostingEnvironment.cs
@@ -7,7 +7,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
 {
     public class HostingEnvironment : IHostingEnvironment
     {
-        public string EnvironmentName { get; set; } = Hosting.EnvironmentName.Production;
+        public string EnvironmentName { get; set; } = Hosting.EnvironmentName.Development;
 
         public string ApplicationName { get; set; }
 


### PR DESCRIPTION
I believe it's extremely dangerous to set "Production" as the default environment. It's just way to easy to screw this up on developer's or test machines! 

E.g. if you're using environment variables for detecting the environment, this basically means that whenever you are starting an app on a new machine, it will run against the production environment by default! This can't be good!

Instead, if we would change the default to "Development" this would mean that it always runs in a "safe" mode unless you actively configure a system to be the production system. (e.g. by setting an Environment variable). This effort should be ok for everyone because it is a one-time thing and a conscious decision to set something as the production environment.

It's also a lot easier to notice that a production system points to a development system than the opposite.

PS: I know this is temporary but just look at the current situation due to all the name-changes in this repository. If people forget to change this when they move to RC2, they will suddenly end up targeting their production environment.