### PR TITLE
Configuration on WebHostBuilder

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/IWebHostBuilder.cs
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/IWebHostBuilder.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -39,6 +40,13 @@ namespace Microsoft.AspNetCore.Hosting
         IWebHostBuilder ConfigureLogging(Action<ILoggerFactory> configureLogging);
 
         /// <summary>
+        /// Adds a delegate for configuring the provided <see cref="ILoggerFactory"/>. This may be called multiple times.
+        /// </summary>
+        /// <param name="configureLogging">The delegate that configures the <see cref="ILoggerFactory"/>.</param>
+        /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
+        IWebHostBuilder ConfigureLogging<T>(Action<T> configureLogging) where T : ILoggerFactory;
+
+        /// <summary>
         /// Add or replace a setting in the configuration.
         /// </summary>
         /// <param name="key">The key of the setting to add or replace.</param>
@@ -52,5 +60,21 @@ namespace Microsoft.AspNetCore.Hosting
         /// <param name="key">The key of the setting to look up.</param>
         /// <returns>The value the setting currently contains.</returns>
         string GetSetting(string key);
+
+        /// <summary>
+        /// Adds a delegate to construct the <see cref="ILoggerFactory"/> that will be registered
+        /// as a singleton and used by the application.
+        /// </summary>
+        /// <param name="createLoggerFactory">The delegate that constructs an <see cref="IConfigurationBuilder" /></param>
+        /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
+        IWebHostBuilder UseLoggerFactory(Func<WebHostBuilderContext, ILoggerFactory> createLoggerFactory);
+
+
+        /// <summary>
+        /// Adds a delegate for configuring the <see cref="IConfigurationBuilder"/> that will construct an <see cref="IConfiguration"/>.
+        /// </summary>
+        /// <param name="configureDelegate">The delegate for configuring the <see cref="IConfigurationBuilder" /> that will be used to construct an <see cref="IConfiguration" />.</param>
+        /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
+        IWebHostBuilder ConfigureConfiguration(Action<WebHostBuilderContext, IConfigurationBuilder> configureDelegate);
     }
 }

--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/WebHostBuilderContext.cs
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/WebHostBuilderContext.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Hosting
+{
+    /// <summary>
+    /// Context containing the common services on the <see cref="IWebHost" />. Some properties may be null until set by the <see cref="IWebHost" />.
+    /// </summary>
+    public class WebHostBuilderContext
+    {
+        /// <summary>
+        /// The <see cref="IHostingEnvironment" /> initialized by the <see cref="IWebHost" />.
+        /// </summary>
+        public IHostingEnvironment HostingEnvironment { get; set; }
+
+        /// <summary>
+        /// The <see cref="IConfiguration" /> containing the merged configuration of the application and the <see cref="IWebHost" />.
+        /// </summary>
+        public IConfiguration Configuration { get; set; }
+
+        /// <summary>
+        /// The <see cref="ILoggerFactory" /> configured on the <see cref="IWebHost" />.
+        /// </summary>
+        public ILoggerFactory LoggerFactory { get; set; }
+    }
+}

--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/exceptions.net45.json
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/exceptions.net45.json
@@ -1,0 +1,20 @@
+[
+  {
+    "OldTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHostBuilder",
+    "NewTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHostBuilder",
+    "NewMemberId": "Microsoft.AspNetCore.Hosting.IWebHostBuilder ConfigureLogging<T0>(System.Action<T0> configureLogging) where T0 : Microsoft.Extensions.Logging.ILoggerFactory",
+    "Kind": "Addition"
+  },
+  {
+    "OldTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHostBuilder",
+    "NewTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHostBuilder",
+    "NewMemberId": "Microsoft.AspNetCore.Hosting.IWebHostBuilder UseLoggerFactory(System.Func<Microsoft.AspNetCore.Hosting.WebHostBuilderContext, Microsoft.Extensions.Logging.ILoggerFactory> createLoggerFactory)",
+    "Kind": "Addition"
+  },
+  {
+    "OldTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHostBuilder",
+    "NewTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHostBuilder",
+    "NewMemberId": "Microsoft.AspNetCore.Hosting.IWebHostBuilder ConfigureConfiguration(System.Action<Microsoft.AspNetCore.Hosting.WebHostBuilderContext, Microsoft.Extensions.Configuration.IConfigurationBuilder> configureDelegate)",
+    "Kind": "Addition"
+  }
+]

--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/exceptions.netcore.json
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/exceptions.netcore.json
@@ -1,0 +1,20 @@
+[
+  {
+    "OldTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHostBuilder",
+    "NewTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHostBuilder",
+    "NewMemberId": "Microsoft.AspNetCore.Hosting.IWebHostBuilder ConfigureLogging<T0>(System.Action<T0> configureLogging) where T0 : Microsoft.Extensions.Logging.ILoggerFactory",
+    "Kind": "Addition"
+  },
+  {
+    "OldTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHostBuilder",
+    "NewTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHostBuilder",
+    "NewMemberId": "Microsoft.AspNetCore.Hosting.IWebHostBuilder UseLoggerFactory(System.Func<Microsoft.AspNetCore.Hosting.WebHostBuilderContext, Microsoft.Extensions.Logging.ILoggerFactory> createLoggerFactory)",
+    "Kind": "Addition"
+  },
+  {
+    "OldTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHostBuilder",
+    "NewTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHostBuilder",
+    "NewMemberId": "Microsoft.AspNetCore.Hosting.IWebHostBuilder ConfigureConfiguration(System.Action<Microsoft.AspNetCore.Hosting.WebHostBuilderContext, Microsoft.Extensions.Configuration.IConfigurationBuilder> configureDelegate)",
+    "Kind": "Addition"
+  }
+]

--- a/src/Microsoft.AspNetCore.Hosting/Microsoft.AspNetCore.Hosting.csproj
+++ b/src/Microsoft.AspNetCore.Hosting/Microsoft.AspNetCore.Hosting.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(AspNetCoreVersion)" />

--- a/src/Microsoft.AspNetCore.Hosting/WebHostBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Hosting/WebHostBuilderExtensions.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Hosting
 {
@@ -91,6 +92,29 @@ namespace Microsoft.AspNetCore.Hosting
                 configure(options);
                 services.Replace(ServiceDescriptor.Singleton<IServiceProviderFactory<IServiceCollection>>(new DefaultServiceProviderFactory(options)));
             });
+        }
+
+        /// <summary>
+        /// Configures and use a <see cref="LoggerFactory"/> for the web host.
+        /// </summary>
+        /// <param name="hostBuilder">The <see cref="IWebHostBuilder"/> to configure.</param>
+        /// <param name="configure">A callback used to configure the <see cref="LoggerFactory"/> that will be added as a singleton and used by the application.</param>
+        /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
+        public static IWebHostBuilder UseLoggerFactory(this IWebHostBuilder hostBuilder, Action<WebHostBuilderContext, LoggerFactory> configure)
+        {
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
+            hostBuilder.UseLoggerFactory(context =>
+            {
+                var loggerFactory = new LoggerFactory();
+                configure(context, loggerFactory);
+                return loggerFactory;
+            });
+
+            return hostBuilder;
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Hosting.Tests/Fakes/CustomLoggerFactory.cs
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/Fakes/CustomLoggerFactory.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Microsoft.AspNetCore.Hosting.Fakes
+{
+    public class CustomLoggerFactory : ILoggerFactory
+    {
+        public void CustomConfigureMethod() { }
+
+        public void AddProvider(ILoggerProvider provider) { }
+
+        public ILogger CreateLogger(string categoryName) => NullLogger.Instance;
+
+        public void Dispose() { }
+    }
+
+    public static class CustomLoggerFactoryExtensions
+    {
+        public static IWebHostBuilder ConfigureCustomLogger(this IWebHostBuilder builder, Action<CustomLoggerFactory> configureLogger)
+        {
+            builder.UseLoggerFactory(_ => new CustomLoggerFactory());
+            builder.ConfigureLogging(configureLogger);
+            return builder;
+        }
+    }
+
+    public class SubLoggerFactory : CustomLoggerFactory { }
+
+    public class NonSubLoggerFactory : ILoggerFactory
+    {
+        public void CustomConfigureMethod() { }
+
+        public void AddProvider(ILoggerProvider provider) { }
+
+        public ILogger CreateLogger(string categoryName) => NullLogger.Instance;
+
+        public void Dispose() { }
+    }
+}


### PR DESCRIPTION
The intent here was to see what it will look like if we have the ability to configure configuration and logging in `main` as well as setup for when `ILoggerFactory` no longer has `AddProvider`. I didn't obsolete things here, but the intent would be to obsolete `ConfigureLogging(ILoggerFactory)` and possibly `UseLoggerFactory(ILoggerFactory)`.

See: https://github.com/aspnet/Hosting/issues/955 and https://github.com/aspnet/Logging/issues/420

The configuration part of it seems fine, but logging not so much.