### PR TITLE
Fix IIS Express deployer for Win7

### DIFF
--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/IISExpressDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/IISExpressDeployer.cs
@@ -99,7 +99,7 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
                         ancmPath = Path.Combine(contentRoot, ancmFile);
                     }
 
-                    if (!File.Exists(ancmPath))
+                    if (!File.Exists(Environment.ExpandEnvironmentVariables(ancmPath)))
                     {
                         throw new FileNotFoundException("AspNetCoreModule could not be found.", ancmPath);
                     }

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/project.json
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/project.json
@@ -37,6 +37,7 @@
       "type": "build",
       "version": "1.2.0-*"
     },
+    "Microsoft.NETCore.Windows.ApiSets": "1.0.1",
     "NETStandard.Library": "1.6.1-*"
   },
   "frameworks": {


### PR DESCRIPTION
@pranavkm @JunTaoLuo 2 issues:
1) File.Exists doesn't support environment variables like %ProgramFiles%. We only do this on Win7 because the nightly build doesn't work there.
2) The OS version check uses RuntimeEnvironment, which p-invokes into API sets that aren't available on Win7 by default. See https://github.com/dotnet/corefx/issues/8091#issuecomment-225641743. Workaround: add a reference to the ApiSets nupkg and add a runtimes section to the test project (separate PR).