### PR TITLE
Fixed RemoteWindowsDeployer to enable copying  dontet runtime to target server f…

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Testing/Deployers/RemoteWindowsDeployer/RemotePSSessionHelper.ps1
+++ b/src/Microsoft.AspNetCore.Server.Testing/Deployers/RemoteWindowsDeployer/RemotePSSessionHelper.ps1
@@ -10,6 +10,9 @@ param(
 	[string]$accountPassword,
 
 	[Parameter(Mandatory=$true)]
+	[string]$dotnetRuntimePath,
+
+	[Parameter(Mandatory=$true)]
 	[string]$executablePath,
 
 	[Parameter(Mandatory=$false)]
@@ -40,7 +43,7 @@ if ($serverAction -eq "StartServer")
 {
 	Write-Host "Starting the application on machine '$serverName'"
 	$startServerScriptPath = "$PSScriptRoot\StartServer.ps1"
-	$remoteResult=Invoke-Command -Session $psSession -FilePath $startServerScriptPath -ArgumentList $executablePath, $executableParameters, $serverType, $serverName, $applicationBaseUrl, $environmentVariables
+	$remoteResult=Invoke-Command -Session $psSession -FilePath $startServerScriptPath -ArgumentList $dotnetRuntimePath, $executablePath, $executableParameters, $serverType, $serverName, $applicationBaseUrl, $environmentVariables
 }
 else
 {
@@ -54,5 +57,8 @@ Remove-PSSession $psSession
 
 # NOTE: Currenty there is no straight forward way to get the exit code from a remotely executing session, so
 # we print out the exit code in the remote script and capture it's output to get the exit code.
-$finalExitCode=$remoteResult[$remoteResult.Length-1]
-exit $finalExitCode
+if($remoteResult.Length > 0)
+{
+    $finalExitCode=$remoteResult[$remoteResult.Length-1]
+    exit $finalExitCode
+}

--- a/src/Microsoft.AspNetCore.Server.Testing/Deployers/RemoteWindowsDeployer/RemotePSSessionHelper.ps1
+++ b/src/Microsoft.AspNetCore.Server.Testing/Deployers/RemoteWindowsDeployer/RemotePSSessionHelper.ps1
@@ -9,8 +9,8 @@ param(
 	[Parameter(Mandatory=$true)]
 	[string]$accountPassword,
 
-	[Parameter(Mandatory=$true)]
-	[string]$dotnetRuntimePath,
+	[Parameter(Mandatory=$false)]
+	[string]$dotnetRuntimePath = "",
 
 	[Parameter(Mandatory=$true)]
 	[string]$executablePath,

--- a/src/Microsoft.AspNetCore.Server.Testing/Deployers/RemoteWindowsDeployer/RemoteWindowsDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.Testing/Deployers/RemoteWindowsDeployer/RemoteWindowsDeployer.cs
@@ -53,7 +53,8 @@ namespace Microsoft.AspNetCore.Server.Testing
                     " Account credentials are required to enable creating a powershell session to the remote server.");
             }
 
-            if (string.IsNullOrWhiteSpace(_deploymentParameters.DotnetRuntimePath))
+            if (_deploymentParameters.ApplicationType == ApplicationType.Portable
+                && string.IsNullOrWhiteSpace(_deploymentParameters.DotnetRuntimePath))
             {
                 throw new ArgumentException($"Invalid value '{_deploymentParameters.DotnetRuntimePath}' for {nameof(RemoteWindowsDeploymentParameters.DotnetRuntimePath)}. ");
             }
@@ -160,7 +161,12 @@ namespace Microsoft.AspNetCore.Server.Testing
             parameterBuilder.Append($" -serverName {_deploymentParameters.ServerName}");
             parameterBuilder.Append($" -accountName {_deploymentParameters.ServerAccountName}");
             parameterBuilder.Append($" -accountPassword {_deploymentParameters.ServerAccountPassword}");
-            parameterBuilder.Append($" -dotnetRuntimePath \"{_deploymentParameters.DotnetRuntimePath}\"");
+
+            if (!string.IsNullOrEmpty(_deploymentParameters.DotnetRuntimePath))
+            {
+                parameterBuilder.Append($" -dotnetRuntimePath \"{_deploymentParameters.DotnetRuntimePath}\"");
+            }
+
             parameterBuilder.Append($" -executablePath \"{executablePath}\"");
 
             if (!string.IsNullOrEmpty(executableParameters))

--- a/src/Microsoft.AspNetCore.Server.Testing/Deployers/RemoteWindowsDeployer/RemoteWindowsDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.Testing/Deployers/RemoteWindowsDeployer/RemoteWindowsDeployer.cs
@@ -53,6 +53,11 @@ namespace Microsoft.AspNetCore.Server.Testing
                     " Account credentials are required to enable creating a powershell session to the remote server.");
             }
 
+            if (string.IsNullOrWhiteSpace(_deploymentParameters.DotnetRuntimePath))
+            {
+                throw new ArgumentException($"Invalid value '{_deploymentParameters.DotnetRuntimePath}' for {nameof(RemoteWindowsDeploymentParameters.DotnetRuntimePath)}. ");
+            }
+
             if (string.IsNullOrWhiteSpace(_deploymentParameters.RemoteServerFileSharePath))
             {
                 throw new ArgumentException($"Invalid value for {nameof(RemoteWindowsDeploymentParameters.RemoteServerFileSharePath)}." +
@@ -155,6 +160,7 @@ namespace Microsoft.AspNetCore.Server.Testing
             parameterBuilder.Append($" -serverName {_deploymentParameters.ServerName}");
             parameterBuilder.Append($" -accountName {_deploymentParameters.ServerAccountName}");
             parameterBuilder.Append($" -accountPassword {_deploymentParameters.ServerAccountPassword}");
+            parameterBuilder.Append($" -dotnetRuntimePath \"{_deploymentParameters.DotnetRuntimePath}\"");
             parameterBuilder.Append($" -executablePath \"{executablePath}\"");
 
             if (!string.IsNullOrEmpty(executableParameters))

--- a/src/Microsoft.AspNetCore.Server.Testing/Deployers/RemoteWindowsDeployer/RemoteWindowsDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.Testing/Deployers/RemoteWindowsDeployer/RemoteWindowsDeployer.cs
@@ -56,7 +56,8 @@ namespace Microsoft.AspNetCore.Server.Testing
             if (_deploymentParameters.ApplicationType == ApplicationType.Portable
                 && string.IsNullOrWhiteSpace(_deploymentParameters.DotnetRuntimePath))
             {
-                throw new ArgumentException($"Invalid value '{_deploymentParameters.DotnetRuntimePath}' for {nameof(RemoteWindowsDeploymentParameters.DotnetRuntimePath)}. ");
+                throw new ArgumentException($"Invalid value '{_deploymentParameters.DotnetRuntimePath}' for {nameof(RemoteWindowsDeploymentParameters.DotnetRuntimePath)}. " +
+                    "It must be non-empty for portable apps.");
             }
 
             if (string.IsNullOrWhiteSpace(_deploymentParameters.RemoteServerFileSharePath))

--- a/src/Microsoft.AspNetCore.Server.Testing/Deployers/RemoteWindowsDeployer/RemoteWindowsDeploymentParameters.cs
+++ b/src/Microsoft.AspNetCore.Server.Testing/Deployers/RemoteWindowsDeployer/RemoteWindowsDeploymentParameters.cs
@@ -7,6 +7,7 @@ namespace Microsoft.AspNetCore.Server.Testing
     {
         public RemoteWindowsDeploymentParameters(
             string applicationPath,
+            string dotnetRuntimePath,
             ServerType serverType,
             RuntimeFlavor runtimeFlavor,
             RuntimeArchitecture runtimeArchitecture,
@@ -20,6 +21,7 @@ namespace Microsoft.AspNetCore.Server.Testing
             ServerName = remoteServerName;
             ServerAccountName = remoteServerAccountName;
             ServerAccountPassword = remoteServerAccountPassword;
+            DotnetRuntimePath = dotnetRuntimePath;
         }
 
         public string ServerName { get; }
@@ -27,6 +29,8 @@ namespace Microsoft.AspNetCore.Server.Testing
         public string ServerAccountName { get; }
 
         public string ServerAccountPassword { get; }
+
+        public string DotnetRuntimePath { get; }
 
         /// <summary>
         /// The full path to the remote server's file share

--- a/src/Microsoft.AspNetCore.Server.Testing/Deployers/RemoteWindowsDeployer/StartServer.ps1
+++ b/src/Microsoft.AspNetCore.Server.Testing/Deployers/RemoteWindowsDeployer/StartServer.ps1
@@ -1,6 +1,6 @@
 ﻿[CmdletBinding()]
 param(
-	[Parameter(Mandatory=$true)]
+	[Parameter(Mandatory=$false)]
 	[string]$dotnetRuntimePath,
 
 	[Parameter(Mandatory=$true)]
@@ -25,9 +25,6 @@ param(
 
 Write-Host "Executing the start server script on machine '$serverName'"
 
-Write-Host "Setting the dotnet runtime path to the PATH environment variable"
-[Environment]::SetEnvironmentVariable("PATH", "$dotnetRuntimePath")
-
 IF (-Not [string]::IsNullOrWhitespace($environmentVariables))
 {
 	Write-Host "Setting up environment variables"
@@ -35,6 +32,12 @@ IF (-Not [string]::IsNullOrWhitespace($environmentVariables))
 		$pair=$envVariablePair.Split("=");
 		[Environment]::SetEnvironmentVariable($pair[0], $pair[1])
 	}
+}
+
+if ($executablePath -eq "dotnet.exe")
+{
+    Write-Host "Setting the dotnet runtime path to the PATH environment variable"
+    [Environment]::SetEnvironmentVariable("PATH", "$dotnetRuntimePath")
 }
 
 Write-Host "Copying shell32.dll as a temporary workaround for issue https://github.com/dotnet/cli/issues/2967"

--- a/src/Microsoft.AspNetCore.Server.Testing/Deployers/RemoteWindowsDeployer/StartServer.ps1
+++ b/src/Microsoft.AspNetCore.Server.Testing/Deployers/RemoteWindowsDeployer/StartServer.ps1
@@ -1,6 +1,9 @@
 ﻿[CmdletBinding()]
 param(
 	[Parameter(Mandatory=$true)]
+	[string]$dotnetRuntimePath,
+
+	[Parameter(Mandatory=$true)]
 	[string]$executablePath,
 
 	[Parameter(Mandatory=$false)]
@@ -22,6 +25,9 @@ param(
 
 Write-Host "Executing the start server script on machine '$serverName'"
 
+Write-Host "Setting the dotnet runtime path to the PATH environment variable"
+[Environment]::SetEnvironmentVariable("PATH", "$dotnetRuntimePath")
+
 IF (-Not [string]::IsNullOrWhitespace($environmentVariables))
 {
 	Write-Host "Setting up environment variables"
@@ -31,8 +37,13 @@ IF (-Not [string]::IsNullOrWhitespace($environmentVariables))
 	}
 }
 
-# Temporary workaround for issue https://github.com/dotnet/cli/issues/2967
-if ($executablePath -ne "dotnet.exe"){
+Write-Host "Copying shell32.dll as a temporary workaround for issue https://github.com/dotnet/cli/issues/2967"
+if ($executablePath -eq "dotnet.exe")
+{
+    Copy-Item C:\Windows\System32\forwarders\shell32.dll $dotnetRuntimePath
+}
+else
+{
     $destinationDir = Split-Path $executablePath
     Copy-Item C:\Windows\System32\forwarders\shell32.dll $destinationDir
 }


### PR DESCRIPTION
…or enabling portable apps scenario

@JunTaoLuo The changes here are for our CI scenario where we run tests against the latest dotnet runtime. Scenario is (i will send out a PR in music store too) that tests do the setup of dotnet runtime on target server upfront and then run the tests.