### PR TITLE
Rybrande/working directory

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Testing/Deployers/SelfHostDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.Testing/Deployers/SelfHostDeployer.cs
@@ -94,7 +94,8 @@ namespace Microsoft.AspNetCore.Server.Testing
                 RedirectStandardError = true,
                 RedirectStandardOutput = true,
                 // Trying a work around for https://github.com/aspnet/Hosting/issues/140.
-                RedirectStandardInput = true
+                RedirectStandardInput = true,
+                WorkingDirectory = DeploymentParameters.ApplicationPath
             };
 
             AddEnvironmentVariablesToProcess(startInfo);

--- a/src/Microsoft.AspNetCore.Server.Testing/Deployers/SelfHostDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.Testing/Deployers/SelfHostDeployer.cs
@@ -94,9 +94,13 @@ namespace Microsoft.AspNetCore.Server.Testing
                 RedirectStandardError = true,
                 RedirectStandardOutput = true,
                 // Trying a work around for https://github.com/aspnet/Hosting/issues/140.
-                RedirectStandardInput = true,
-                WorkingDirectory = DeploymentParameters.ApplicationPath
+                RedirectStandardInput = true
             };
+
+            if (DeploymentParameters.ApplicationPath != null)
+            {
+                startInfo.WorkingDirectory = DeploymentParameters.ApplicationPath;
+            }
 
             AddEnvironmentVariablesToProcess(startInfo);
 


### PR DESCRIPTION
Set the working directory of the SelfHostDeployer to the ApplicationPath so that projects that do `UseContentRoot(Directory.GetCurrentDirectory())` (Like https://github.com/aspnet/Entropy/tree/dev/samples/Localization.StarterWeb) will be able to find their content.