### PR TITLE
Avoid having to return anything in StartupBase.ConfigureServices

### DIFF
--- a/samples/SampleStartups/StartupBlockingOnStart.cs
+++ b/samples/SampleStartups/StartupBlockingOnStart.cs
@@ -11,11 +11,10 @@ namespace SampleStartups
 {
     public class StartupBlockingOnStart : StartupBase
     {
-        public override IServiceProvider ConfigureServices(IServiceCollection services)
+        public override void ConfigureServices(IServiceCollection services)
         {
             // This method gets called by the runtime. Use this method to add services to the container.
             // For more information on how to configure your application, visit http://go.microsoft.com/fwlink/?LinkID=398940
-            return base.ConfigureServices(services);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/Microsoft.AspNetCore.Hosting/Startup/StartupBase.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Startup/StartupBase.cs
@@ -11,7 +11,17 @@ namespace Microsoft.AspNetCore.Hosting
     {
         public abstract void Configure(IApplicationBuilder app);
 
-        public virtual IServiceProvider ConfigureServices(IServiceCollection services)
+        IServiceProvider IStartup.ConfigureServices(IServiceCollection services)
+        {
+            ConfigureServices(services);
+            return CreateServiceProvider(services);
+        }
+
+        public virtual void ConfigureServices(IServiceCollection services)
+        {
+        }
+
+        public virtual IServiceProvider CreateServiceProvider(IServiceCollection services)
         {
             return services.BuildServiceProvider();
         }

--- a/src/Microsoft.AspNetCore.Hosting/Startup/StartupBase.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Startup/StartupBase.cs
@@ -27,11 +27,11 @@ namespace Microsoft.AspNetCore.Hosting
         }
     }
 
-    public abstract class StartupBase<TContainerBuilder> : StartupBase
+    public abstract class StartupBase<TBuilder> : StartupBase
     {
-        private readonly IServiceProviderFactory<TContainerBuilder> _factory;
+        private readonly IServiceProviderFactory<TBuilder> _factory;
 
-        public StartupBase(IServiceProviderFactory<TContainerBuilder> factory)
+        public StartupBase(IServiceProviderFactory<TBuilder> factory)
         {
             _factory = factory;
         }
@@ -43,6 +43,8 @@ namespace Microsoft.AspNetCore.Hosting
             return _factory.CreateServiceProvider(builder);
         }
 
-        public virtual void ConfigureContainer(TContainerBuilder containerBuilder) { }
+        public virtual void ConfigureContainer(TBuilder builder)
+        {
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Hosting/Startup/StartupBase.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Startup/StartupBase.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.Hosting
         }
     }
 
-    public abstract class StartupBase<TContainerBuilder> : IStartup
+    public abstract class StartupBase<TContainerBuilder> : StartupBase
     {
         private readonly IServiceProviderFactory<TContainerBuilder> _factory;
 
@@ -36,16 +36,8 @@ namespace Microsoft.AspNetCore.Hosting
             _factory = factory;
         }
 
-        public abstract void Configure(IApplicationBuilder app);
-
-        public virtual void ConfigureServices(IServiceCollection services)
+        public override IServiceProvider CreateServiceProvider(IServiceCollection services)
         {
-
-        }
-
-        IServiceProvider IStartup.ConfigureServices(IServiceCollection services)
-        {
-            ConfigureServices(services);
             var builder = _factory.CreateBuilder(services);
             ConfigureContainer(builder);
             return _factory.CreateServiceProvider(builder);


### PR DESCRIPTION
This is more a proposal than anything else, as it's a breaking change. Maybe it could go in as part of 2.0?

For the vast majority of the time, when deriving from `StartupBase` you don't need or want to provide a custom `IServiceProvider`. You usually just call (and return) `base.ConfigureServices(services)` or `services.BuildServiceProvider()`. This is just noise and should be handled by the framework IMO.

This proposal makes the `IStartup.ConfigureServices` implementation explicit and adds a method, `CreateServiceProvider` to `StartupBase` that the user can override if they want to customize the provider.

It also aligns `StartupBase` and `StartupBase<TBuilder>` by having the latter derive from the former and override the new `CreateServiceProvider` method.

// @davidfowl 