### PR TITLE
ApplicationDeployer: Supply the build configuration to dotnet publish

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Testing/Common/DeploymentParameters.cs
+++ b/src/Microsoft.AspNetCore.Server.Testing/Common/DeploymentParameters.cs
@@ -72,6 +72,11 @@ namespace Microsoft.AspNetCore.Server.Testing
         public string TargetFramework { get; set; }
 
         /// <summary>
+        /// Configuration under which to build (ex: Release or Debug)
+        /// </summary>
+        public string Configuration { get; set; } = "Debug";
+
+        /// <summary>
         /// To publish the application before deployment.
         /// </summary>
         public bool PublishApplicationBeforeDeployment { get; set; }

--- a/src/Microsoft.AspNetCore.Server.Testing/Deployers/ApplicationDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.Testing/Deployers/ApplicationDeployer.cs
@@ -48,8 +48,9 @@ namespace Microsoft.AspNetCore.Server.Testing
             DeploymentParameters.PublishedApplicationRootPath = publishRoot ?? Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
 
             var parameters = $"publish \"{DeploymentParameters.ApplicationPath}\""
-                + $" -o \"{DeploymentParameters.PublishedApplicationRootPath}\""
-                + $" --framework {DeploymentParameters.TargetFramework}";
+                + $" --output \"{DeploymentParameters.PublishedApplicationRootPath}\""
+                + $" --framework {DeploymentParameters.TargetFramework}"
+                + $" --configuration {DeploymentParameters.Configuration}";
 
             Logger.LogInformation($"Executing command {DotnetCommandName} {parameters}");
 


### PR DESCRIPTION
@Tratcher I working on the following issue when I came across this being a potential cause for it.
https://github.com/aspnet/Coherence-Signed/issues/348

