### PR TITLE
Replace some of PlatformAbstractions with RuntimeInformation

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Testing/Deployers/ApplicationDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.Testing/Deployers/ApplicationDeployer.cs
@@ -4,10 +4,10 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.Extensions.Internal;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.PlatformAbstractions;
 
 namespace Microsoft.AspNetCore.Server.Testing
 {
@@ -22,7 +22,7 @@ namespace Microsoft.AspNetCore.Server.Testing
         // app being run when running dotnet run
         public static readonly string DotnetArgumentSeparator = "--";
         private static readonly bool IsWindows =
-            PlatformServices.Default.Runtime.OperatingSystem.Equals("Windows", StringComparison.OrdinalIgnoreCase);
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
         private readonly Stopwatch _stopwatch = new Stopwatch();
 
@@ -200,14 +200,19 @@ namespace Microsoft.AspNetCore.Server.Testing
 
         protected static string GetOSPrefix()
         {
-            switch (PlatformServices.Default.Runtime.OperatingSystemPlatform)
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                case Platform.Linux: return "linux";
-                case Platform.Darwin: return "darwin";
-                case Platform.Windows: return "win";
-                default:
-                    throw new InvalidOperationException("Unrecognized operating system");
+                return "win";
             }
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return "linux";
+            }
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return "darwin";
+            }
+            throw new InvalidOperationException("Unrecognized operating system");
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Server.Testing/Deployers/SelfHostDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.Testing/Deployers/SelfHostDeployer.cs
@@ -4,10 +4,10 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.AspNetCore.Server.Testing.Common;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.PlatformAbstractions;
 
 namespace Microsoft.AspNetCore.Server.Testing
 {
@@ -57,7 +57,7 @@ namespace Microsoft.AspNetCore.Server.Testing
                     DeploymentParameters.ApplicationType == ApplicationType.Portable ? ".dll" : "";
                 var executable = Path.Combine(DeploymentParameters.PublishedApplicationRootPath, new DirectoryInfo(DeploymentParameters.ApplicationPath).Name + executableExtension);
                 
-                if (DeploymentParameters.RuntimeFlavor == RuntimeFlavor.Clr && PlatformServices.Default.Runtime.OperatingSystemPlatform != Platform.Windows)
+                if (DeploymentParameters.RuntimeFlavor == RuntimeFlavor.Clr && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
                     executableName = "mono";
                     executableArgs = executable;

--- a/src/Microsoft.AspNetCore.Server.Testing/project.json
+++ b/src/Microsoft.AspNetCore.Server.Testing/project.json
@@ -11,7 +11,7 @@
       "Deployers/RemoteWindowsDeployer/RemotePSSessionHelper.ps1",
       "Deployers/RemoteWindowsDeployer/StartServer.ps1",
       "Deployers/RemoteWindowsDeployer/StopServer.ps1"
-    ],
+    ]
   },
   "description": "ASP.NET Core helpers to deploy applications to IIS Express, IIS, WebListener and Kestrel for testing.",
   "packOptions": {
@@ -25,10 +25,10 @@
     ]
   },
   "dependencies": {
+    "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-*",
     "Microsoft.AspNetCore.Testing": "1.0.0-*",
     "Microsoft.Extensions.Logging.Abstractions": "1.0.0-*",
     "Microsoft.Extensions.FileProviders.Embedded": "1.0.0-*",
-    "Microsoft.Extensions.PlatformAbstractions": "1.0.0-*",
     "Microsoft.Extensions.Process.Sources": {
       "type": "build",
       "version": "1.0.0-*"

--- a/test/Microsoft.AspNetCore.Hosting.Tests/WebHostBuilderTests.cs
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/WebHostBuilderTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting.Fakes;
@@ -398,7 +399,7 @@ namespace Microsoft.AspNetCore.Hosting
         [Fact]
         public void RelativeContentRootIsResolved()
         {
-            var contentRootNet451 = PlatformServices.Default.Runtime.OperatingSystemPlatform == Platform.Windows ?
+            var contentRootNet451 = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
                 "testroot" : "../../../../test/Microsoft.AspNetCore.Hosting.Tests/testroot";
 
             var host = new WebHostBuilder()

--- a/test/Microsoft.AspNetCore.Hosting.Tests/project.json
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/project.json
@@ -14,6 +14,7 @@
     ]
   },
   "dependencies": {
+    "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-*",
     "dotnet-test-xunit": "1.0.0-*",
     "Microsoft.NETCore.Platforms": "1.0.1-*",
     "Microsoft.AspNetCore.Hosting": "1.0.0-*",


### PR DESCRIPTION
@pranavkm 
Can't replace all references to PlatformServices.Default.Runtime yet see: https://github.com/aspnet/Hosting/blob/98bf64819e6d45b67cf4bf869e89e0ad938dbb2e/src/Microsoft.AspNetCore.Hosting/Startup/StartupExceptionPage.cs#L235