### PR TITLE
Enable configuring the default service provider

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting/Startup/DelegateStartup.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Startup/DelegateStartup.cs
@@ -3,14 +3,15 @@
 
 using System;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Hosting
 {
-    public class DelegateStartup : StartupBase
+    public class DelegateStartup : StartupBase<IServiceCollection>
     {
         private Action<IApplicationBuilder> _configureApp;
-        
-        public DelegateStartup(Action<IApplicationBuilder> configureApp)
+
+        public DelegateStartup(IServiceProviderFactory<IServiceCollection> factory, Action<IApplicationBuilder> configureApp) : base(factory)
         {
             _configureApp = configureApp;
         }

--- a/src/Microsoft.AspNetCore.Hosting/WebHostBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Hosting/WebHostBuilderExtensions.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting.Internal;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Microsoft.AspNetCore.Hosting
 {
@@ -88,7 +89,7 @@ namespace Microsoft.AspNetCore.Hosting
             {
                 var options = new ServiceProviderOptions();
                 configure(options);
-                services.AddSingleton<IServiceProviderFactory<IServiceCollection>>(new DefaultServiceProviderFactory(options));
+                services.Replace(ServiceDescriptor.Singleton<IServiceProviderFactory<IServiceCollection>>(new DefaultServiceProviderFactory(options)));
             });
         }
     }

--- a/test/Microsoft.AspNetCore.Hosting.Tests/WebHostBuilderTests.cs
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/WebHostBuilderTests.cs
@@ -158,6 +158,28 @@ namespace Microsoft.AspNetCore.Hosting
         }
 
         [Fact]
+        public void ConfigureDefaultServiceProvider()
+        {
+            var hostBuilder = new WebHostBuilder()
+                .UseServer(new TestServer())
+                .ConfigureServices(s =>
+                {
+                    s.AddTransient<ServiceD>();
+                    s.AddScoped<ServiceC>();
+                })
+                .Configure(app =>
+                {
+                    app.ApplicationServices.GetRequiredService<ServiceC>();
+                })
+                .UseDefaultServiceProvider(options =>
+                {
+                    options.ValidateScopes = true;
+                });
+
+            Assert.Throws<InvalidOperationException>(() => hostBuilder.Build());
+        }
+
+        [Fact]
         public void UseLoggerFactoryHonored()
         {
             var loggerFactory = new LoggerFactory();
@@ -619,6 +641,19 @@ namespace Microsoft.AspNetCore.Hosting
                     application.DisposeContext(httpContext, null);
                 };
             }
+        }
+
+        private class ServiceC
+        {
+            public ServiceC(ServiceD serviceD)
+            {
+
+            }
+        }
+
+        private class ServiceD
+        {
+
         }
 
         private class ServiceA


### PR DESCRIPTION
- Added UseDefaultServiceProvider method
- Made DelegateStartup use the IServiceProviderFactory. One downside
here is that we can't use 3rd party DI containers with the Configure
delegate since it's hardcoded to the the specific Startup type but that's
not a regression.