### PR TITLE
Make dotnet publish use LogInformation instead of LogTrace

### DIFF
--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/ApplicationDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/ApplicationDeployer.cs
@@ -69,7 +69,7 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
 
             var hostProcess = new Process() { StartInfo = startInfo };
             hostProcess.ErrorDataReceived += (sender, dataArgs) => { Logger.LogWarning(dataArgs.Data ?? string.Empty); };
-            hostProcess.OutputDataReceived += (sender, dataArgs) => { Logger.LogTrace(dataArgs.Data ?? string.Empty); };
+            hostProcess.OutputDataReceived += (sender, dataArgs) => { Logger.LogInformation(dataArgs.Data ?? string.Empty); };
             hostProcess.Start();
             hostProcess.BeginErrorReadLine();
             hostProcess.BeginOutputReadLine();


### PR DESCRIPTION
This would make it have the same LogLevel as dotnet run so we'd have better diagnostics without having to change tests.