### PR TITLE
Logging optimization.2 14

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting/Internal/HostingApplication.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/HostingApplication.cs
@@ -52,7 +52,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             return new Context
             {
                 HttpContext = httpContext,
-                Scope = scope,
+                Scope = scope,   // Scope can be null if logging is not on.   
                 StartTimestamp = startTimestamp,
             };
         }

--- a/src/Microsoft.AspNetCore.Hosting/Internal/HostingLoggerExtensions.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/HostingLoggerExtensions.cs
@@ -18,7 +18,11 @@ namespace Microsoft.AspNetCore.Hosting.Internal
 
         public static IDisposable RequestScope(this ILogger logger, HttpContext httpContext)
         {
-            return logger.BeginScope(new HostingLogScope(httpContext));
+            // to avoid allocation, return a null scope if the logger is not on.  
+            if (logger.IsEnabled(LogLevel.Information))
+                return logger.BeginScope(new HostingLogScope(httpContext));
+            else
+                return null;
         }
 
         public static void RequestStarting(this ILogger logger, HttpContext httpContext)

--- a/src/Microsoft.AspNetCore.Hosting/Internal/HostingLoggerExtensions.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/HostingLoggerExtensions.cs
@@ -18,8 +18,8 @@ namespace Microsoft.AspNetCore.Hosting.Internal
 
         public static IDisposable RequestScope(this ILogger logger, HttpContext httpContext)
         {
-            // to avoid allocation, return a null scope if the logger is not on.  
-            if (logger.IsEnabled(LogLevel.Information))
+            // to avoid allocation, return a null scope if the logger is not on at least to some degree.   
+            if (logger.IsEnabled(LogLevel.Critical))
                 return logger.BeginScope(new HostingLogScope(httpContext));
             else
                 return null;


### PR DESCRIPTION
In my TechEmpower benchmark I noticed we were allocating a HostingLogScope on every request.   This is completely unnecessary.  Fix it so that we only allocate this scope when logging is actually on.   