### PR TITLE
WebHost Start/Run/StopAsync and IServer.Start/StopAsync

### DIFF
--- a/samples/SampleStartups/StartupExternallyControlled.cs
+++ b/samples/SampleStartups/StartupExternallyControlled.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -34,8 +36,9 @@ namespace SampleStartups
                 .Start(_urls.ToArray());
         }
 
-        public void Stop()
+        public async Task StopAsync()
         {
+            await _host.StopAsync(TimeSpan.FromSeconds(5));
             _host.Dispose();
         }
 

--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/HostingAbstractionsWebHostBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/HostingAbstractionsWebHostBuilderExtensions.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -166,7 +168,7 @@ namespace Microsoft.AspNetCore.Hosting
         public static IWebHost Start(this IWebHostBuilder hostBuilder, params string[] urls)
         {
             var host = hostBuilder.UseUrls(urls).Build();
-            host.Start();
+            host.StartAsync(CancellationToken.None).GetAwaiter().GetResult();
             return host;
         }
     }

--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/IWebHost.cs
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/IWebHost.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http.Features;
 
 namespace Microsoft.AspNetCore.Hosting
@@ -24,6 +26,13 @@ namespace Microsoft.AspNetCore.Hosting
         /// <summary>
         /// Starts listening on the configured addresses.
         /// </summary>
-        void Start();
+        Task StartAsync(CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Attempt to gracefully stop the host.
+        /// </summary>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task StopAsync(CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/WebHostDefaults.cs
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/WebHostDefaults.cs
@@ -16,5 +16,7 @@ namespace Microsoft.AspNetCore.Hosting
         public static readonly string ServerUrlsKey = "urls";
         public static readonly string ContentRootKey = "contentRoot";
         public static readonly string PreferHostingUrls = "preferHostingUrls";
+
+        public static readonly string ShutdownTimeoutKey = "shutdownTimeoutSeconds";
     }
 }

--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/exceptions.net45.json
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/exceptions.net45.json
@@ -16,5 +16,24 @@
     "NewTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHostBuilder",
     "NewMemberId": "Microsoft.AspNetCore.Hosting.IWebHostBuilder ConfigureConfiguration(System.Action<Microsoft.AspNetCore.Hosting.WebHostBuilderContext, Microsoft.Extensions.Configuration.IConfigurationBuilder> configureDelegate)",
     "Kind": "Addition"
+  },
+  {
+    "OldTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHost : System.IDisposable",
+    "OldMemberId": "System.Void Start()",
+    "NewTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHost : System.IDisposable",
+    "NewMemberId": "System.Threading.Tasks.Task StartAsync(System.Threading.CancellationToken cancellationToken)",
+    "Kind": "Modification"
+  },
+  {
+    "OldTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHost : System.IDisposable",
+    "NewTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHost : System.IDisposable",
+    "NewMemberId": "System.Threading.Tasks.Task StartAsync(System.Threading.CancellationToken cancellationToken)",
+    "Kind": "Addition"
+  },
+  {
+    "OldTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHost : System.IDisposable",
+    "NewTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHost : System.IDisposable",
+    "NewMemberId": "System.Threading.Tasks.Task StopAsync(System.Threading.CancellationToken cancellationToken)",
+    "Kind": "Addition"
   }
 ]

--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/exceptions.netcore.json
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/exceptions.netcore.json
@@ -16,5 +16,24 @@
     "NewTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHostBuilder",
     "NewMemberId": "Microsoft.AspNetCore.Hosting.IWebHostBuilder ConfigureConfiguration(System.Action<Microsoft.AspNetCore.Hosting.WebHostBuilderContext, Microsoft.Extensions.Configuration.IConfigurationBuilder> configureDelegate)",
     "Kind": "Addition"
+  },
+  {
+    "OldTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHost : System.IDisposable",
+    "OldMemberId": "System.Void Start()",
+    "NewTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHost : System.IDisposable",
+    "NewMemberId": "System.Threading.Tasks.Task StartAsync(System.Threading.CancellationToken cancellationToken)",
+    "Kind": "Modification"
+  },
+  {
+    "OldTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHost : System.IDisposable",
+    "NewTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHost : System.IDisposable",
+    "NewMemberId": "System.Threading.Tasks.Task StartAsync(System.Threading.CancellationToken cancellationToken)",
+    "Kind": "Addition"
+  },
+  {
+    "OldTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHost : System.IDisposable",
+    "NewTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHost : System.IDisposable",
+    "NewMemberId": "System.Threading.Tasks.Task StopAsync(System.Threading.CancellationToken cancellationToken)",
+    "Kind": "Addition"
   }
 ]

--- a/src/Microsoft.AspNetCore.Hosting.Server.Abstractions/IServer.cs
+++ b/src/Microsoft.AspNetCore.Hosting.Server.Abstractions/IServer.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http.Features;
 
 namespace Microsoft.AspNetCore.Hosting.Server
@@ -21,6 +23,13 @@ namespace Microsoft.AspNetCore.Hosting.Server
         /// </summary>
         /// <param name="application">An instance of <see cref="IHttpApplication{TContext}"/>.</param>
         /// <typeparam name="TContext">The context associated with the application.</typeparam>
-        void Start<TContext>(IHttpApplication<TContext> application);
+        /// <param name="cancellationToken">Indicates if the server startup should be aborted.</param>
+        Task StartAsync<TContext>(IHttpApplication<TContext> application, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Stop processing requests and shut down the server, gracefully if possible.
+        /// </summary>
+        /// <param name="cancellationToken">Indicates if the graceful shutdown should be aborted.</param>
+        Task StopAsync(CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.AspNetCore.Hosting.Server.Abstractions/exceptions.net45.json
+++ b/src/Microsoft.AspNetCore.Hosting.Server.Abstractions/exceptions.net45.json
@@ -10,5 +10,24 @@
     "NewTypeId": "public interface Microsoft.AspNetCore.Hosting.Server.Features.IServerAddressesFeature",
     "NewMemberId": "System.Void set_PreferHostingUrls(System.Boolean value)",
     "Kind": "Addition"
+  },
+  {
+    "OldTypeId": "public interface Microsoft.AspNetCore.Hosting.Server.IServer : System.IDisposable",
+    "OldMemberId": "System.Void Start<T0>(Microsoft.AspNetCore.Hosting.Server.IHttpApplication<T0> application)",
+    "NewTypeId": "public interface Microsoft.AspNetCore.Hosting.Server.IServer : System.IDisposable",
+    "NewMemberId": "System.Threading.Tasks.Task StartAsync<T0>(Microsoft.AspNetCore.Hosting.Server.IHttpApplication<T0> application, System.Threading.CancellationToken cancellationToken)",
+    "Kind": "Modification"
+  },
+  {
+    "OldTypeId": "public interface Microsoft.AspNetCore.Hosting.Server.IServer : System.IDisposable",
+    "NewTypeId": "public interface Microsoft.AspNetCore.Hosting.Server.IServer : System.IDisposable",
+    "NewMemberId": "System.Threading.Tasks.Task StartAsync<T0>(Microsoft.AspNetCore.Hosting.Server.IHttpApplication<T0> application, System.Threading.CancellationToken cancellationToken)",
+    "Kind": "Addition"
+  },
+  {
+    "OldTypeId": "public interface Microsoft.AspNetCore.Hosting.Server.IServer : System.IDisposable",
+    "NewTypeId": "public interface Microsoft.AspNetCore.Hosting.Server.IServer : System.IDisposable",
+    "NewMemberId": "System.Threading.Tasks.Task StopAsync(System.Threading.CancellationToken cancellationToken)",
+    "Kind": "Addition"
   }
 ]

--- a/src/Microsoft.AspNetCore.Hosting.Server.Abstractions/exceptions.netcore.json
+++ b/src/Microsoft.AspNetCore.Hosting.Server.Abstractions/exceptions.netcore.json
@@ -10,5 +10,24 @@
     "NewTypeId": "public interface Microsoft.AspNetCore.Hosting.Server.Features.IServerAddressesFeature",
     "NewMemberId": "System.Void set_PreferHostingUrls(System.Boolean value)",
     "Kind": "Addition"
+  },
+  {
+    "OldTypeId": "public interface Microsoft.AspNetCore.Hosting.Server.IServer : System.IDisposable",
+    "OldMemberId": "System.Void Start<T0>(Microsoft.AspNetCore.Hosting.Server.IHttpApplication<T0> application)",
+    "NewTypeId": "public interface Microsoft.AspNetCore.Hosting.Server.IServer : System.IDisposable",
+    "NewMemberId": "System.Threading.Tasks.Task StartAsync<T0>(Microsoft.AspNetCore.Hosting.Server.IHttpApplication<T0> application, System.Threading.CancellationToken cancellationToken)",
+    "Kind": "Modification"
+  },
+  {
+    "OldTypeId": "public interface Microsoft.AspNetCore.Hosting.Server.IServer : System.IDisposable",
+    "NewTypeId": "public interface Microsoft.AspNetCore.Hosting.Server.IServer : System.IDisposable",
+    "NewMemberId": "System.Threading.Tasks.Task StartAsync<T0>(Microsoft.AspNetCore.Hosting.Server.IHttpApplication<T0> application, System.Threading.CancellationToken cancellationToken)",
+    "Kind": "Addition"
+  },
+  {
+    "OldTypeId": "public interface Microsoft.AspNetCore.Hosting.Server.IServer : System.IDisposable",
+    "NewTypeId": "public interface Microsoft.AspNetCore.Hosting.Server.IServer : System.IDisposable",
+    "NewMemberId": "System.Threading.Tasks.Task StopAsync(System.Threading.CancellationToken cancellationToken)",
+    "Kind": "Addition"
   }
 ]

--- a/src/Microsoft.AspNetCore.Hosting/Internal/HostingLoggerExtensions.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/HostingLoggerExtensions.cs
@@ -82,6 +82,16 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             }
         }
 
+        public static void ServerShutdownException(this ILogger logger, Exception ex)
+        {
+            if (logger.IsEnabled(LogLevel.Debug))
+            {
+                logger.LogDebug(
+                    eventId: LoggerEventIds.ServerShutdownException,
+                    exception: ex,
+                    message: "Server shutdown exception");
+            }
+        }
 
         private class HostingLogScope : IReadOnlyList<KeyValuePair<string, object>>
         {

--- a/src/Microsoft.AspNetCore.Hosting/Internal/LoggerEventIds.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/LoggerEventIds.cs
@@ -16,5 +16,6 @@ namespace Microsoft.AspNetCore.Hosting.Internal
         public const int HostedServiceStartException = 9;
         public const int HostedServiceStopException = 10;
         public const int HostingStartupAssemblyException = 11;
+        public const int ServerShutdownException = 12;
     }
 }

--- a/src/Microsoft.AspNetCore.Hosting/Internal/WebHostOptions.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/WebHostOptions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.AspNetCore.Hosting.Internal
@@ -27,6 +28,13 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             ContentRootPath = configuration[WebHostDefaults.ContentRootKey];
             HostingStartupAssemblies = configuration[WebHostDefaults.HostingStartupAssembliesKey]?.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries) ?? new string[0];
             PreferHostingUrls = ParseBool(configuration, WebHostDefaults.PreferHostingUrls);
+
+            var timeout = configuration[WebHostDefaults.ShutdownTimeoutKey];
+            if (!string.IsNullOrEmpty(timeout)
+                && int.TryParse(timeout, NumberStyles.None, CultureInfo.InvariantCulture, out var seconds))
+            {
+                ShutdownTimeout = TimeSpan.FromSeconds(seconds);
+            }
         }
 
         public string ApplicationName { get; set; }
@@ -46,6 +54,8 @@ namespace Microsoft.AspNetCore.Hosting.Internal
         public string ContentRootPath { get; set; }
 
         public bool PreferHostingUrls { get; set; }
+
+        public TimeSpan ShutdownTimeout { get; set; } = TimeSpan.FromSeconds(5);
 
         private static bool ParseBool(IConfiguration configuration, string key)
         {

--- a/src/Microsoft.AspNetCore.TestHost/TestServer.cs
+++ b/src/Microsoft.AspNetCore.TestHost/TestServer.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
@@ -39,7 +40,7 @@ namespace Microsoft.AspNetCore.TestHost
             Features = featureCollection;
 
             var host = builder.UseServer(this).Build();
-            host.Start();
+            host.StartAsync().GetAwaiter().GetResult();
             _hostInstance = host;
         }
 
@@ -91,7 +92,7 @@ namespace Microsoft.AspNetCore.TestHost
             }
         }
 
-        void IServer.Start<TContext>(IHttpApplication<TContext> application)
+        Task IServer.StartAsync<TContext>(IHttpApplication<TContext> application, CancellationToken cancellationToken)
         {
             _application = new ApplicationWrapper<Context>((IHttpApplication<Context>)application, () =>
             {
@@ -100,6 +101,13 @@ namespace Microsoft.AspNetCore.TestHost
                     throw new ObjectDisposedException(GetType().FullName);
                 }
             });
+
+            return Task.CompletedTask;
+        }
+
+        Task IServer.StopAsync(CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
         }
 
         private class ApplicationWrapper<TContext> : IHttpApplication<TContext>

--- a/test/Microsoft.AspNetCore.Hosting.TestSites/Program.cs
+++ b/test/Microsoft.AspNetCore.Hosting.TestSites/Program.cs
@@ -1,11 +1,12 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
 using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Configuration;
 
 namespace ServerComparison.TestSites
 {
@@ -36,8 +37,14 @@ namespace ServerComparison.TestSites
 
         public IFeatureCollection Features { get; } = new FeatureCollection();
 
-        public void Start<TContext>(IHttpApplication<TContext> application)
+        public Task StartAsync<TContext>(IHttpApplication<TContext> application, CancellationToken cancellationToken)
         {
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
         }
     }
 }


### PR DESCRIPTION
#947 
Stopping the server before we dispose the container (and server) allows requests to drain gracefully without the chance of encountering already disposed services.