### PR TITLE
Faster RequestServices

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting/Internal/RequestServicesContainerMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/RequestServicesContainerMiddleware.cs
@@ -45,7 +45,6 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                 return;
             }
 
-            // _scopeFactory is pre-validated so use inlinable .ctor and property
             var replacementFeature = new RequestServicesFeature(_scopeFactory);
 
             try

--- a/src/Microsoft.AspNetCore.Hosting/Internal/RequestServicesContainerMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/RequestServicesContainerMiddleware.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
@@ -31,11 +32,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
 
         public async Task Invoke(HttpContext httpContext)
         {
-            if (httpContext == null)
-            {
-                // Defer Exception creation and throw to non-returning throw helper
-                ThrowArgumentNullExceptionHttpContext();
-            }
+            Debug.Assert(httpContext != null);
 
             // local cache for virtual disptach result
             var features = httpContext.Features;
@@ -49,7 +46,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             }
 
             // _scopeFactory is pre-validated so use inlinable .ctor and property
-            var replacementFeature = new RequestServicesFeature() { ServiceScopeFactory = _scopeFactory };
+            var replacementFeature = new RequestServicesFeature(_scopeFactory);
 
             try
             {
@@ -62,11 +59,6 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                 // Restore previous feature state
                 features.Set(existingFeature);
             }
-        }
-
-        private static void ThrowArgumentNullExceptionHttpContext()
-        {
-            throw new ArgumentNullException("httpContext");
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Hosting/Internal/RequestServicesFeature.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/RequestServicesFeature.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -9,33 +10,15 @@ namespace Microsoft.AspNetCore.Hosting.Internal
 {
     public class RequestServicesFeature : IServiceProvidersFeature, IDisposable
     {
-        private IServiceScopeFactory _scopeFactory;
+        private readonly IServiceScopeFactory _scopeFactory;
         private IServiceProvider _requestServices;
         private IServiceScope _scope;
         private bool _requestServicesSet;
 
         public RequestServicesFeature(IServiceScopeFactory scopeFactory)
         {
-            if (scopeFactory == null)
-            {
-                throw new ArgumentNullException(nameof(scopeFactory));
-            }
-
+            Debug.Assert(scopeFactory != null);
             _scopeFactory = scopeFactory;
-        }
-
-        internal RequestServicesFeature()
-        {
-            // For use with pre-validated IServiceScopeFactory
-        }
-
-        internal IServiceScopeFactory ServiceScopeFactory
-        {
-            set
-            {
-                // Setting pre-validated IServiceScopeFactory
-                _scopeFactory = value; 
-            }
         }
 
         public IServiceProvider RequestServices

--- a/src/Microsoft.AspNetCore.Hosting/Internal/RequestServicesFeature.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/RequestServicesFeature.cs
@@ -24,6 +24,20 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             _scopeFactory = scopeFactory;
         }
 
+        internal RequestServicesFeature()
+        {
+            // For use with pre-validated IServiceScopeFactory
+        }
+
+        internal IServiceScopeFactory ServiceScopeFactory
+        {
+            set
+            {
+                // Setting pre-validated IServiceScopeFactory
+                _scopeFactory = value; 
+            }
+        }
+
         public IServiceProvider RequestServices
         {
             get


### PR DESCRIPTION
Its an oddly chunky middleware

![](https://aoa.blob.core.windows.net/aspnet/RequestServices-1.png)

Changes

* `httpContext.Features` to local to reduce virtual lookups from 3 to 1 in common path
* Merge two finally blocks (`using` and `finally`)
* Inlinable `RequestServicesFeature` .ctor 

Pre

![](https://aoa.blob.core.windows.net/aspnet/RequestServices-2.png)

Post

![](https://aoa.blob.core.windows.net/aspnet/RequestServices-3.png)

I tried using a `ThreadStatic` cache for `RequestServicesFeature` and while it reduced most of the allocations; it was slower than allocating 😭 