### PR TITLE
OnStarting throws when Response.HasStarted

### DIFF
--- a/src/Microsoft.AspNetCore.TestHost/ResponseFeature.cs
+++ b/src/Microsoft.AspNetCore.TestHost/ResponseFeature.cs
@@ -36,6 +36,11 @@ namespace Microsoft.AspNetCore.TestHost
 
         public void OnStarting(Func<object, Task> callback, object state)
         {
+            if (HasStarted)
+            {
+                throw new InvalidOperationException();
+            }
+
             var prior = _responseStartingAsync;
             _responseStartingAsync = async () =>
             {

--- a/test/Microsoft.AspNetCore.TestHost.Tests/ResponseFeatureTests.cs
+++ b/test/Microsoft.AspNetCore.TestHost.Tests/ResponseFeatureTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -21,6 +22,23 @@ namespace Microsoft.AspNetCore.TestHost
             await responseInformation.FireOnSendingHeadersAsync();
 
             Assert.True(responseInformation.HasStarted);
+        }
+
+        [Fact]
+        public void OnStarting_ThrowsWhenHasStarted()
+        {
+            // Arrange
+            var responseInformation = new ResponseFeature();
+            responseInformation.HasStarted = true;
+
+            // Act & Assert
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                responseInformation.OnStarting((status) =>
+                {
+                    return Task.FromResult(string.Empty);
+                }, state: "string");
+            });
         }
     }
 }


### PR DESCRIPTION
This is the same behavior our servers exhibit (see [here](https://github.com/aspnet/KestrelHttpServer/pull/1038/files)).