### PR TITLE
Add new constructor to TestSever which allows providing preconfigured FeatureCollection to use before Build / Start is invoked.

### DIFF
--- a/src/Microsoft.AspNetCore.TestHost/TestServer.cs
+++ b/src/Microsoft.AspNetCore.TestHost/TestServer.cs
@@ -21,12 +21,21 @@ namespace Microsoft.AspNetCore.TestHost
         private IHttpApplication<Context> _application;
 
         public TestServer(IWebHostBuilder builder)
-            : this(builder, null)
+            : this(builder, new FeatureCollection())
         {
         }
 
         public TestServer(IWebHostBuilder builder, IFeatureCollection featureCollection)
         {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+            if (featureCollection == null)
+            {
+                throw new ArgumentNullException(nameof(featureCollection));
+            }        
+        
             Features = featureCollection;
 
             var host = builder.UseServer(this).Build();

--- a/src/Microsoft.AspNetCore.TestHost/TestServer.cs
+++ b/src/Microsoft.AspNetCore.TestHost/TestServer.cs
@@ -27,6 +27,14 @@ namespace Microsoft.AspNetCore.TestHost
             _hostInstance = host;
         }
 
+        public TestServer(IWebHostBuilder builder, Action<TestServer> configureServer)
+        {
+            configureServer(this);
+            var host = builder.UseServer(this).Build();
+            host.Start();
+            _hostInstance = host;
+        }
+
         public Uri BaseAddress { get; set; } = new Uri("http://localhost/");
 
         public IWebHost Host
@@ -37,7 +45,7 @@ namespace Microsoft.AspNetCore.TestHost
             }
         }
 
-        IFeatureCollection IServer.Features { get; }
+        IFeatureCollection IServer.Features { get; } = new FeatureCollection();
 
         public HttpMessageHandler CreateHandler()
         {

--- a/src/Microsoft.AspNetCore.TestHost/TestServer.cs
+++ b/src/Microsoft.AspNetCore.TestHost/TestServer.cs
@@ -21,10 +21,8 @@ namespace Microsoft.AspNetCore.TestHost
         private IHttpApplication<Context> _application;
 
         public TestServer(IWebHostBuilder builder)
+            : this(builder, null)
         {
-            var host = builder.UseServer(this).Build();
-            host.Start();
-            _hostInstance = host;
         }
 
         public TestServer(IWebHostBuilder builder, IFeatureCollection featureCollection)

--- a/src/Microsoft.AspNetCore.TestHost/TestServer.cs
+++ b/src/Microsoft.AspNetCore.TestHost/TestServer.cs
@@ -6,7 +6,6 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
-using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Context = Microsoft.AspNetCore.Hosting.Internal.HostingApplication.Context;

--- a/src/Microsoft.AspNetCore.TestHost/TestServer.cs
+++ b/src/Microsoft.AspNetCore.TestHost/TestServer.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Context = Microsoft.AspNetCore.Hosting.Internal.HostingApplication.Context;
@@ -27,9 +28,14 @@ namespace Microsoft.AspNetCore.TestHost
             _hostInstance = host;
         }
 
-        public TestServer(IWebHostBuilder builder, Action<TestServer> configureServer)
+        public TestServer(IWebHostBuilder builder, IFeatureCollection featureCollection)
         {
-            configureServer(this);
+            var server = this as IServer;
+            foreach (var feature in featureCollection)
+            {
+                server.Features[feature.Key] = feature.Value;
+            }
+
             var host = builder.UseServer(this).Build();
             host.Start();
             _hostInstance = host;

--- a/src/Microsoft.AspNetCore.TestHost/TestServer.cs
+++ b/src/Microsoft.AspNetCore.TestHost/TestServer.cs
@@ -29,11 +29,7 @@ namespace Microsoft.AspNetCore.TestHost
 
         public TestServer(IWebHostBuilder builder, IFeatureCollection featureCollection)
         {
-            var server = this as IServer;
-            foreach (var feature in featureCollection)
-            {
-                server.Features[feature.Key] = feature.Value;
-            }
+            Features = featureCollection;
 
             var host = builder.UseServer(this).Build();
             host.Start();
@@ -50,7 +46,7 @@ namespace Microsoft.AspNetCore.TestHost
             }
         }
 
-        IFeatureCollection IServer.Features { get; } = new FeatureCollection();
+        public IFeatureCollection Features { get; }
 
         public HttpMessageHandler CreateHandler()
         {

--- a/test/Microsoft.AspNetCore.TestHost.Tests/TestServerTests.cs
+++ b/test/Microsoft.AspNetCore.TestHost.Tests/TestServerTests.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Testing.xunit;
@@ -16,8 +17,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DiagnosticAdapter;
 using Microsoft.Extensions.Logging;
 using Xunit;
-using Microsoft.AspNetCore.Hosting.Server;
-using Microsoft.AspNetCore.Hosting.Server.Features;
 
 namespace Microsoft.AspNetCore.TestHost
 {
@@ -122,7 +121,7 @@ namespace Microsoft.AspNetCore.TestHost
         }
 
         [Fact]
-        public void TestServerConstructorWithConfigureServerAllowsInitializingServerFeatures()
+        public void TestServerConstructorWithFeatureCollectionAllowsInitializingServerFeatures()
         {
             // Arrange
             var url = "http://localhost:8000/appName/serviceName";
@@ -131,7 +130,7 @@ namespace Microsoft.AspNetCore.TestHost
                 .Configure(applicationBuilder =>
                 {
                     var serverAddressesFeature = applicationBuilder.ServerFeatures.Get<IServerAddressesFeature>();
-                    Assert.Contains(serverAddressesFeature.Addresses, s => string.Compare(s,url, true) == 0);
+                    Assert.Contains(serverAddressesFeature.Addresses, s => string.Compare(s, url, true) == 0);
                 });
 
 

--- a/test/Microsoft.AspNetCore.TestHost.Tests/TestServerTests.cs
+++ b/test/Microsoft.AspNetCore.TestHost.Tests/TestServerTests.cs
@@ -130,7 +130,7 @@ namespace Microsoft.AspNetCore.TestHost
                 .Configure(applicationBuilder =>
                 {
                     var serverAddressesFeature = applicationBuilder.ServerFeatures.Get<IServerAddressesFeature>();
-                    Assert.Contains(serverAddressesFeature.Addresses, s => string.Compare(s, url, true) == 0);
+                    Assert.Contains(serverAddressesFeature.Addresses, s => string.Equals(s, url, StringComparison.Ordinal));
                 });
 
 

--- a/test/Microsoft.AspNetCore.TestHost.Tests/TestServerTests.cs
+++ b/test/Microsoft.AspNetCore.TestHost.Tests/TestServerTests.cs
@@ -145,17 +145,12 @@ namespace Microsoft.AspNetCore.TestHost
         }
 
         [Fact]
-        public void TestServerConstructorWithNullFeatureCollectionDoesNotThrow()
+        public void TestServerConstructorWithNullFeatureCollectionThrows()
         {
-            // Arrange
             var builder = new WebHostBuilder()
                 .Configure(b => { });
 
-            // Act
-            new TestServer(builder, null);
-
-            // Assert
-            // Does not throw
+            Assert.Throws<ArgumentNullException>(() => new TestServer(builder, null));
         }
 
         public class TestService { }

--- a/test/Microsoft.AspNetCore.TestHost.Tests/TestServerTests.cs
+++ b/test/Microsoft.AspNetCore.TestHost.Tests/TestServerTests.cs
@@ -134,12 +134,12 @@ namespace Microsoft.AspNetCore.TestHost
                     Assert.Contains(serverAddressesFeature.Addresses, s => string.Compare(s,url, true) == 0);
                 });
 
+
+            var featureCollection = new FeatureCollection();
+            featureCollection.Set<IServerAddressesFeature>(new ServerAddressesFeature());
+
             // Act
-            var testServer = new TestServer(builder, server =>
-            {
-                var iserver = server as IServer;
-                iserver.Features.Set<IServerAddressesFeature>(new ServerAddressesFeature());
-            });
+            var testServer = new TestServer(builder, featureCollection);
 
             // Assert
             // Is inside configure callback

--- a/test/Microsoft.AspNetCore.TestHost.Tests/TestServerTests.cs
+++ b/test/Microsoft.AspNetCore.TestHost.Tests/TestServerTests.cs
@@ -138,10 +138,24 @@ namespace Microsoft.AspNetCore.TestHost
             featureCollection.Set<IServerAddressesFeature>(new ServerAddressesFeature());
 
             // Act
-            var testServer = new TestServer(builder, featureCollection);
+            new TestServer(builder, featureCollection);
 
             // Assert
             // Is inside configure callback
+        }
+
+        [Fact]
+        public void TestServerConstructorWithNullFeatureCollectionDoesNotThrow()
+        {
+            // Arrange
+            var builder = new WebHostBuilder()
+                .Configure(b => { });
+
+            // Act
+            new TestServer(builder, null);
+
+            // Assert
+            // Does not throw
         }
 
         public class TestService { }


### PR DESCRIPTION
This allows setting up Features for tests to match behavior of Kestrel and WebListener.

I added a test which verifies it will address the issue I opened.

I hope this is non-breaking change since it's new constructor which people would have to opt into using. However, it does initialize the `IServer.Features` to new empty `FeatureCollection` so if someone was relying on that being null perhaps it is change.  From my understanding the WebHostBuilder was only populating ServerFeatures if the feature was set in the collection.

See related issue:
#967
