### PR TITLE
Updated IISDeployer

### DIFF
--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/IISDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/IISDeployer.cs
@@ -36,13 +36,15 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
 
             _application = new IISApplication(DeploymentParameters, Logger);
 
-            // Publish to IIS root\application folder.
-            DotnetPublish(publishRoot: _application.WebSiteRootFolder);
+            if (DeploymentParameters.PublishApplicationBeforeDeployment)
+            {
+                DotnetPublish(publishRoot: _application.WebSiteRootFolder);
+            }
 
             // Drop a json file instead of setting environment variable.
             SetAspEnvironmentWithJson();
 
-            var uri = TestUriHelper.BuildTestUri();
+            var uri = TestUriHelper.BuildTestUri(DeploymentParameters.ApplicationBaseUriHint);
 
             lock (_syncObject)
             {
@@ -112,7 +114,8 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
 
             public void Deploy(Uri uri)
             {
-                _serverManager.Sites.Add(WebSiteName, _deploymentParameters.ApplicationPath, uri.Port);
+                var contentRoot = _deploymentParameters.PublishApplicationBeforeDeployment ? _deploymentParameters.PublishedApplicationRootPath : _deploymentParameters.ApplicationPath;
+                _serverManager.Sites.Add(WebSiteName, contentRoot, uri.Port);
                 _serverManager.CommitChanges();
             }
 


### PR DESCRIPTION
@pranavkm @Tratcher Please review this PR and approve if you agree so that I can merge this code change on my fork to dev branch. 

Brief descripton of the issue: 

IIS Deployer has an issue regarding the applicationPath pointing wrong directory instead of publish directory and so I fixed it following the way used by IISExpress Deployer and confirmed the issue is fixed. 