### PR TITLE
Add support for executing IHostingStartup in specified assemblies

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/HostingStartupAttribute.cs
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/HostingStartupAttribute.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Reflection;
+
+namespace Microsoft.AspNetCore.Hosting
+{
+    /// <summary>
+    /// Marker attribute indicating an implementation of <see cref="IHostingStartup"/> that will be loaded and executed when building an <see cref="IWebHost"/>.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly, Inherited = false, AllowMultiple = true)]
+    public sealed class HostingStartupAttribute : Attribute
+    {
+        /// <summary>
+        /// The implementation of <see cref="IHostingStartup"/> that should be loaded when 
+        /// starting an application.
+        /// </summary>
+        public Type HostingStartupType { get; private set; }
+
+        /// <summary>
+        /// Constructs the <see cref="HostingStartupAttribute"/> with the specified type.
+        /// </summary>
+        /// <param name="hostingStartupType">A type that implements <see cref="IHostingStartup"/>.</param>
+        public HostingStartupAttribute(Type hostingStartupType)
+        {
+            if (hostingStartupType == null)
+            {
+                throw new ArgumentNullException(nameof(hostingStartupType));
+            }
+
+            if (!typeof(IHostingStartup).GetTypeInfo().IsAssignableFrom(hostingStartupType.GetTypeInfo()))
+            {
+                throw new ArgumentException($@"""{hostingStartupType}"" does not implement {typeof(IHostingStartup)}.", nameof(hostingStartupType));
+            }
+
+            HostingStartupType = hostingStartupType;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/IHostingStartup.cs
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/IHostingStartup.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace Microsoft.AspNetCore.Hosting
+{
+    /// <summary>
+    /// Represents platform specific configuration that will be applied to a <see cref="IWebHostBuilder"/> when building an <see cref="IWebHost"/>
+    /// </summary>
+    public interface IHostingStartup
+    {
+        /// <summary>
+        /// Configure the <see cref="IWebHostBuilder"/>.
+        /// </summary>
+        /// <remarks>
+        /// Configure is intended to be called before user code, allowing a user to overwrite any changes made.
+        /// </remarks>
+        /// <param name="builder"></param>
+        void Configure(IWebHostBuilder builder);
+    }
+}

--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/WebHostDefaults.cs
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/WebHostDefaults.cs
@@ -7,7 +7,8 @@ namespace Microsoft.AspNetCore.Hosting
     {
         public static readonly string ApplicationKey = "applicationName";
         public static readonly string StartupAssemblyKey = "startupAssembly";
-        
+        public static readonly string HostingStartupAssembliesKey = "hostingStartupAssemblies";
+
         public static readonly string DetailedErrorsKey = "detailedErrors";
         public static readonly string EnvironmentKey = "environment";
         public static readonly string WebRootKey = "webroot";

--- a/src/Microsoft.AspNetCore.Hosting/Internal/WebHost.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/WebHost.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.AspNetCore.Builder;
@@ -33,6 +34,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
         private readonly ApplicationLifetime _applicationLifetime;
         private readonly WebHostOptions _options;
         private readonly IConfiguration _config;
+        private readonly ExceptionDispatchInfo _startupError;
 
         private IServiceProvider _applicationServices;
         private RequestDelegate _application;
@@ -47,7 +49,8 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             IServiceCollection appServices,
             IServiceProvider hostingServiceProvider,
             WebHostOptions options,
-            IConfiguration config)
+            IConfiguration config,
+            ExceptionDispatchInfo startupError)
         {
             if (appServices == null)
             {
@@ -65,6 +68,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             }
 
             _config = config;
+            _startupError = startupError;
             _options = options;
             _applicationServiceCollection = appServices;
             _hostingServiceProvider = hostingServiceProvider;
@@ -136,6 +140,8 @@ namespace Microsoft.AspNetCore.Hosting.Internal
         {
             try
             {
+                _startupError?.Throw();
+
                 EnsureApplicationServices();
                 EnsureServer();
 

--- a/src/Microsoft.AspNetCore.Hosting/Internal/WebHostOptions.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/WebHostOptions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.AspNetCore.Hosting.Internal
@@ -26,9 +27,12 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             Environment = configuration[WebHostDefaults.EnvironmentKey];
             WebRoot = configuration[WebHostDefaults.WebRootKey];
             ContentRootPath = configuration[WebHostDefaults.ContentRootKey];
+            PlatformAssemblies = configuration[WebHostDefaults.HostingStartupAssembliesKey]?.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries) ?? new string[0];
         }
 
         public string ApplicationName { get; set; }
+
+        public IReadOnlyList<string> PlatformAssemblies { get; set; }
 
         public bool DetailedErrors { get; set; }
 

--- a/test/Microsoft.AspNetCore.Hosting.Tests/project.json
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/project.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "dotnet-test-xunit": "2.2.0-*",
     "Microsoft.AspNetCore.Hosting": "1.1.0-*",
+    "Microsoft.Extensions.Logging.Testing": "1.1.0-*",
     "Microsoft.AspNetCore.Owin": "1.1.0-*",
     "Microsoft.AspNetCore.Testing": "1.1.0-*",
     "Microsoft.Extensions.Options": "1.1.0-*",


### PR DESCRIPTION
- Assemblies that are specified in the "hostingStartupAssemblies" configuration (; delimited)
  setting can specify assemblies that use an assembly level attribute (HostingStartupAttribute)
  to specify a type that implements IHostingStartup. This allows hosting environments to
  extend the IWebHostBuilder with platform specific behavior before the application runs.
- If Startup fails and CaptureStartupErrors is true, we'll show the error in the usual
  Startup page.
- Added tests

/cc @anurse @glennc @Tratcher @muratg 
