### PR TITLE
additional checks and logging for iisx shutdown

### DIFF
--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/IISExpressDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/IISExpressDeployer.cs
@@ -291,6 +291,13 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
 
                 StopTimer();
             }
+
+            // If by this point, the host process is still running (somehow), throw an error.
+            // A test failure is better than a silent hang and unknown failure later on
+            if(!_hostProcess.HasExited)
+            {
+                throw new Exception($"iisexpress Process {_hostProcess.Id} failed to shutdown");
+            }
         }
     }
 }


### PR DESCRIPTION
If we fail to kill IISExpress, we just print a warning to the logs. This makes some sense at the point at which we kill IIS Express because we have more clean-up to do. However, we should just fail the test if IIS Express is still running at the end of the test. A failed test is better than a mystery process ;).

/cc @natemcmaster 

Related to aspnet/ServerTests#66 (not a fix, but it will help)