### PR TITLE
Allow for an alternate application name to be used as part of deploym…

### DIFF
--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Common/DeploymentParameters.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Common/DeploymentParameters.cs
@@ -41,6 +41,7 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
             }
 
             ApplicationPath = applicationPath;
+            ApplicationName = new DirectoryInfo(ApplicationPath).Name;
             ServerType = serverType;
             RuntimeFlavor = runtimeFlavor;
             EnvironmentVariables.Add(new KeyValuePair<string, string>("ASPNETCORE_DETAILEDERRORS", "true"));
@@ -68,6 +69,12 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
         public string SiteName { get; set; }
 
         public string ApplicationPath { get; }
+
+        /// <summary>
+        /// Gets or sets the name of the application. This is used to execute the application when deployed.
+        /// Defaults to the file name of <see cref="ApplicationPath"/>.
+        /// </summary>
+        public string ApplicationName { get; set; }
 
         public string TargetFramework { get; set; }
 

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/SelfHostDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/SelfHostDeployer.cs
@@ -57,7 +57,7 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
                 var executableExtension =
                     DeploymentParameters.RuntimeFlavor == RuntimeFlavor.Clr ? ".exe" :
                     DeploymentParameters.ApplicationType == ApplicationType.Portable ? ".dll" : "";
-                var executable = Path.Combine(DeploymentParameters.PublishedApplicationRootPath, new DirectoryInfo(DeploymentParameters.ApplicationPath).Name + executableExtension);
+                var executable = Path.Combine(DeploymentParameters.PublishedApplicationRootPath, DeploymentParameters.ApplicationName + executableExtension);
 
                 if (DeploymentParameters.RuntimeFlavor == RuntimeFlavor.Clr && !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {


### PR DESCRIPTION
…ent.

This lets us test applications that are compiled with a different assembly name