### PR TITLE
[WIP]: Spike IApplicationLifetimeEvents

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/IApplicationLifetimeEvents.cs
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/IApplicationLifetimeEvents.cs
@@ -1,5 +1,11 @@
-﻿namespace Microsoft.AspNetCore.Hosting
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Hosting
 {
+    /// <summary>
+    /// Allows consumers to perform cleanup during a graceful shutdown.
+    /// </summary>
     public interface IApplicationLifetimeEvents
     {
         /// <summary>

--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/IApplicationLifetimeEvents.cs
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/IApplicationLifetimeEvents.cs
@@ -1,0 +1,25 @@
+﻿namespace Microsoft.AspNetCore.Hosting
+{
+    public interface IApplicationLifetimeEvents
+    {
+        /// <summary>
+        /// Triggered when the application host has fully started and is about to wait
+        /// for a graceful shutdown.
+        /// </summary>
+        void OnApplicationStarted();
+
+        /// <summary>
+        /// Triggered when the application host is performing a graceful shutdown.
+        /// Requests may still be in flight. Shutdown will block until this event completes.
+        /// </summary>
+        void OnApplicationStopping();
+
+        /// <summary>
+        /// Triggered when the application host is performing a graceful shutdown.
+        /// All requests should be complete at this point. Shutdown will block
+        /// until this event completes.
+        /// </summary>
+        void OnApplicationStopped();
+
+    }
+}

--- a/src/Microsoft.AspNetCore.Hosting/Internal/ApplicationLifetime.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/ApplicationLifetime.cs
@@ -20,11 +20,6 @@ namespace Microsoft.AspNetCore.Hosting.Internal
         private readonly IEnumerable<IApplicationLifetimeEvents> _handlers = Enumerable.Empty<IApplicationLifetimeEvents>();
         private readonly ILogger<ApplicationLifetime> _logger;
 
-        public ApplicationLifetime(ILogger<ApplicationLifetime> logger)
-        {
-            _logger = logger;
-        }
-
         public ApplicationLifetime(ILogger<ApplicationLifetime> logger, IEnumerable<IApplicationLifetimeEvents> handlers)
         {
             _logger = logger;
@@ -69,12 +64,12 @@ namespace Microsoft.AspNetCore.Hosting.Internal
 
                 try
                 {
+                    _stoppingSource.Cancel(throwOnFirstException: false);
+
                     foreach (var handler in _handlers)
                     {
                         handler.OnApplicationStopping();
                     }
-
-                    _stoppingSource.Cancel(throwOnFirstException: false);
                 }
                 catch (Exception ex)
                 {
@@ -92,12 +87,12 @@ namespace Microsoft.AspNetCore.Hosting.Internal
         {
             try
             {
+                _startedSource.Cancel(throwOnFirstException: false);
+
                 foreach (var handler in _handlers)
                 {
                     handler.OnApplicationStarted();
                 }
-
-                _startedSource.Cancel(throwOnFirstException: false);
             }
             catch (Exception ex)
             {
@@ -114,12 +109,12 @@ namespace Microsoft.AspNetCore.Hosting.Internal
         {
             try
             {
+                _stoppedSource.Cancel(throwOnFirstException: false);
+
                 foreach (var handler in _handlers)
                 {
                     handler.OnApplicationStopped();
                 }
-
-                _stoppedSource.Cancel(throwOnFirstException: false);
             }
             catch (Exception ex)
             {

--- a/src/Microsoft.AspNetCore.Hosting/Internal/ApplicationLifetime.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/ApplicationLifetime.cs
@@ -2,7 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Hosting.Internal
 {
@@ -14,6 +17,19 @@ namespace Microsoft.AspNetCore.Hosting.Internal
         private readonly CancellationTokenSource _startedSource = new CancellationTokenSource();
         private readonly CancellationTokenSource _stoppingSource = new CancellationTokenSource();
         private readonly CancellationTokenSource _stoppedSource = new CancellationTokenSource();
+        private readonly IEnumerable<IApplicationLifetimeEvents> _handlers = Enumerable.Empty<IApplicationLifetimeEvents>();
+        private readonly ILogger<ApplicationLifetime> _logger;
+
+        public ApplicationLifetime(ILogger<ApplicationLifetime> logger)
+        {
+            _logger = logger;
+        }
+
+        public ApplicationLifetime(ILogger<ApplicationLifetime> logger, IEnumerable<IApplicationLifetimeEvents> handlers)
+        {
+            _logger = logger;
+            _handlers = handlers;
+        }
 
         /// <summary>
         /// Triggered when the application host has fully started and is about to wait
@@ -44,13 +60,27 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             // which will no-op since the first call already requested cancellation, get a chance to execute.
             lock (_stoppingSource)
             {
+                // Noop if this is already cancelled, user code can call this so 
+                // we should guard against multiple calls here
+                if (_stoppingSource.IsCancellationRequested)
+                {
+                    return;
+                }
+
                 try
                 {
+                    foreach (var handler in _handlers)
+                    {
+                        handler.OnApplicationStopping();
+                    }
+
                     _stoppingSource.Cancel(throwOnFirstException: false);
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
-                    // TODO: LOG
+                    _logger.ApplicationError(LoggerEventIds.ApplicationStoppingException,
+                                             "An error occurred stopping the application",
+                                             ex);
                 }
             }
         }
@@ -62,11 +92,18 @@ namespace Microsoft.AspNetCore.Hosting.Internal
         {
             try
             {
+                foreach (var handler in _handlers)
+                {
+                    handler.OnApplicationStarted();
+                }
+
                 _startedSource.Cancel(throwOnFirstException: false);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                // TODO: LOG
+                _logger.ApplicationError(LoggerEventIds.ApplicationStartupException,
+                                         "An error occurred starting the application",
+                                         ex);
             }
         }
 
@@ -77,11 +114,18 @@ namespace Microsoft.AspNetCore.Hosting.Internal
         {
             try
             {
+                foreach (var handler in _handlers)
+                {
+                    handler.OnApplicationStopped();
+                }
+
                 _stoppedSource.Cancel(throwOnFirstException: false);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                // TODO: LOG
+                _logger.ApplicationError(LoggerEventIds.ApplicationStoppedException,
+                                         "An error occurred stopping the application",
+                                         ex);
             }
         }
     }

--- a/src/Microsoft.AspNetCore.Hosting/Internal/HostingLoggerExtensions.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/HostingLoggerExtensions.cs
@@ -52,20 +52,9 @@ namespace Microsoft.AspNetCore.Hosting.Internal
 
         public static void ApplicationError(this ILogger logger, Exception exception)
         {
-            var message = "Application startup exception";
-
-            var reflectionTypeLoadException = exception as ReflectionTypeLoadException;
-            if (reflectionTypeLoadException != null)
-            {
-                foreach (var ex in reflectionTypeLoadException.LoaderExceptions)
-                {
-                    message = message + Environment.NewLine + ex.Message;
-                }
-            }
-
-            logger.LogCritical(
+            logger.ApplicationError(
                 eventId: LoggerEventIds.ApplicationStartupException,
-                message: message,
+                message: "Application startup exception",
                 exception: exception);
         }
 

--- a/src/Microsoft.AspNetCore.Hosting/Internal/HostingLoggerExtensions.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/HostingLoggerExtensions.cs
@@ -69,6 +69,23 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                 exception: exception);
         }
 
+        public static void ApplicationError(this ILogger logger, EventId eventId, string message, Exception exception)
+        {
+            var reflectionTypeLoadException = exception as ReflectionTypeLoadException;
+            if (reflectionTypeLoadException != null)
+            {
+                foreach (var ex in reflectionTypeLoadException.LoaderExceptions)
+                {
+                    message = message + Environment.NewLine + ex.Message;
+                }
+            }
+
+            logger.LogCritical(
+                eventId: eventId,
+                message: message,
+                exception: exception);
+        }
+
         public static void Starting(this ILogger logger)
         {
             if (logger.IsEnabled(LogLevel.Debug))

--- a/src/Microsoft.AspNetCore.Hosting/Internal/LoggerEventIds.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/LoggerEventIds.cs
@@ -11,5 +11,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
         public const int Started = 4;
         public const int Shutdown = 5;
         public const int ApplicationStartupException = 6;
+        public const int ApplicationStoppingException = 7;
+        public const int ApplicationStoppedException = 8;
     }
 }

--- a/src/Microsoft.AspNetCore.Hosting/Internal/WebHost.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/WebHost.cs
@@ -27,9 +27,9 @@ namespace Microsoft.AspNetCore.Hosting.Internal
 
         private readonly IServiceCollection _applicationServiceCollection;
         private IStartup _startup;
+        private ApplicationLifetime _applicationLifetime;
 
         private readonly IServiceProvider _hostingServiceProvider;
-        private ApplicationLifetime _applicationLifetime;
         private readonly WebHostOptions _options;
         private readonly IConfiguration _config;
 

--- a/src/Microsoft.AspNetCore.Hosting/Internal/WebHost.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/WebHost.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
-using System.Threading;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting.Builder;
 using Microsoft.AspNetCore.Hosting.Server;
@@ -30,7 +29,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
         private IStartup _startup;
 
         private readonly IServiceProvider _hostingServiceProvider;
-        private readonly ApplicationLifetime _applicationLifetime;
+        private ApplicationLifetime _applicationLifetime;
         private readonly WebHostOptions _options;
         private readonly IConfiguration _config;
 
@@ -68,8 +67,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             _options = options;
             _applicationServiceCollection = appServices;
             _hostingServiceProvider = hostingServiceProvider;
-            _applicationLifetime = new ApplicationLifetime();
-            _applicationServiceCollection.AddSingleton<IApplicationLifetime>(_applicationLifetime);
+            _applicationServiceCollection.AddSingleton<IApplicationLifetime, ApplicationLifetime>();
         }
 
         public IServiceProvider Services
@@ -101,6 +99,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
         {
             Initialize();
 
+            _applicationLifetime = _applicationServices.GetRequiredService<IApplicationLifetime>() as ApplicationLifetime;
             _logger = _applicationServices.GetRequiredService<ILogger<WebHost>>();
             var diagnosticSource = _applicationServices.GetRequiredService<DiagnosticSource>();
             var httpContextFactory = _applicationServices.GetRequiredService<IHttpContextFactory>();
@@ -109,7 +108,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
 
             Server.Start(new HostingApplication(_application, _logger, diagnosticSource, httpContextFactory));
 
-            _applicationLifetime.NotifyStarted();
+            _applicationLifetime?.NotifyStarted();
             _logger.Started();
         }
 
@@ -244,10 +243,10 @@ namespace Microsoft.AspNetCore.Hosting.Internal
         public void Dispose()
         {
             _logger?.Shutdown();
-            _applicationLifetime.StopApplication();
+            _applicationLifetime?.StopApplication();
             (_hostingServiceProvider as IDisposable)?.Dispose();
             (_applicationServices as IDisposable)?.Dispose();
-            _applicationLifetime.NotifyStopped();
+            _applicationLifetime?.NotifyStopped();
         }
     }
 }


### PR DESCRIPTION
- Introduce a new DI friendly API for handling lifetime events. IApplicationLifetime isn't replaceable so we introduce a new DI friendly API that can be implemented to handle
lifetime events of an ASP.NET application. It should also make it possible to write up extension
on IWebHostBuilder to wire up to external systems that need to register the state of the application (like systemd).
- Need to add tests

Here's what the demo application looks like:

```C#
public class Startup
{
    // This method gets called by the runtime. Use this method to add services to the container.
    // For more information on how to configure your application, visit http://go.microsoft.com/fwlink/?LinkID=398940
    public void ConfigureServices(IServiceCollection services)
    {
        services.AddSingleton<IApplicationLifetimeEvents, Events>();
    }

    // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
    public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
    {
        loggerFactory.AddConsole();

        if (env.IsDevelopment())
        {
            app.UseDeveloperExceptionPage();
        }

        app.Run(async (context) =>
        {
            await context.Response.WriteAsync("Hello World!");
        });
    }
}

public class Events : IApplicationLifetimeEvents
{
    private readonly IApplicationLifetime _lifetime;

    public Events(IApplicationLifetime lifetime)
    {
        _lifetime = lifetime;
    }

    public void OnApplicationStarted()
    {
        Console.WriteLine("Application started");
    }

    public void OnApplicationStopped()
    {
        // Disposable things have been disposed by the time we get here.
        Console.WriteLine("Application stopped");
    }

    public void OnApplicationStopping()
    {
        Console.WriteLine("Application stopping");
    }
}
```

#871 

/cc @Tratcher @pakrym @muratg 