### PR TITLE
Remove DNX branding from footer

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting/Startup/StartupExceptionPage.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Startup/StartupExceptionPage.cs
@@ -234,6 +234,7 @@ namespace Microsoft.AspNetCore.Hosting.Startup
         {
             var environment = PlatformServices.Default.Runtime;
             var runtimeType = HtmlEncodeAndReplaceLineBreaks(environment.RuntimeType);
+            var runtimeDisplayName = runtimeType == "CoreCLR" ? ".NET Core" : runtimeType == "CLR" ? ".NET Framework" : "Mono";
 #if NETCOREAPP1_0 || NETSTANDARD1_3
             var systemRuntimeAssembly = typeof(System.ComponentModel.DefaultValueAttribute).GetTypeInfo().Assembly;
             var assemblyVersion = new AssemblyName(systemRuntimeAssembly.FullName).Version.ToString();
@@ -242,7 +243,6 @@ namespace Microsoft.AspNetCore.Hosting.Startup
             var clrVersion = HtmlEncodeAndReplaceLineBreaks(Environment.Version.ToString());
 #endif
             var runtimeArch = HtmlEncodeAndReplaceLineBreaks(environment.RuntimeArchitecture);
-            var dnxVersion = HtmlEncodeAndReplaceLineBreaks(environment.RuntimeVersion);
             var currentAssembly = typeof(StartupExceptionPage).GetTypeInfo().Assembly;
             var currentAssemblyVersion = currentAssembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
             currentAssemblyVersion = HtmlEncodeAndReplaceLineBreaks(currentAssemblyVersion);
@@ -250,8 +250,8 @@ namespace Microsoft.AspNetCore.Hosting.Startup
             var os = HtmlEncodeAndReplaceLineBreaks(environment.OperatingSystem);
             var osVersion = HtmlEncodeAndReplaceLineBreaks(environment.OperatingSystemVersion);
 
-            return string.Format(CultureInfo.InvariantCulture, _errorFooterFormatString, runtimeType, clrVersion,
-                runtimeArch, dnxVersion, currentAssemblyVersion, os, osVersion);
+            return string.Format(CultureInfo.InvariantCulture, _errorFooterFormatString, runtimeDisplayName, runtimeArch, clrVersion,
+                currentAssemblyVersion, os, osVersion);
         }
 
         private static string HtmlEncodeAndReplaceLineBreaks(string input)

--- a/src/Microsoft.AspNetCore.Hosting/compiler/resources/GenericError_Footer.html
+++ b/src/Microsoft.AspNetCore.Hosting/compiler/resources/GenericError_Footer.html
@@ -1,3 +1,3 @@
 <footer>
-    .NET Framework {0} version {1}&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;DNX {2} version {3}&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;Microsoft.AspNetCore.Hosting version {4}&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;{5} {6}&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;<a href="http://go.microsoft.com/fwlink/?LinkId=517394">Need help?</a>
+    {0} {1} v{2}&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;Microsoft.AspNetCore.Hosting version {3}&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;{4} {5}&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;<a href="http://go.microsoft.com/fwlink/?LinkId=517394">Need help?</a>
 </footer>

--- a/src/Microsoft.AspNetCore.Server.Testing/Common/DeploymentParameters.cs
+++ b/src/Microsoft.AspNetCore.Server.Testing/Common/DeploymentParameters.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Server.Testing
         /// <param name="applicationPath">Source code location of the target location to be deployed.</param>
         /// <param name="serverType">Where to be deployed on.</param>
         /// <param name="runtimeFlavor">Flavor of the clr to run against.</param>
-        /// <param name="runtimeArchitecture">Architecture of the DNX to be used.</param>
+        /// <param name="runtimeArchitecture">Architecture of the runtime to be used.</param>
         public DeploymentParameters(
             string applicationPath,
             ServerType serverType,

--- a/src/Microsoft.AspNetCore.Server.Testing/Deployers/IISExpressDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.Testing/Deployers/IISExpressDeployer.cs
@@ -85,15 +85,6 @@ namespace Microsoft.AspNetCore.Server.Testing
 
             AddEnvironmentVariablesToProcess(startInfo);
 
-            // IIS express figures out the DNX from %PATH%.
-#if NET451
-            SetEnvironmentVariable(startInfo.EnvironmentVariables, "PATH", startInfo.EnvironmentVariables["PATH"]);
-            SetEnvironmentVariable(startInfo.EnvironmentVariables, "DNX_APPBASE", DeploymentParameters.ApplicationPath);
-#elif NETSTANDARD1_3
-            SetEnvironmentVariable(startInfo.Environment, "PATH", startInfo.Environment["PATH"]);
-            SetEnvironmentVariable(startInfo.Environment, "DNX_APPBASE", DeploymentParameters.ApplicationPath);
-#endif
-
             _hostProcess = new Process() { StartInfo = startInfo };
             _hostProcess.ErrorDataReceived += (sender, dataArgs) => { Logger.LogError(dataArgs.Data ?? string.Empty); };
             _hostProcess.OutputDataReceived += (sender, dataArgs) => { Logger.LogInformation(dataArgs.Data ?? string.Empty); };

--- a/src/Microsoft.AspNetCore.Server.Testing/xunit/SkipIfCurrentRuntimeIsCoreClrAttribute.cs
+++ b/src/Microsoft.AspNetCore.Server.Testing/xunit/SkipIfCurrentRuntimeIsCoreClrAttribute.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Testing.xunit;
 namespace Microsoft.AspNetCore.Server.Testing
 {
     /// <summary>
-    /// Skips a test if the DNX used to run the test is CoreClr.
+    /// Skips a test if the runtime used to run the test is CoreClr.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
     public class SkipIfCurrentRuntimeIsCoreClrAttribute : Attribute, ITestCondition
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Server.Testing
         {
             get
             {
-                return "Cannot run these test variations using CoreCLR DNX as helpers are not available on CoreCLR.";
+                return "Cannot run these test variations using CoreCLR runtime as helpers are not available on CoreCLR.";
             }
         }
     }


### PR DESCRIPTION
#722 I also did a quick search for other occurrences of the word dnx. Still need to investigate the use of https://github.com/aspnet/Hosting/blob/12fff1833fdcaa36b6d43bbdeb0465a11d9cf365/src/Microsoft.AspNetCore.Server.Testing/Deployers/IISExpressDeployer.cs#L88-L95.

The new error footer looks like:
![image](https://cloud.githubusercontent.com/assets/2030323/14793341/72713e72-0ad3-11e6-9c81-4a8cadacba71.png)


Review: @Tratcher 
Approval: @Eilon @DamianEdwards 