### PR TITLE
Skip specifying the project argument when running dotnet commands

### DIFF
--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/ApplicationDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/ApplicationDeployer.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
 
             DeploymentParameters.PublishedApplicationRootPath = publishRoot ?? Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
 
-            var parameters = $"publish \"{DeploymentParameters.ApplicationPath}\""
+            var parameters = $"publish "
                 + $" --output \"{DeploymentParameters.PublishedApplicationRootPath}\""
                 + $" --framework {DeploymentParameters.TargetFramework}"
                 + $" --configuration {DeploymentParameters.Configuration}";
@@ -59,7 +59,8 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
                 UseShellExecute = false,
                 CreateNoWindow = true,
                 RedirectStandardError = true,
-                RedirectStandardOutput = true
+                RedirectStandardOutput = true,
+                WorkingDirectory = DeploymentParameters.ApplicationPath,
             };
 
             AddEnvironmentVariablesToProcess(startInfo, DeploymentParameters.PublishEnvironmentVariables);

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/SelfHostDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/SelfHostDeployer.cs
@@ -80,7 +80,7 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
                 var targetFramework = DeploymentParameters.TargetFramework ?? (DeploymentParameters.RuntimeFlavor == RuntimeFlavor.Clr ? "net451" : "netcoreapp1.1");
 
                 executableName = DotnetCommandName;
-                executableArgs = $"run -p \"{DeploymentParameters.ApplicationPath}\" --framework {targetFramework} {DotnetArgumentSeparator}";
+                executableArgs = $"run --framework {targetFramework} {DotnetArgumentSeparator}";
             }
 
             executableArgs += $" --server.urls {uri} "


### PR DESCRIPTION
Workaround for https://github.com/dotnet/cli/issues/5168 and https://github.com/dotnet/cli/issues/5211