### PR TITLE
increase timeout for remote deployer

### DIFF
--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/RemoteWindowsDeployer/RemoteWindowsDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/RemoteWindowsDeployer/RemoteWindowsDeployer.cs
@@ -263,7 +263,7 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
 
                     runScriptsOnRemoteServerProcess.StartAndCaptureOutAndErrToLogger(serverAction, Logger);
 
-                    await processExited.Task.OrTimeout(TimeSpan.FromMinutes(1));
+                    await processExited.Task.OrTimeout(TimeSpan.FromMinutes(5));
                     runScriptsOnRemoteServerProcess.WaitForExit((int)TimeSpan.FromMinutes(1).TotalMilliseconds);
 
                     if (runScriptsOnRemoteServerProcess.HasExited && runScriptsOnRemoteServerProcess.ExitCode != 0)


### PR DESCRIPTION
Turns out it takes a while to deploy to nano server