### PR TITLE
Add setting to extend dotnet-publish arguments in ApplicationDeployer

### DIFF
--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Common/DeploymentParameters.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Common/DeploymentParameters.cs
@@ -77,6 +77,12 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
         public string Configuration { get; set; } = "Debug";
 
         /// <summary>
+        /// Space separated command line arguments to be passed to dotnet-publish
+        /// </summary>
+        /// <returns></returns>
+        public string AdditionalPublishParameters { get; set; }
+
+        /// <summary>
         /// To publish the application before deployment.
         /// </summary>
         public bool PublishApplicationBeforeDeployment { get; set; }

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Common/DeploymentParameters.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Common/DeploymentParameters.cs
@@ -79,7 +79,6 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
         /// <summary>
         /// Space separated command line arguments to be passed to dotnet-publish
         /// </summary>
-        /// <returns></returns>
         public string AdditionalPublishParameters { get; set; }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/ApplicationDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/ApplicationDeployer.cs
@@ -48,7 +48,8 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
             var parameters = $"publish "
                 + $" --output \"{DeploymentParameters.PublishedApplicationRootPath}\""
                 + $" --framework {DeploymentParameters.TargetFramework}"
-                + $" --configuration {DeploymentParameters.Configuration}";
+                + $" --configuration {DeploymentParameters.Configuration}"
+                + $" {DeploymentParameters.AdditionalPublishParameters}";
 
             Logger.LogInformation($"Executing command {DotnetCommandName} {parameters}");
 
@@ -103,6 +104,8 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
         {
             if (hostProcess != null && !hostProcess.HasExited)
             {
+                Logger.LogInformation("Attempting to cancel process {0}", hostProcess.Id);
+
                 // Shutdown the host process.
                 hostProcess.KillTree();
                 if (!hostProcess.HasExited)


### PR DESCRIPTION
Required to port MusicStore to vs2017.