### PR TITLE
Add test logging helpers to Hosting

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -11,5 +11,7 @@
     <WebAdministrationVersion>7.0.0</WebAdministrationVersion>
     <WindowsApiSetsVersion>1.0.1</WindowsApiSetsVersion>
     <XunitVersion>2.2.0</XunitVersion>
+    <SerilogExtensionsLoggingVersion>1.4.0</SerilogExtensionsLoggingVersion>
+    <SerilogFileSinkVersion>3.2.0</SerilogFileSinkVersion>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Common/DeploymentResult.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Common/DeploymentResult.cs
@@ -1,7 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Net.Http;
 using System.Threading;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.IntegrationTesting
 {
@@ -10,25 +13,57 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
     /// </summary>
     public class DeploymentResult
     {
+        private readonly ILoggerFactory _loggerFactory;
+
         /// <summary>
         /// Base Uri of the deployment application.
         /// </summary>
-        public string ApplicationBaseUri { get; set; }
+        public string ApplicationBaseUri { get; }
 
         /// <summary>
         /// The folder where the application is hosted. This path can be different from the
         /// original application source location if published before deployment.
         /// </summary>
-        public string ContentRoot { get; set; }
+        public string ContentRoot { get; }
 
         /// <summary>
         /// Original deployment parameters used for this deployment.
         /// </summary>
-        public DeploymentParameters DeploymentParameters { get; set; }
+        public DeploymentParameters DeploymentParameters { get; }
 
         /// <summary>
         /// Triggered when the host process dies or pulled down.
         /// </summary>
-        public CancellationToken HostShutdownToken { get; set; }
+        public CancellationToken HostShutdownToken { get; }
+
+        /// <summary>
+        /// An <see cref="HttpClient"/> with <see cref="LoggingHandler"/> configured and the <see cref="HttpClient.BaseAddress"/> set to the <see cref="ApplicationBaseUri"/>
+        /// </summary>
+        public HttpClient HttpClient { get; }
+
+        public DeploymentResult(ILoggerFactory loggerFactory, DeploymentParameters deploymentParameters, string applicationBaseUri)
+            : this(loggerFactory, deploymentParameters: deploymentParameters, applicationBaseUri: applicationBaseUri, contentRoot: string.Empty, hostShutdownToken: CancellationToken.None)
+        { }
+
+        public DeploymentResult(ILoggerFactory loggerFactory, DeploymentParameters deploymentParameters, string applicationBaseUri, string contentRoot, CancellationToken hostShutdownToken)
+        {
+            _loggerFactory = loggerFactory;
+
+            ApplicationBaseUri = applicationBaseUri;
+            ContentRoot = contentRoot;
+            DeploymentParameters = deploymentParameters;
+            HostShutdownToken = hostShutdownToken;
+
+            HttpClient = CreateHttpClient(new HttpClientHandler());
+        }
+
+        /// <summary>
+        /// Create an <see cref="HttpClient"/> with <see cref="LoggingHandler"/> configured and the <see cref="HttpClient.BaseAddress"/> set to the <see cref="ApplicationBaseUri"/>,
+        /// but using the provided <see cref="HttpMessageHandler"/> and the underlying handler.
+        /// </summary>
+        /// <param name="baseHandler"></param>
+        /// <returns></returns>
+        public HttpClient CreateHttpClient(HttpMessageHandler baseHandler) =>
+            new HttpClient(new LoggingHandler(_loggerFactory, baseHandler)) { BaseAddress = new Uri(ApplicationBaseUri) };
     }
 }

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Common/LoggingHandler.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Common/LoggingHandler.cs
@@ -1,0 +1,25 @@
+﻿using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Server.IntegrationTesting
+{
+    internal class LoggingHandler : DelegatingHandler
+    {
+        private ILogger _logger;
+
+        public LoggingHandler(ILoggerFactory loggerFactory, HttpMessageHandler innerHandler) : base(innerHandler)
+        {
+            _logger = loggerFactory.CreateLogger<HttpClient>();
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            _logger.LogDebug("Sending {method} {url}", request.Method, request.RequestUri);
+            var response = await base.SendAsync(request, cancellationToken);
+            _logger.LogDebug("Received {statusCode} {reasonPhrase} {url}", response.StatusCode, response.ReasonPhrase, request.RequestUri);
+            return response;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Common/LoggingHandler.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Common/LoggingHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http;
+﻿using System;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -17,9 +18,17 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             _logger.LogDebug("Sending {method} {url}", request.Method, request.RequestUri);
-            var response = await base.SendAsync(request, cancellationToken);
-            _logger.LogDebug("Received {statusCode} {reasonPhrase} {url}", response.StatusCode, response.ReasonPhrase, request.RequestUri);
-            return response;
+            try
+            {
+                var response = await base.SendAsync(request, cancellationToken);
+                _logger.LogDebug("Received {statusCode} {reasonPhrase} {url}", response.StatusCode, response.ReasonPhrase, request.RequestUri);
+                return response;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(0, ex, "Exception while sending '{method} {url}'", request.Method, request.RequestUri, request.RequestUri);
+                throw;
+            }
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Common/ProcessLoggingExtensions.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Common/ProcessLoggingExtensions.cs
@@ -14,7 +14,7 @@ namespace System.Diagnostics
             {
                 if (!string.IsNullOrEmpty(dataArgs.Data))
                 {
-                    logger.LogWarning($"{prefix} stdout: {{line}}", dataArgs.Data);
+                    logger.LogInformation($"{prefix} stdout: {{line}}", dataArgs.Data);
                 }
             };
 

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Common/RetryHelper.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Common/RetryHelper.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -59,7 +59,7 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
                         if (exception is HttpRequestException
 #if NET46
                         || exception is System.Net.WebException
-#elif NETSTANDARD1_3
+#elif NETSTANDARD1_5
 #else
 #error Target frameworks need to be updated.
 #endif

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/ApplicationDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/ApplicationDeployer.cs
@@ -26,14 +26,16 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
 
         private readonly Stopwatch _stopwatch = new Stopwatch();
 
-        public ApplicationDeployer(DeploymentParameters deploymentParameters, ILogger logger)
+        public ApplicationDeployer(DeploymentParameters deploymentParameters, ILoggerFactory loggerFactory)
         {
             DeploymentParameters = deploymentParameters;
-            Logger = logger;
+            LoggerFactory = loggerFactory;
+            Logger = LoggerFactory.CreateLogger(GetType().FullName);
         }
 
         protected DeploymentParameters DeploymentParameters { get; }
 
+        protected ILoggerFactory LoggerFactory { get; }
         protected ILogger Logger { get; }
 
         public abstract Task<DeploymentResult> DeployAsync();

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/ApplicationDeployerFactory.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/ApplicationDeployerFactory.cs
@@ -32,14 +32,14 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
             switch (deploymentParameters.ServerType)
             {
                 case ServerType.IISExpress:
-                    return new IISExpressDeployer(deploymentParameters, loggerFactory.CreateLogger<IISExpressDeployer>());
+                    return new IISExpressDeployer(deploymentParameters, loggerFactory);
                 case ServerType.IIS:
                     throw new NotSupportedException("The IIS deployer is no longer supported");
                 case ServerType.WebListener:
                 case ServerType.Kestrel:
-                    return new SelfHostDeployer(deploymentParameters, loggerFactory.CreateLogger<SelfHostDeployer>());
+                    return new SelfHostDeployer(deploymentParameters, loggerFactory);
                 case ServerType.Nginx:
-                    return new NginxDeployer(deploymentParameters, loggerFactory.CreateLogger<NginxDeployer>());
+                    return new NginxDeployer(deploymentParameters, loggerFactory);
                 default:
                     throw new NotSupportedException(
                         string.Format("Found no deployers suitable for server type '{0}' with the current runtime.",

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/IISExpressDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/IISExpressDeployer.cs
@@ -27,8 +27,8 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
 
         private Process _hostProcess;
 
-        public IISExpressDeployer(DeploymentParameters deploymentParameters, ILogger logger)
-            : base(deploymentParameters, logger)
+        public IISExpressDeployer(DeploymentParameters deploymentParameters, ILoggerFactory loggerFactory)
+            : base(deploymentParameters, loggerFactory)
         {
         }
 
@@ -74,14 +74,13 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
 
                 Logger.LogInformation("Application ready at URL: {appUrl}", actualUri);
 
-                return new DeploymentResult
-                {
-                    ContentRoot = contentRoot,
-                    DeploymentParameters = DeploymentParameters,
-                    // Right now this works only for urls like http://localhost:5001/. Does not work for http://localhost:5001/subpath.
-                    ApplicationBaseUri = actualUri.ToString(),
-                    HostShutdownToken = hostExitToken
-                };
+                // Right now this works only for urls like http://localhost:5001/. Does not work for http://localhost:5001/subpath.
+                return new DeploymentResult(
+                    LoggerFactory,
+                    DeploymentParameters,
+                    applicationBaseUri: actualUri.ToString(),
+                    contentRoot: contentRoot,
+                    hostShutdownToken: hostExitToken);
             }
         }
 
@@ -294,7 +293,7 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
 
             // If by this point, the host process is still running (somehow), throw an error.
             // A test failure is better than a silent hang and unknown failure later on
-            if(!_hostProcess.HasExited)
+            if (!_hostProcess.HasExited)
             {
                 throw new Exception($"iisexpress Process {_hostProcess.Id} failed to shutdown");
             }

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/NginxDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/NginxDeployer.cs
@@ -19,8 +19,8 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
         private string _configFile;
         private readonly int _waitTime = (int)TimeSpan.FromSeconds(30).TotalMilliseconds;
 
-        public NginxDeployer(DeploymentParameters deploymentParameters, ILogger logger)
-            : base(deploymentParameters, logger)
+        public NginxDeployer(DeploymentParameters deploymentParameters, ILoggerFactory loggerFactory)
+            : base(deploymentParameters, loggerFactory)
         {
         }
 
@@ -61,13 +61,12 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
                     }
                 }
 
-                return new DeploymentResult
-                {
-                    ContentRoot = DeploymentParameters.ApplicationPath,
-                    DeploymentParameters = DeploymentParameters,
-                    ApplicationBaseUri = uri.ToString(),
-                    HostShutdownToken = exitToken
-                };
+                return new DeploymentResult(
+                    LoggerFactory,
+                    DeploymentParameters,
+                    applicationBaseUri: uri.ToString(),
+                    contentRoot: DeploymentParameters.ApplicationPath,
+                    hostShutdownToken: exitToken);
             }
         }
 

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/RemoteWindowsDeployer/RemoteWindowsDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/RemoteWindowsDeployer/RemoteWindowsDeployer.cs
@@ -26,8 +26,8 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
         private bool _isDisposed;
         private static readonly Lazy<Scripts> _scripts = new Lazy<Scripts>(() => CopyEmbeddedScriptFilesToDisk());
 
-        public RemoteWindowsDeployer(RemoteWindowsDeploymentParameters deploymentParameters, ILogger logger)
-            : base(deploymentParameters, logger)
+        public RemoteWindowsDeployer(RemoteWindowsDeploymentParameters deploymentParameters, ILoggerFactory loggerFactory)
+            : base(deploymentParameters, loggerFactory)
         {
             _deploymentParameters = deploymentParameters;
 
@@ -103,11 +103,10 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
 
                 await RunScriptAsync("StartServer");
 
-                return new DeploymentResult
-                {
-                    ApplicationBaseUri = DeploymentParameters.ApplicationBaseUriHint,
-                    DeploymentParameters = DeploymentParameters
-                };
+                return new DeploymentResult(
+                    LoggerFactory,
+                    DeploymentParameters,
+                    DeploymentParameters.ApplicationBaseUriHint);
             }
         }
 

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/SelfHostDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/SelfHostDeployer.cs
@@ -23,8 +23,8 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
 
         public Process HostProcess { get; private set; }
 
-        public SelfHostDeployer(DeploymentParameters deploymentParameters, ILogger logger)
-            : base(deploymentParameters, logger)
+        public SelfHostDeployer(DeploymentParameters deploymentParameters, ILoggerFactory loggerFactory)
+            : base(deploymentParameters, loggerFactory)
         {
         }
 
@@ -47,13 +47,12 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
 
                 Logger.LogInformation("Application ready at URL: {appUrl}", actualUrl);
 
-                return new DeploymentResult
-                {
-                    ContentRoot = DeploymentParameters.PublishApplicationBeforeDeployment ? DeploymentParameters.PublishedApplicationRootPath : DeploymentParameters.ApplicationPath,
-                    DeploymentParameters = DeploymentParameters,
-                    ApplicationBaseUri = actualUrl.ToString(),
-                    HostShutdownToken = hostExitToken
-                };
+                return new DeploymentResult(
+                    LoggerFactory,
+                    DeploymentParameters,
+                    applicationBaseUri: actualUrl.ToString(),
+                    contentRoot: DeploymentParameters.PublishApplicationBeforeDeployment ? DeploymentParameters.PublishedApplicationRootPath : DeploymentParameters.ApplicationPath,
+                    hostShutdownToken: hostExitToken);
             }
         }
 

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Microsoft.AspNetCore.Server.IntegrationTesting.csproj
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Microsoft.AspNetCore.Server.IntegrationTesting.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Testing" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Testing" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Process.Sources" Version="$(AspNetCoreVersion)" PrivateAssets="All" />

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Microsoft.AspNetCore.Server.IntegrationTesting.csproj
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Microsoft.AspNetCore.Server.IntegrationTesting.csproj
@@ -20,11 +20,14 @@
     <PackageReference Include="System.ValueTuple" Version="$(CoreFxVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Testing" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Testing" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Process.Sources" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.RuntimeEnvironment.Sources" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETCore.Windows.ApiSets" Version="$(WindowsApiSetsVersion)" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="1.4.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="3.2.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Microsoft.AspNetCore.Server.IntegrationTesting.csproj
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Microsoft.AspNetCore.Server.IntegrationTesting.csproj
@@ -26,8 +26,8 @@
     <PackageReference Include="Microsoft.Extensions.Process.Sources" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.RuntimeEnvironment.Sources" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETCore.Windows.ApiSets" Version="$(WindowsApiSetsVersion)" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="1.4.0" />
-    <PackageReference Include="Serilog.Sinks.File" Version="3.2.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="$(SerilogExtensionsLoggingVersion)" />
+    <PackageReference Include="Serilog.Sinks.File" Version="$(SerilogFileSinkVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Microsoft.AspNetCore.Server.IntegrationTesting.csproj
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Microsoft.AspNetCore.Server.IntegrationTesting.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <Description>ASP.NET Core helpers to deploy applications to IIS Express, IIS, WebListener and Kestrel for testing.</Description>
     <VersionPrefix>0.4.0</VersionPrefix>
-    <TargetFrameworks>net46;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net46;netstandard1.5</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore;testing</PackageTags>

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Microsoft.AspNetCore.Server.IntegrationTesting.csproj
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Microsoft.AspNetCore.Server.IntegrationTesting.csproj
@@ -36,7 +36,7 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
     <PackageReference Include="System.Diagnostics.Process" Version="$(CoreFxVersion)" />
     <PackageReference Include="System.Threading.Thread" Version="$(CoreFxVersion)" />
   </ItemGroup>

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/xunit/TestLogging.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/xunit/TestLogging.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.IO;
 using System.Reflection;
 using System.Runtime.CompilerServices;

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/xunit/TestLogging.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/xunit/TestLogging.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.Logging;
+using Serilog;
+using Xunit.Abstractions;
+
+namespace Microsoft.AspNetCore.Server.IntegrationTesting.xunit
+{
+    public static class TestLogging
+    {
+        public static readonly string OutputDirectoryEnvironmentVariableName = "ASPNETCORE_TEST_LOG_DIR";
+        public static readonly string TestOutputRoot = Environment.GetEnvironmentVariable(OutputDirectoryEnvironmentVariableName);
+
+        public static IDisposable Start<TTestClass>(ITestOutputHelper output, out ILoggerFactory loggerFactory, [CallerMemberName] string testName = null)
+        {
+            loggerFactory = CreateLoggerFactory<TTestClass>(output, testName);
+            var logger = loggerFactory.CreateLogger("TestLifetime");
+            logger.LogInformation("Starting test {testName}", testName);
+            return new Disposable(() => logger.LogInformation("Finished test {testName}", testName));
+        }
+
+        public static ILoggerFactory CreateLoggerFactory<TTestClass>(ITestOutputHelper output, [CallerMemberName] string testName = null)
+        {
+            var loggerFactory = new LoggerFactory();
+            loggerFactory.AddXunit(output, LogLevel.Debug);
+
+            if (!string.IsNullOrEmpty(TestOutputRoot))
+            {
+                var testClass = typeof(TTestClass).GetTypeInfo();
+                var testOutputDir = Path.Combine(TestOutputRoot, testClass.Assembly.GetName().Name, testClass.FullName);
+                if (!Directory.Exists(testOutputDir))
+                {
+                    Directory.CreateDirectory(testOutputDir);
+                }
+
+                var testOutputFile = Path.Combine(testOutputDir, $"{testName}.log");
+
+                if (File.Exists(testOutputFile))
+                {
+                    File.Delete(testOutputFile);
+                }
+
+                var serilogger = new LoggerConfiguration()
+                    .Enrich.FromLogContext()
+                    .MinimumLevel.Verbose()
+                    .WriteTo.File(testOutputFile, flushToDiskInterval: TimeSpan.FromSeconds(1))
+                    .CreateLogger();
+                loggerFactory.AddSerilog(serilogger);
+            }
+
+            return loggerFactory;
+        }
+
+        private class Disposable : IDisposable
+        {
+            private Action _action;
+
+            public Disposable(Action action)
+            {
+                _action = action;
+            }
+
+            public void Dispose()
+            {
+                _action();
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/xunit/TestLogging.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/xunit/TestLogging.cs
@@ -93,7 +93,7 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting.xunit
             AddFileLogging(loggerFactory, globalLogFileName);
 
             var logger = loggerFactory.CreateLogger("GlobalTestLog");
-            logger.LogInformation($"Global Test Logging initialized. Set the '{OutputDirectoryEnvironmentVariableName}' Environment Variable to a path in order to save logs to files");
+            logger.LogInformation($"Global Test Logging initialized. Set the '{OutputDirectoryEnvironmentVariableName}' Environment Variable in order to create log files on disk.");
             return logger;
         }
 

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/xunit/TestLogging.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/xunit/TestLogging.cs
@@ -29,7 +29,16 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting.xunit
             if (!string.IsNullOrEmpty(TestOutputRoot))
             {
                 var testClass = typeof(TTestClass).GetTypeInfo();
-                var testOutputDir = Path.Combine(TestOutputRoot, testClass.Assembly.GetName().Name, testClass.FullName);
+                var asmName = testClass.Assembly.GetName().Name;
+                var className = testClass.FullName;
+
+                // Try to shorten the class name using the assembly name
+                if (className.StartsWith(asmName + "."))
+                {
+                    className = className.Substring(asmName.Length + 1);
+                }
+
+                var testOutputDir = Path.Combine(TestOutputRoot, asmName, className);
                 if (!Directory.Exists(testOutputDir))
                 {
                     Directory.CreateDirectory(testOutputDir);

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/xunit/TestLogging.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/xunit/TestLogging.cs
@@ -65,7 +65,21 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting.xunit
             Console.WriteLine("Creating global logger");
             var loggerFactory = new LoggerFactory();
 
-            var appName = Assembly.GetEntryAssembly().GetName().Name;
+            // We can't use entry assembly, because it's testhost
+            // We can't use process mainmodule, because it's dotnet.exe
+            // So we're left with this...
+            string appName;
+            var files = Directory.GetFiles(AppContext.BaseDirectory, "*.runtimeconfig.json");
+            if (files.Length == 0)
+            {
+                // Just use a GUID...
+                appName = Guid.NewGuid().ToString("N");
+            }
+            else
+            {
+                // Strip off .json and .runtimeconfig
+                appName = Path.GetFileNameWithoutExtension(Path.GetFileNameWithoutExtension(files[0]));
+            }
 
             var globalLogFileName = Path.Combine(appName, "global.log");
             Console.WriteLine($"Logging to: {globalLogFileName}");

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/xunit/TestLogging.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/xunit/TestLogging.cs
@@ -11,10 +11,16 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting.xunit
     public static class TestLogging
     {
         // Need to qualify because of Serilog.ILogger :(
-        private static readonly Extensions.Logging.ILogger GlobalLogger = CreateGlobalLogger();
+        private static readonly Extensions.Logging.ILogger GlobalLogger;
 
         public static readonly string OutputDirectoryEnvironmentVariableName = "ASPNETCORE_TEST_LOG_DIR";
-        public static readonly string TestOutputRoot = Environment.GetEnvironmentVariable(OutputDirectoryEnvironmentVariableName);
+        public static readonly string TestOutputRoot;
+
+        static TestLogging()
+        {
+            TestOutputRoot = Environment.GetEnvironmentVariable(OutputDirectoryEnvironmentVariableName);
+            GlobalLogger = CreateGlobalLogger(TestOutputRoot);
+        }
 
         public static IDisposable Start<TTestClass>(ITestOutputHelper output, out ILoggerFactory loggerFactory, [CallerMemberName] string testName = null) =>
             Start(output, out loggerFactory, typeof(TTestClass).GetTypeInfo().Assembly.GetName().Name, typeof(TTestClass).FullName, testName);
@@ -54,7 +60,7 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting.xunit
         }
 
         // Need to qualify because of Serilog.ILogger :(
-        private static Extensions.Logging.ILogger CreateGlobalLogger()
+        private static Extensions.Logging.ILogger CreateGlobalLogger(string testOutputRoot)
         {
             Console.WriteLine("Creating global logger");
             var loggerFactory = new LoggerFactory();

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/xunit/TestLogging.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/xunit/TestLogging.cs
@@ -65,8 +65,10 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting.xunit
         // Need to qualify because of Serilog.ILogger :(
         private static Extensions.Logging.ILogger CreateGlobalLogger(string testOutputRoot)
         {
-            Console.WriteLine("Creating global logger");
             var loggerFactory = new LoggerFactory();
+
+            // Let the global logger log to the console, it's just "Starting X..." "Finished X..."
+            loggerFactory.AddConsole();
 
             // We can't use entry assembly, because it's testhost
             // We can't use process mainmodule, because it's dotnet.exe
@@ -85,7 +87,6 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting.xunit
             }
 
             var globalLogFileName = Path.Combine(appName, "global.log");
-            Console.WriteLine($"Logging to: {globalLogFileName}");
             AddFileLogging(loggerFactory, globalLogFileName);
 
             return loggerFactory.CreateLogger("GlobalTestLog");

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/xunit/TestLogging.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/xunit/TestLogging.cs
@@ -56,11 +56,14 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting.xunit
         // Need to qualify because of Serilog.ILogger :(
         private static Extensions.Logging.ILogger CreateGlobalLogger()
         {
+            Console.WriteLine("Creating global logger");
             var loggerFactory = new LoggerFactory();
 
             var appName = Assembly.GetEntryAssembly().GetName().Name;
 
-            AddFileLogging(loggerFactory, Path.Combine(appName, "global.log"));
+            var globalLogFileName = Path.Combine(appName, "global.log");
+            Console.WriteLine($"Logging to: {globalLogFileName}");
+            AddFileLogging(loggerFactory, globalLogFileName);
 
             return loggerFactory.CreateLogger("GlobalTestLog");
         }
@@ -70,6 +73,7 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting.xunit
             if (!string.IsNullOrEmpty(TestOutputRoot))
             {
                 fileName = Path.Combine(TestOutputRoot, fileName);
+                Console.WriteLine($"Creating logging for: {fileName}");
 
                 var dir = Path.GetDirectoryName(fileName);
                 if (!Directory.Exists(dir))

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/xunit/TestLogging.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/xunit/TestLogging.cs
@@ -10,6 +10,9 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting.xunit
 {
     public static class TestLogging
     {
+        // Need to qualify because of Serilog.ILogger :(
+        private static readonly Extensions.Logging.ILogger GlobalLogger = CreateGlobalLogger();
+
         public static readonly string OutputDirectoryEnvironmentVariableName = "ASPNETCORE_TEST_LOG_DIR";
         public static readonly string TestOutputRoot = Environment.GetEnvironmentVariable(OutputDirectoryEnvironmentVariableName);
 
@@ -17,8 +20,14 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting.xunit
         {
             loggerFactory = CreateLoggerFactory<TTestClass>(output, testName);
             var logger = loggerFactory.CreateLogger("TestLifetime");
+
+            GlobalLogger.LogInformation("Starting test {testName}", testName);
             logger.LogInformation("Starting test {testName}", testName);
-            return new Disposable(() => logger.LogInformation("Finished test {testName}", testName));
+            return new Disposable(() =>
+            {
+                GlobalLogger.LogInformation("Finished test {testName}", testName);
+                logger.LogInformation("Finished test {testName}", testName);
+            });
         }
 
         public static ILoggerFactory CreateLoggerFactory<TTestClass>(ITestOutputHelper output, [CallerMemberName] string testName = null)
@@ -26,40 +35,73 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting.xunit
             var loggerFactory = new LoggerFactory();
             loggerFactory.AddXunit(output, LogLevel.Debug);
 
+            var testClass = typeof(TTestClass).GetTypeInfo();
+            var asmName = testClass.Assembly.GetName().Name;
+            var className = testClass.FullName;
+
+            // Try to shorten the class name using the assembly name
+            if (className.StartsWith(asmName + "."))
+            {
+                className = className.Substring(asmName.Length + 1);
+            }
+
+            var testOutputFile = Path.Combine(asmName, className, $"{testName}.log");
+            AddFileLogging(loggerFactory, testOutputFile);
+
+            return loggerFactory;
+        }
+
+        // Need to qualify because of Serilog.ILogger :(
+        private static Extensions.Logging.ILogger CreateGlobalLogger()
+        {
+            var loggerFactory = new LoggerFactory();
+
+#if NET46
+            var appName = Assembly.GetEntryAssembly().GetName().Name;
+#else
+            // GROOOSSS but should work...
+            string appName;
+            var files = Directory.GetFiles(AppContext.BaseDirectory, "*.runtimeconfig.json");
+            if(files.Length == 0)
+            {
+                // Even Grosser
+                appName = Guid.NewGuid().ToString("N");
+            }
+            else
+            {
+                appName = Path.GetFileNameWithoutExtension(Path.GetFileNameWithoutExtension(files[0]));
+            }
+#endif
+
+            AddFileLogging(loggerFactory, Path.Combine(appName, "global.log"));
+
+            return loggerFactory.CreateLogger("GlobalTestLog");
+        }
+
+        private static void AddFileLogging(ILoggerFactory loggerFactory, string fileName)
+        {
             if (!string.IsNullOrEmpty(TestOutputRoot))
             {
-                var testClass = typeof(TTestClass).GetTypeInfo();
-                var asmName = testClass.Assembly.GetName().Name;
-                var className = testClass.FullName;
+                fileName = Path.Combine(TestOutputRoot, fileName);
 
-                // Try to shorten the class name using the assembly name
-                if (className.StartsWith(asmName + "."))
+                var dir = Path.GetDirectoryName(fileName);
+                if (!Directory.Exists(dir))
                 {
-                    className = className.Substring(asmName.Length + 1);
+                    Directory.CreateDirectory(dir);
                 }
 
-                var testOutputDir = Path.Combine(TestOutputRoot, asmName, className);
-                if (!Directory.Exists(testOutputDir))
+                if (File.Exists(fileName))
                 {
-                    Directory.CreateDirectory(testOutputDir);
-                }
-
-                var testOutputFile = Path.Combine(testOutputDir, $"{testName}.log");
-
-                if (File.Exists(testOutputFile))
-                {
-                    File.Delete(testOutputFile);
+                    File.Delete(fileName);
                 }
 
                 var serilogger = new LoggerConfiguration()
                     .Enrich.FromLogContext()
                     .MinimumLevel.Verbose()
-                    .WriteTo.File(testOutputFile, flushToDiskInterval: TimeSpan.FromSeconds(1))
+                    .WriteTo.File(fileName, flushToDiskInterval: TimeSpan.FromSeconds(1))
                     .CreateLogger();
                 loggerFactory.AddSerilog(serilogger);
             }
-
-            return loggerFactory;
         }
 
         private class Disposable : IDisposable

--- a/test/Microsoft.AspNetCore.Hosting.FunctionalTests/ShutdownTests.cs
+++ b/test/Microsoft.AspNetCore.Hosting.FunctionalTests/ShutdownTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.AspNetCore.Hosting.FunctionalTests
                     PublishApplicationBeforeDeployment = true
                 };
 
-                using (var deployer = new SelfHostDeployer(deploymentParameters, logger))
+                using (var deployer = new SelfHostDeployer(deploymentParameters, loggerFactory))
                 {
                     await deployer.DeployAsync();
 

--- a/test/Microsoft.AspNetCore.Hosting.FunctionalTests/ShutdownTests.cs
+++ b/test/Microsoft.AspNetCore.Hosting.FunctionalTests/ShutdownTests.cs
@@ -4,62 +4,71 @@
 using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting.FunctionalTests;
 using Microsoft.AspNetCore.Server.IntegrationTesting;
 using Microsoft.AspNetCore.Server.IntegrationTesting.xunit;
 using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.Logging;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.Hosting.FunctionalTests
 {
     public class ShutdownTests
     {
+        private readonly ITestOutputHelper _output;
+
+        public ShutdownTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
         [ConditionalFact]
         [OSSkipCondition(OperatingSystems.Windows)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         public async Task ShutdownTest()
         {
-            var logger = new LoggerFactory()
-                .AddConsole()
-                .CreateLogger(nameof(ShutdownTest));
-            logger.LogInformation("Started test: {testName}", nameof(ShutdownTest));
-
-            var applicationPath = Path.Combine(TestProjectHelpers.GetSolutionRoot(), "test",
-                "Microsoft.AspNetCore.Hosting.TestSites");
-
-            var deploymentParameters = new DeploymentParameters(
-                applicationPath,
-                ServerType.Kestrel,
-                RuntimeFlavor.CoreClr,
-                RuntimeArchitecture.x64)
+            using (TestLogging.Start<ShutdownTests>(_output, out var loggerFactory))
             {
-                EnvironmentName = "Shutdown",
-                TargetFramework = "netcoreapp2.0",
-                ApplicationType = ApplicationType.Portable,
-                PublishApplicationBeforeDeployment = true
-            };
+                var logger = loggerFactory.CreateLogger(nameof(ShutdownTest));
 
-            using (var deployer = new SelfHostDeployer(deploymentParameters, logger))
-            {
-                await deployer.DeployAsync();
+                var applicationPath = Path.Combine(TestProjectHelpers.GetSolutionRoot(), "test",
+                    "Microsoft.AspNetCore.Hosting.TestSites");
 
-                // Wait for application to start
-                await Task.Delay(1000);
+                var deploymentParameters = new DeploymentParameters(
+                    applicationPath,
+                    ServerType.Kestrel,
+                    RuntimeFlavor.CoreClr,
+                    RuntimeArchitecture.x64)
+                {
+                    EnvironmentName = "Shutdown",
+                    TargetFramework = "netcoreapp2.0",
+                    ApplicationType = ApplicationType.Portable,
+                    PublishApplicationBeforeDeployment = true
+                };
 
-                string output = string.Empty;
-                deployer.HostProcess.OutputDataReceived += (sender, args) => output += args.Data + '\n';
+                using (var deployer = new SelfHostDeployer(deploymentParameters, logger))
+                {
+                    await deployer.DeployAsync();
 
-                SendSIGINT(deployer.HostProcess.Id);
+                    // Wait for application to start
+                    await Task.Delay(1000);
 
-                WaitForExitOrKill(deployer.HostProcess);
+                    string output = string.Empty;
+                    deployer.HostProcess.OutputDataReceived += (sender, args) => output += args.Data + '\n';
 
-                output = output.Trim('\n');
+                    SendSIGINT(deployer.HostProcess.Id);
 
-                Assert.Equal(output, "Application is shutting down...\n" +
-                                     "Stopping firing\n" +
-                                     "Stopping end\n" +
-                                     "Stopped firing\n" +
-                                     "Stopped end");
+                    WaitForExitOrKill(deployer.HostProcess);
+
+                    output = output.Trim('\n');
+
+                    Assert.Equal(output, "Application is shutting down...\n" +
+                                         "Stopping firing\n" +
+                                         "Stopping end\n" +
+                                         "Stopped firing\n" +
+                                         "Stopped end");
+                }
             }
         }
 

--- a/test/Microsoft.AspNetCore.Hosting.FunctionalTests/ShutdownTests.cs
+++ b/test/Microsoft.AspNetCore.Hosting.FunctionalTests/ShutdownTests.cs
@@ -4,23 +4,18 @@
 using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Hosting.FunctionalTests;
 using Microsoft.AspNetCore.Server.IntegrationTesting;
 using Microsoft.AspNetCore.Server.IntegrationTesting.xunit;
 using Microsoft.AspNetCore.Testing.xunit;
-using Microsoft.Extensions.Logging;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.Hosting.FunctionalTests
 {
-    public class ShutdownTests
+    public class ShutdownTests : LoggedTest
     {
-        private readonly ITestOutputHelper _output;
-
-        public ShutdownTests(ITestOutputHelper output)
+        public ShutdownTests(ITestOutputHelper output) : base(output)
         {
-            _output = output;
         }
 
         [ConditionalFact]
@@ -28,7 +23,7 @@ namespace Microsoft.AspNetCore.Hosting.FunctionalTests
         [OSSkipCondition(OperatingSystems.MacOSX)]
         public async Task ShutdownTest()
         {
-            using (TestLogging.Start<ShutdownTests>(_output, out var loggerFactory))
+            using (StartLog(out var loggerFactory))
             {
                 var logger = loggerFactory.CreateLogger(nameof(ShutdownTest));
 


### PR DESCRIPTION
These are based off the ones in ServerTests. Now that I've seen them at work, I want to add these to Entropy because we're seeing some hanging tests, but I don't want copy-pasta so I figured I'd make it common in Hosting.

I do plan to make this even more low-impact by adding some xunit extensibility to make it "magic", but I don't want to do that until I've worked out the logging process on a few tests.

There's a particular spot in here I'm not so proud of, but very open to suggestions ;). See if you can spot it!

Note: At some point I plan to pull this to somewhere even more common (Common?) in order to be able to use it in all our tests. Also, I plan to use some xunit hooks to avoid some of the boilerplate.