### PR TITLE
Update shutdown logic for hosted applications

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting/Internal/ApplicationLifetime.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/ApplicationLifetime.cs
@@ -39,13 +39,19 @@ namespace Microsoft.AspNetCore.Hosting.Internal
         /// </summary>
         public void StopApplication()
         {
-            try
+            // Lock on CTS to synchronize multiple calls to StopApplication. This guarantees that the first call 
+            // to StopApplication and its callbacks run to completion before subsequent calls to StopApplication, 
+            // which will no-op since the first call already requested cancellation, get a chance to execute.
+            lock (_stoppingSource)
             {
-                _stoppingSource.Cancel(throwOnFirstException: false);
-            }
-            catch (Exception)
-            {
-                // TODO: LOG
+                try
+                {
+                    _stoppingSource.Cancel(throwOnFirstException: false);
+                }
+                catch (Exception)
+                {
+                    // TODO: LOG
+                }
             }
         }
 


### PR DESCRIPTION
#812 

This new logic will block until `ApplicationStopping` and `ApplicationStopped` are run until completion on the main thread before `host.Run()` returns. Adding a `ManualResetEvent` seems arbitrary though. Any ideas? cc @davidfowl @Tratcher 

I'll also look into adding some tests in the mean time.