### PR TITLE
Fixed RemoteWindowsDeployer for testing portable apps and temporary workaround for a dotnet cli issue

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Testing/Deployers/RemoteWindowsDeployer/RemotePSSessionHelper.ps1
+++ b/src/Microsoft.AspNetCore.Server.Testing/Deployers/RemoteWindowsDeployer/RemotePSSessionHelper.ps1
@@ -5,13 +5,16 @@ param(
 
 	[Parameter(Mandatory=$true)]
 	[string]$accountName,
-	
+
 	[Parameter(Mandatory=$true)]
 	[string]$accountPassword,
-	
+
 	[Parameter(Mandatory=$true)]
 	[string]$executablePath,
-	
+
+	[Parameter(Mandatory=$false)]
+	[string]$executableParameters,
+
 	[Parameter(Mandatory=$true)]
 	[string]$serverType,
 
@@ -37,7 +40,7 @@ if ($serverAction -eq "StartServer")
 {
 	Write-Host "Starting the application on machine '$serverName'"
 	$startServerScriptPath = "$PSScriptRoot\StartServer.ps1"
-	$remoteResult=Invoke-Command -Session $psSession -FilePath $startServerScriptPath -ArgumentList $executablePath, $serverType, $serverName, $applicationBaseUrl, $environmentVariables
+	$remoteResult=Invoke-Command -Session $psSession -FilePath $startServerScriptPath -ArgumentList $executablePath, $executableParameters, $serverType, $serverName, $applicationBaseUrl, $environmentVariables
 }
 else
 {
@@ -50,6 +53,6 @@ else
 Remove-PSSession $psSession
 
 # NOTE: Currenty there is no straight forward way to get the exit code from a remotely executing session, so
-# we print out the exit code in the remote script and capture it's output to get the exit code. 
+# we print out the exit code in the remote script and capture it's output to get the exit code.
 $finalExitCode=$remoteResult[$remoteResult.Length-1]
 exit $finalExitCode

--- a/src/Microsoft.AspNetCore.Server.Testing/Deployers/RemoteWindowsDeployer/RemoteWindowsDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.Testing/Deployers/RemoteWindowsDeployer/RemoteWindowsDeployer.cs
@@ -138,10 +138,12 @@ namespace Microsoft.AspNetCore.Server.Testing
             var remotePSSessionHelperScript = _scripts.Value.RemotePSSessionHelper;
 
             string executablePath = null;
+            string executableParameters = null;
             var applicationName = new DirectoryInfo(DeploymentParameters.ApplicationPath).Name;
             if (DeploymentParameters.ApplicationType == ApplicationType.Portable)
             {
-                executablePath = $"dotnet {applicationName}.dll";
+                executablePath = "dotnet.exe";
+                executableParameters = Path.Combine(_deployedFolderPathInFileShare, applicationName + ".dll");
             }
             else
             {
@@ -153,7 +155,13 @@ namespace Microsoft.AspNetCore.Server.Testing
             parameterBuilder.Append($" -serverName {_deploymentParameters.ServerName}");
             parameterBuilder.Append($" -accountName {_deploymentParameters.ServerAccountName}");
             parameterBuilder.Append($" -accountPassword {_deploymentParameters.ServerAccountPassword}");
-            parameterBuilder.Append($" -executablePath \'{executablePath}\'");
+            parameterBuilder.Append($" -executablePath \"{executablePath}\"");
+
+            if (!string.IsNullOrEmpty(executableParameters))
+            {
+                parameterBuilder.Append($" -executableParameters \"{executableParameters}\"");
+            }
+
             parameterBuilder.Append($" -serverType {_deploymentParameters.ServerType}");
             parameterBuilder.Append($" -serverAction {serverAction}");
             parameterBuilder.Append($" -applicationBaseUrl {_deploymentParameters.ApplicationBaseUriHint}");

--- a/src/Microsoft.AspNetCore.Server.Testing/Deployers/RemoteWindowsDeployer/StartServer.ps1
+++ b/src/Microsoft.AspNetCore.Server.Testing/Deployers/RemoteWindowsDeployer/StartServer.ps1
@@ -44,14 +44,14 @@ if ($serverType -eq "IIS")
 }
 elseif ($serverType -eq "Kestrel")
 {
-    $command = $command + " --server Microsoft.AspNetCore.Server.Kestrel"
-    Write-Host "Executing the command '$command'"
+	$command = $command + " --server Microsoft.AspNetCore.Server.Kestrel"
+	Write-Host "Executing the command '$command'"
 	Invoke-Expression $command
 }
 elseif ($serverType -eq "WebListener")
 {
 	$command = $command + " --server Microsoft.AspNetCore.Server.WebListener"
-    Write-Host "Executing the command '$command'"
+	Write-Host "Executing the command '$command'"
 	Invoke-Expression $command
 }
 else

--- a/src/Microsoft.AspNetCore.Server.Testing/Deployers/RemoteWindowsDeployer/StartServer.ps1
+++ b/src/Microsoft.AspNetCore.Server.Testing/Deployers/RemoteWindowsDeployer/StartServer.ps1
@@ -2,7 +2,10 @@
 param(
 	[Parameter(Mandatory=$true)]
 	[string]$executablePath,
-	
+
+	[Parameter(Mandatory=$false)]
+	[string]$executableParameters,
+
 	[Parameter(Mandatory=$true)]
 	[string]$serverType,
 
@@ -28,19 +31,28 @@ IF (-Not [string]::IsNullOrWhitespace($environmentVariables))
 	}
 }
 
+# Temporary workaround for issue https://github.com/dotnet/cli/issues/2967
+if ($executablePath -ne "dotnet.exe"){
+    $destinationDir = Split-Path $executablePath
+    Copy-Item C:\Windows\System32\forwarders\shell32.dll $destinationDir
+}
+
+$command = $executablePath + " " + $executableParameters + " --server.urls " + $applicationBaseUrl
 if ($serverType -eq "IIS")
 {
 	throw [System.NotImplementedException] "IIS deployment scenarios not yet implemented."
 }
 elseif ($serverType -eq "Kestrel")
 {
-	Write-Host "Starting the process '$executablePath'"
-	& $executablePath --server.urls $applicationBaseUrl
+    $command = $command + " --server Microsoft.AspNetCore.Server.Kestrel"
+    Write-Host "Executing the command '$command'"
+	Invoke-Expression $command
 }
 elseif ($serverType -eq "WebListener")
 {
-	Write-Host "Starting the process '$executablePath'"
-	& $executablePath --server.urls $applicationBaseUrl --server "Microsoft.AspNetCore.Server.WebListener"
+	$command = $command + " --server Microsoft.AspNetCore.Server.WebListener"
+    Write-Host "Executing the command '$command'"
+	Invoke-Expression $command
 }
 else
 {


### PR DESCRIPTION
@JunTaoLuo 

I have tested these fixes with a Nano VM hosted locally.