### PR TITLE
Fix pinning of Microsoft.AspNetCore.Server.Testing

### DIFF
--- a/src/Microsoft.AspNetCore.Server.Testing/project.json
+++ b/src/Microsoft.AspNetCore.Server.Testing/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-rc2-20896",
+  "version": "0.1.0-rtm-21431",
   "buildOptions": {
     "warningsAsErrors": true,
     "keyFile": "../../tools/Key.snk",


### PR DESCRIPTION
Microsoft.AspNetCore.Server.Testing got mis-pinned in the master pinning. The released package was rolled back to 0.1.0 but ended up getting pinned at 1.0.0. This will mess with our ability to rebuild master, so we should remedy this.

**NOTE**: This is a PR to `master`, so it is changing our 1.0.0 release code. The change is not relevant to `dev` because the package has been renamed.

/cc @pranavkm @Eilon 