### PR TITLE
[Prototype] Event counters

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting/Internal/WebHost.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/WebHost.cs
@@ -70,6 +70,10 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             _hostingServiceProvider = hostingServiceProvider;
             _applicationServiceCollection.AddSingleton<IApplicationLifetime, ApplicationLifetime>();
             _applicationServiceCollection.AddSingleton<HostedServiceExecutor>();
+
+            // This is here for the sole reason to load it as fast as possible in the application domain and be found
+            // by the EventSource.GetSources() api.
+            var eventSource = HostingEventSource.Log;
         }
 
         public IServiceProvider Services

--- a/test/Microsoft.AspNetCore.Hosting.Tests/Internal/HostingEventSourceTests.cs
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/Internal/HostingEventSourceTests.cs
@@ -151,7 +151,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             eventListener.EnableEvents(hostingEventSource, EventLevel.Informational);
 
             // Act
-            hostingEventSource.RequestStop();
+            hostingEventSource.RequestStop(startTimestamp: 0, endTimestamp: 0);
 
             // Assert
             var eventData = eventListener.EventData;


### PR DESCRIPTION
@davidfowl @rynowak 

`EventCounters` is an event that is logged for the interval time (in seconds) that we specify. Here the interval has been set as 1 sec. There is a timer which keeps writing out an EventCounters event for every event counter that is created and so you see the mean, standard deviation, count to be NaN initially (when the client hasn't made requests yet). Regarding using this data, just as any other event source event, these  `EventCounters` events can be processed via the TraceEvent nuget package and a UI could be built on top of it (if you are trying to compare the experience of perfmon).

![image](https://cloud.githubusercontent.com/assets/6559784/20441966/863effc0-ad7b-11e6-8375-7e3d52525413.png)

![image](https://cloud.githubusercontent.com/assets/6559784/20442140/58e0e38a-ad7c-11e6-8a8a-7fdd5407ade6.png)
