### PR TITLE
WIP: Simplify hosting configuration with some extension methods

### DIFF
--- a/samples/SampleStartups/StartupBlockingOnStart.cs
+++ b/samples/SampleStartups/StartupBlockingOnStart.cs
@@ -40,7 +40,8 @@ namespace SampleStartups
             using (host)
             {
                 host.Start();
-                Console.ReadLine();
+
+                host.WaitForShutdown();
             }
         }
     }

--- a/samples/SampleStartups/StartupHelloWorld.cs
+++ b/samples/SampleStartups/StartupHelloWorld.cs
@@ -22,7 +22,7 @@ namespace SampleStartups
         public static void MainWithMiddleware()
         {
             var host = new WebHostBuilder()
-                .RunWith(app =>
+                .RunApplication(app =>
                 {
                     // You can add middleware here
                     app.Run(async context =>

--- a/samples/SampleStartups/StartupHelloWorld.cs
+++ b/samples/SampleStartups/StartupHelloWorld.cs
@@ -19,6 +19,32 @@ namespace SampleStartups
             host.WaitForShutdown();
         }
 
+        public static void MainWithPort()
+        {
+            var host = new WebHostBuilder()
+                .Run(8080, async context =>
+                {
+                    await context.Response.WriteAsync("Hello World");
+                });
+
+            host.WaitForShutdown();
+        }
+
+        public static void MainWithMiddlewareWithPort()
+        {
+            var host = new WebHostBuilder()
+                .RunApplication(8080, app =>
+                {
+                    // You can add middleware here
+                    app.Run(async context =>
+                        {
+                            await context.Response.WriteAsync("Hello World");
+                        });
+                });
+
+            host.WaitForShutdown();
+        }
+
         public static void MainWithMiddleware()
         {
             var host = new WebHostBuilder()

--- a/samples/SampleStartups/StartupHelloWorld.cs
+++ b/samples/SampleStartups/StartupHelloWorld.cs
@@ -6,26 +6,32 @@ using Microsoft.AspNetCore.Http;
 
 namespace SampleStartups
 {
-    public class StartupHelloWorld : StartupBase
+    public class Program
     {
-        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public override void Configure(IApplicationBuilder app)
-        {
-            app.Run(async (context) =>
-            {
-                await context.Response.WriteAsync("Hello World!");
-            });
-        }
-
-        // Entry point for the application.
-        public static void Main(string[] args)
+        public static void Main()
         {
             var host = new WebHostBuilder()
-              //.UseKestrel()
-                .UseStartup<StartupHelloWorld>()
-                .Build();
+                .Run(async context =>
+                {
+                    await context.Response.WriteAsync("Hello World");
+                });
 
-            host.Run();
+            host.WaitForShutdown();
+        }
+
+        public static void MainWithMiddleware()
+        {
+            var host = new WebHostBuilder()
+                .RunWith(app =>
+                {
+                    // You can add middleware here
+                    app.Run(async context =>
+                    {
+                        await context.Response.WriteAsync("Hello World");
+                    });
+                });
+
+            host.WaitForShutdown();
         }
     }
 }

--- a/samples/SampleStartups/StartupHelloWorld.cs
+++ b/samples/SampleStartups/StartupHelloWorld.cs
@@ -22,7 +22,7 @@ namespace SampleStartups
         public static void MainWithPort()
         {
             var host = new WebHostBuilder()
-                .Run(8080, async context =>
+                .Run("localhost", 8080, async context =>
                 {
                     await context.Response.WriteAsync("Hello World");
                 });
@@ -33,13 +33,13 @@ namespace SampleStartups
         public static void MainWithMiddlewareWithPort()
         {
             var host = new WebHostBuilder()
-                .RunApplication(8080, app =>
+                .RunApplication("localhost", 8080, app =>
                 {
                     // You can add middleware here
                     app.Run(async context =>
-                        {
-                            await context.Response.WriteAsync("Hello World");
-                        });
+                    {
+                        await context.Response.WriteAsync("Hello World");
+                    });
                 });
 
             host.WaitForShutdown();

--- a/src/Microsoft.AspNetCore.Hosting/WebHostBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Hosting/WebHostBuilderExtensions.cs
@@ -110,10 +110,40 @@ namespace Microsoft.AspNetCore.Hosting
         /// Runs a web application with the specified handler
         /// </summary>
         /// <param name="hostBuilder">The <see cref="IWebHostBuilder"/> to run.</param>
+        /// <param name="port">The port to bind to.</param>
+        /// <param name="handler">A delegate that handles the request.</param>
+        public static IWebHost Run(this IWebHostBuilder hostBuilder, int port, RequestDelegate handler)
+        {
+            var host = hostBuilder.UseUrls($"http://*:{port}/")
+                                  .Configure(app => app.Run(handler))
+                                  .Build();
+            host.Start();
+            return host;
+        }
+
+        /// <summary>
+        /// Runs a web application with the specified handler
+        /// </summary>
+        /// <param name="hostBuilder">The <see cref="IWebHostBuilder"/> to run.</param>
         /// <param name="configure">The delegate that configures the <see cref="IApplicationBuilder"/>.</param>
         public static IWebHost RunApplication(this IWebHostBuilder hostBuilder, Action<IApplicationBuilder> configure)
         {
             var host = hostBuilder.Configure(configure).Build();
+            host.Start();
+            return host;
+        }
+
+        /// <summary>
+        /// Runs a web application with the specified handler
+        /// </summary>
+        /// <param name="hostBuilder">The <see cref="IWebHostBuilder"/> to run.</param>
+        /// <param name="port">The port to bind to.</param>
+        /// <param name="configure">The delegate that configures the <see cref="IApplicationBuilder"/>.</param>
+        public static IWebHost RunApplication(this IWebHostBuilder hostBuilder, int port, Action<IApplicationBuilder> configure)
+        {
+            var host = hostBuilder.UseUrls($"http://*:{port}/")
+                                  .Configure(configure)
+                                  .Build();
             host.Start();
             return host;
         }

--- a/src/Microsoft.AspNetCore.Hosting/WebHostBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Hosting/WebHostBuilderExtensions.cs
@@ -110,11 +110,12 @@ namespace Microsoft.AspNetCore.Hosting
         /// Runs a web application with the specified handler
         /// </summary>
         /// <param name="hostBuilder">The <see cref="IWebHostBuilder"/> to run.</param>
+        /// <param name="hostname">The host name to bind to.</param>
         /// <param name="port">The port to bind to.</param>
         /// <param name="handler">A delegate that handles the request.</param>
-        public static IWebHost Run(this IWebHostBuilder hostBuilder, int port, RequestDelegate handler)
+        public static IWebHost Run(this IWebHostBuilder hostBuilder, string hostname, int port, RequestDelegate handler)
         {
-            var host = hostBuilder.UseUrls($"http://*:{port}/")
+            var host = hostBuilder.UseUrls($"http://{hostname}:{port}/")
                                   .Configure(app => app.Run(handler))
                                   .Build();
             host.Start();
@@ -137,11 +138,12 @@ namespace Microsoft.AspNetCore.Hosting
         /// Runs a web application with the specified handler
         /// </summary>
         /// <param name="hostBuilder">The <see cref="IWebHostBuilder"/> to run.</param>
+        /// <param name="hostname">The host name to bind to.</param>
         /// <param name="port">The port to bind to.</param>
         /// <param name="configure">The delegate that configures the <see cref="IApplicationBuilder"/>.</param>
-        public static IWebHost RunApplication(this IWebHostBuilder hostBuilder, int port, Action<IApplicationBuilder> configure)
+        public static IWebHost RunApplication(this IWebHostBuilder hostBuilder, string hostname, int port, Action<IApplicationBuilder> configure)
         {
-            var host = hostBuilder.UseUrls($"http://*:{port}/")
+            var host = hostBuilder.UseUrls($"http://{hostname}:{port}/")
                                   .Configure(configure)
                                   .Build();
             host.Start();

--- a/src/Microsoft.AspNetCore.Hosting/WebHostBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Hosting/WebHostBuilderExtensions.cs
@@ -111,7 +111,7 @@ namespace Microsoft.AspNetCore.Hosting
         /// </summary>
         /// <param name="hostBuilder">The <see cref="IWebHostBuilder"/> to run.</param>
         /// <param name="configure">The delegate that configures the <see cref="IApplicationBuilder"/>.</param>
-        public static IWebHost RunWith(this IWebHostBuilder hostBuilder, Action<IApplicationBuilder> configure)
+        public static IWebHost RunApplication(this IWebHostBuilder hostBuilder, Action<IApplicationBuilder> configure)
         {
             var host = hostBuilder.Configure(configure).Build();
             host.Start();

--- a/src/Microsoft.AspNetCore.Hosting/WebHostBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Hosting/WebHostBuilderExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Reflection;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting.Internal;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -91,6 +92,30 @@ namespace Microsoft.AspNetCore.Hosting
                 configure(options);
                 services.Replace(ServiceDescriptor.Singleton<IServiceProviderFactory<IServiceCollection>>(new DefaultServiceProviderFactory(options)));
             });
+        }
+
+        /// <summary>
+        /// Runs a web application with the specified handler
+        /// </summary>
+        /// <param name="hostBuilder">The <see cref="IWebHostBuilder"/> to run.</param>
+        /// <param name="handler">A delegate that handles the request.</param>
+        public static IWebHost Run(this IWebHostBuilder hostBuilder, RequestDelegate handler)
+        {
+            var host = hostBuilder.Configure(app => app.Run(handler)).Build();
+            host.Start();
+            return host;
+        }
+
+        /// <summary>
+        /// Runs a web application with the specified handler
+        /// </summary>
+        /// <param name="hostBuilder">The <see cref="IWebHostBuilder"/> to run.</param>
+        /// <param name="configure">The delegate that configures the <see cref="IApplicationBuilder"/>.</param>
+        public static IWebHost RunWith(this IWebHostBuilder hostBuilder, Action<IApplicationBuilder> configure)
+        {
+            var host = hostBuilder.Configure(configure).Build();
+            host.Start();
+            return host;
         }
     }
 }


### PR DESCRIPTION
- Added WaitForShutdown method to IWebHost
- Added Run and RunApplication to IWebHostBuilder to Build and
Start the application in a single method.

After a discussion about what could be done to further simplify some of the startup logic with the `WebHostBuilder` a few things came up. These were some of the methods that we could add to make the startup logic more approachable while not completely diverging from the original API.

Further simplification requires picking kestrel to to be the default server but that won't happen as part of this PR and requires further discussion.

/cc @glennc @Tratcher @DamianEdwards 