### PR TITLE
Update self host deployer to target specific framework when lauching without publish

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Testing/Common/DeploymentParameters.cs
+++ b/src/Microsoft.AspNetCore.Server.Testing/Common/DeploymentParameters.cs
@@ -69,14 +69,14 @@ namespace Microsoft.AspNetCore.Server.Testing
 
         public string ApplicationPath { get; set; }
 
+        public string TargetFramework { get; set; }
+
         /// <summary>
         /// To publish the application before deployment.
         /// </summary>
         public bool PublishApplicationBeforeDeployment { get; set; }
 
         public ApplicationType ApplicationType { get; set; }
-
-        public string PublishTargetFramework { get; set; }
 
         public string PublishedApplicationRootPath { get; set; }
 

--- a/src/Microsoft.AspNetCore.Server.Testing/Deployers/ApplicationDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.Testing/Deployers/ApplicationDeployer.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.Server.Testing
 
         protected void DotnetPublish(string publishRoot = null)
         {
-            if (string.IsNullOrEmpty(DeploymentParameters.PublishTargetFramework))
+            if (string.IsNullOrEmpty(DeploymentParameters.TargetFramework))
             {
                 throw new Exception($"A target framework must be specified in the deployment parameters for applications that require publishing before deployment");
             }
@@ -49,7 +49,7 @@ namespace Microsoft.AspNetCore.Server.Testing
 
             var parameters = $"publish \"{DeploymentParameters.ApplicationPath}\""
                 + $" -o \"{DeploymentParameters.PublishedApplicationRootPath}\""
-                + $" --framework {DeploymentParameters.PublishTargetFramework}";
+                + $" --framework {DeploymentParameters.TargetFramework}";
 
             Logger.LogInformation($"Executing command {DotnetCommandName} {parameters}");
 

--- a/src/Microsoft.AspNetCore.Server.Testing/Deployers/SelfHostDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.Testing/Deployers/SelfHostDeployer.cs
@@ -74,8 +74,10 @@ namespace Microsoft.AspNetCore.Server.Testing
             }
             else
             {
+                var targetFramework = DeploymentParameters.TargetFramework ?? (DeploymentParameters.RuntimeFlavor == RuntimeFlavor.Clr ? "net451" : "netcoreapp1.0");
+
                 executableName = DotnetCommandName;
-                executableArgs = $"run -p \"{DeploymentParameters.ApplicationPath}\" {DotnetArgumentSeparator}";
+                executableArgs = $"run -p \"{DeploymentParameters.ApplicationPath}\" --framework {targetFramework} {DotnetArgumentSeparator}";
             }
 
             executableArgs += $" --server.urls {uri} "


### PR DESCRIPTION
#728 As titled.

I'm renaming the property to reflect the fact that it is no longer only used for publishing. This will require changes in Entropy, MusicStore, IISIntegration, ServerTests, Localization.
I have tested this locally, both default targets and explicit targets, to verify that apps are launched in the correct framework but I'll wait for some feedback before seeking RC2 approval.