### PR TITLE
Deterministically dispose instances created by WebHostBuilder

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/HostingAbstractionsWebHostBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/HostingAbstractionsWebHostBuilderExtensions.cs
@@ -77,8 +77,7 @@ namespace Microsoft.AspNetCore.Hosting
             {
                 // It would be nicer if this was transient but we need to pass in the
                 // factory instance directly
-                // Registering as factory so server gets disposed along with a WebHost
-                services.AddSingleton(provider => server);
+                services.AddSingleton(server);
             });
         }
 

--- a/src/Microsoft.AspNetCore.Hosting/Internal/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/ServiceCollectionExtensions.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.AspNetCore.Hosting.Internal
+{
+    internal static class ServiceCollectionExtensions
+    {
+        public static IServiceCollection Clone(this IServiceCollection serviceCollection)
+        {
+            IServiceCollection clone = new ServiceCollection();
+            foreach (var service in serviceCollection)
+            {
+                clone.Add(service);
+            }
+            return clone;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Hosting/Internal/WebHost.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/WebHost.cs
@@ -245,23 +245,9 @@ namespace Microsoft.AspNetCore.Hosting.Internal
         {
             _logger?.Shutdown();
             _applicationLifetime.StopApplication();
+            (_hostingServiceProvider as IDisposable)?.Dispose();
             (_applicationServices as IDisposable)?.Dispose();
             _applicationLifetime.NotifyStopped();
-        }
-
-        private class Disposable : IDisposable
-        {
-            private Action _dispose;
-
-            public Disposable(Action dispose)
-            {
-                _dispose = dispose;
-            }
-
-            public void Dispose()
-            {
-                Interlocked.Exchange(ref _dispose, () => { }).Invoke();
-            }
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Hosting/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Properties/Resources.Designer.cs
@@ -58,6 +58,22 @@ namespace Microsoft.AspNetCore.Hosting
             return GetString("ErrorPageHtml_UnknownLocation");
         }
 
+        /// <summary>
+        /// WebHostBuilder allows creation only of a single instance of WebHost
+        /// </summary>
+        internal static string WebHostBuilder_SingleInstance
+        {
+            get { return GetString("WebHostBuilder_SingleInstance"); }
+        }
+
+        /// <summary>
+        /// WebHostBuilder allows creation only of a single instance of WebHost
+        /// </summary>
+        internal static string FormatWebHostBuilder_SingleInstance()
+        {
+            return GetString("WebHostBuilder_SingleInstance");
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.AspNetCore.Hosting/Resources.resx
+++ b/src/Microsoft.AspNetCore.Hosting/Resources.resx
@@ -126,4 +126,7 @@
   <data name="ErrorPageHtml_UnknownLocation" xml:space="preserve">
     <value>Unknown location</value>
   </data>
+  <data name="WebHostBuilder_SingleInstance" xml:space="preserve">
+    <value>WebHostBuilder allows creation only of a single instance of WebHost</value>
+  </data>
 </root>

--- a/src/Microsoft.AspNetCore.Hosting/WebHostBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Hosting/WebHostBuilderExtensions.cs
@@ -35,7 +35,7 @@ namespace Microsoft.AspNetCore.Hosting
 
 
         /// <summary>
-        /// Specify the startup type to be used by the web host. 
+        /// Specify the startup type to be used by the web host.
         /// </summary>
         /// <param name="hostBuilder">The <see cref="IWebHostBuilder"/> to configure.</param>
         /// <param name="startupType">The <see cref="Type"/> to be used.</param>

--- a/test/Microsoft.AspNetCore.Hosting.Tests/Fakes/StartupWithILoggerFactory.cs
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/Fakes/StartupWithILoggerFactory.cs
@@ -1,0 +1,31 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Hosting.Fakes
+{
+    public class StartupWithILoggerFactory
+    {
+        public ILoggerFactory ConstructorLoggerFactory { get; set; }
+
+        public ILoggerFactory ConfigureLoggerFactory { get; set; }
+
+        public StartupWithILoggerFactory(ILoggerFactory constructorLoggerFactory)
+        {
+             ConstructorLoggerFactory = constructorLoggerFactory;
+        }
+
+        public void ConfigureServices(IServiceCollection collection)
+        {
+            collection.AddSingleton(this);
+        }
+
+        public void Configure(IApplicationBuilder builder, ILoggerFactory loggerFactory)
+        {
+            ConfigureLoggerFactory = loggerFactory;
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Hosting.Tests/WebHostBuilderTests.cs
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/WebHostBuilderTests.cs
@@ -15,6 +15,7 @@ using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.ObjectPool;
 using Microsoft.Extensions.PlatformAbstractions;
 using Xunit;
@@ -494,6 +495,84 @@ namespace Microsoft.AspNetCore.Hosting
             Assert.Equal("Microsoft.AspNetCore.Hosting.Tests", hostingEnv.ApplicationName);
         }
 
+        [Fact]
+        public void Build_DoesNotAllowBuildingMuiltipleTimes()
+        {
+            var builder = CreateWebHostBuilder();
+            var server = new TestServer();
+            builder.UseServer(server)
+                .UseStartup<StartupNoServices>()
+                .Build();
+
+            var ex = Assert.Throws<InvalidOperationException>(() => builder.Build());
+
+            Assert.Equal("WebHostBuilder allows creation only of a single instance of WebHost", ex.Message);
+        }
+
+        [Fact]
+        public void Build_PassesSameAutoCreatedILoggerFactoryEverywhere()
+        {
+            var builder = CreateWebHostBuilder();
+            var server = new TestServer();
+            var host = builder.UseServer(server)
+                .UseStartup<StartupWithILoggerFactory>()
+                .Build();
+
+            var startup = host.Services.GetService<StartupWithILoggerFactory>();
+
+            Assert.Equal(startup.ConfigureLoggerFactory, startup.ConstructorLoggerFactory);
+        }
+
+        [Fact]
+        public void Build_PassesSamePassedILoggerFactoryEverywhere()
+        {
+            var factory = new LoggerFactory();
+            var builder = CreateWebHostBuilder();
+            var server = new TestServer();
+            var host = builder.UseServer(server)
+                .UseLoggerFactory(factory)
+                .UseStartup<StartupWithILoggerFactory>()
+                .Build();
+
+            var startup = host.Services.GetService<StartupWithILoggerFactory>();
+
+            Assert.Equal(factory, startup.ConfigureLoggerFactory);
+            Assert.Equal(factory, startup.ConstructorLoggerFactory);
+        }
+
+        [Fact]
+        public void Build_PassedILoggerFactoryNotDisposed()
+        {
+            var factory = new DisposableLoggerFactory();
+            var builder = CreateWebHostBuilder();
+            var server = new TestServer();
+
+            var host = builder.UseServer(server)
+                .UseLoggerFactory(factory)
+                .UseStartup<StartupWithILoggerFactory>()
+                .Build();
+
+            host.Dispose();
+
+            Assert.Equal(false, factory.Disposed);
+        }
+
+        [Fact]
+        public void Build_DoesNotOverrideILoggerFactorySetByConfigureServices()
+        {
+            var factory = new DisposableLoggerFactory();
+            var builder = CreateWebHostBuilder();
+            var server = new TestServer();
+
+            var host = builder.UseServer(server)
+                .ConfigureServices(collection => collection.AddSingleton<ILoggerFactory>(factory))
+                .UseStartup<StartupWithILoggerFactory>()
+                .Build();
+
+            var factoryFromHost = host.Services.GetService<ILoggerFactory>();
+            Assert.Equal(factory, factoryFromHost);
+        }
+
         private static void StaticConfigureMethod(IApplicationBuilder app)
         { }
 
@@ -557,6 +636,25 @@ namespace Microsoft.AspNetCore.Hosting
         private class ServiceB
         {
 
+        }
+
+        private class DisposableLoggerFactory : ILoggerFactory
+        {
+            public void Dispose()
+            {
+                Disposed = true;
+            }
+
+            public bool Disposed { get; set; }
+
+            public ILogger CreateLogger(string categoryName)
+            {
+                return NullLogger.Instance;
+            }
+
+            public void AddProvider(ILoggerProvider provider)
+            {
+            }
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Hosting.Tests/WebHostTests.cs
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/WebHostTests.cs
@@ -135,7 +135,7 @@ namespace Microsoft.AspNetCore.Hosting
 
             host.Dispose();
 
-            Assert.Equal(1, _startInstances[0].DisposeCalls);
+            Assert.Equal(0, _startInstances[0].DisposeCalls);
         }
 
         [Fact]
@@ -163,7 +163,7 @@ namespace Microsoft.AspNetCore.Hosting
             // Wait on the host to shutdown
             lifetime.ApplicationStopped.WaitHandle.WaitOne();
 
-            Assert.Equal(1, _startInstances[0].DisposeCalls);
+            Assert.Equal(0, _startInstances[0].DisposeCalls);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes: https://github.com/aspnet/Hosting/issues/867
IServiceProvider would stop disposing instances: https://github.com/aspnet/DependencyInjection/pull/462

@davidfowl @Tratcher 
