### PR TITLE
Pre-populate the environment rather than fall back to it.

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting/Internal/HostingEnvironmentExtensions.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/HostingEnvironmentExtensions.cs
@@ -63,7 +63,6 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             
             hostingEnvironment.EnvironmentName =
                 options.Environment ??
-                Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ??
                 hostingEnvironment.EnvironmentName;
         }
     }

--- a/src/Microsoft.AspNetCore.Hosting/WebHostBuilder.cs
+++ b/src/Microsoft.AspNetCore.Hosting/WebHostBuilder.cs
@@ -47,7 +47,19 @@ namespace Microsoft.AspNetCore.Hosting
             _configureLoggingDelegates = new List<Action<ILoggerFactory>>();
 
             // This may end up storing null, but that's indistinguishable from not adding it.
-            UseSetting(WebHostDefaults.EnvironmentKey, Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT"));
+            UseSetting(WebHostDefaults.EnvironmentKey, Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT")
+                // Legacy keys, never remove these.
+                ?? Environment.GetEnvironmentVariable("Hosting:Environment")
+                ?? Environment.GetEnvironmentVariable("ASPNET_ENV"));
+
+            if (Environment.GetEnvironmentVariable("Hosting:Environment") != null)
+            {
+                Console.WriteLine("The environment variable 'Hosting:Environment' is obsolete and has been replaced with 'ASPNETCORE_ENVIRONMENT'");
+            }
+            if (Environment.GetEnvironmentVariable("ASPNET_ENV") != null)
+            {
+                Console.WriteLine("The environment variable 'ASPNET_ENV' is obsolete and has been replaced with 'ASPNETCORE_ENVIRONMENT'");
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.Hosting/WebHostBuilder.cs
+++ b/src/Microsoft.AspNetCore.Hosting/WebHostBuilder.cs
@@ -45,6 +45,9 @@ namespace Microsoft.AspNetCore.Hosting
             _hostingEnvironment = new HostingEnvironment();
             _configureServicesDelegates = new List<Action<IServiceCollection>>();
             _configureLoggingDelegates = new List<Action<ILoggerFactory>>();
+
+            // This may end up storing null, but that's indistinguishable from not adding it.
+            UseSetting(WebHostDefaults.EnvironmentKey, Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT"));
         }
 
         /// <summary>


### PR DESCRIPTION
@davidfowl This is followup to https://github.com/aspnet/Hosting/pull/730/files#diff-b41ef5dfd9823ae114dd7c9ea12d1676.

When updating the downstream projects we found it's better to pre-populate the environment so we know what it is while configuring WebHostBuilder rather than afterwards.
https://github.com/aspnet/MusicStore/blob/cf35795db6449949d5a297e15a9cc649df5c9266/src/MusicStore.Standalone/Program.cs#L24-L27