### PR TITLE
Check hostingLog enabled

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting/Internal/HostingApplication.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/HostingApplication.cs
@@ -45,7 +45,9 @@ namespace Microsoft.AspNetCore.Hosting.Internal
 
             var hostingLog = HostingEventSource.Log;
             if (hostingLog.IsEnabled())
+            {
                 hostingLog.RequestStart(httpContext.Request.Method, httpContext.Request.Path);
+            }
 
             return new Context
             {
@@ -84,11 +86,15 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                 }
 
                 if (hostingLog.IsEnabled())
+                {
                     hostingLog.UnhandledException();
+                }
             }
 
             if (hostingLog.IsEnabled())
+            {
                 hostingLog.RequestStop();
+            }
 
             context.Scope?.Dispose();
 

--- a/src/Microsoft.AspNetCore.Hosting/Internal/HostingApplication.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/HostingApplication.cs
@@ -43,7 +43,9 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                 _diagnosticSource.Write("Microsoft.AspNetCore.Hosting.BeginRequest", new { httpContext = httpContext, timestamp = startTimestamp });
             }
 
-            HostingEventSource.Log.RequestStart(httpContext.Request.Method, httpContext.Request.Path);
+            var hostingLog = HostingEventSource.Log;
+            if (hostingLog.IsEnabled())
+                hostingLog.RequestStart(httpContext.Request.Method, httpContext.Request.Path);
 
             return new Context
             {
@@ -56,7 +58,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
         public void DisposeContext(Context context, Exception exception)
         {
             var httpContext = context.HttpContext;
-
+            var hostingLog = HostingEventSource.Log;
             if (exception == null)
             {
                 var diagnoticsEnabled = _diagnosticSource.IsEnabled("Microsoft.AspNetCore.Hosting.EndRequest");
@@ -81,10 +83,12 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                     _diagnosticSource.Write("Microsoft.AspNetCore.Hosting.UnhandledException", new { httpContext = httpContext, timestamp = currentTimestamp, exception = exception });
                 }
 
-                HostingEventSource.Log.UnhandledException();
+                if (hostingLog.IsEnabled())
+                    hostingLog.UnhandledException();
             }
 
-            HostingEventSource.Log.RequestStop();
+            if (hostingLog.IsEnabled())
+                hostingLog.RequestStop();
 
             context.Scope?.Dispose();
 


### PR DESCRIPTION
Is showing up in traces; `IsEnabled()` can be inlined `Write(..` cannot, even though it then exits early with an enabled test.

Resolves https://github.com/aspnet/Hosting/issues/932