### PR TITLE
Simplify WebHostBuilderTests.CanUseCustomLoggerFactory

### DIFF
--- a/test/Microsoft.AspNetCore.Hosting.Tests/Fakes/CustomLoggerFactory.cs
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/Fakes/CustomLoggerFactory.cs
@@ -18,16 +18,6 @@ namespace Microsoft.AspNetCore.Hosting.Fakes
         public void Dispose() { }
     }
 
-    public static class CustomLoggerFactoryExtensions
-    {
-        public static IWebHostBuilder ConfigureCustomLogger(this IWebHostBuilder builder, Action<CustomLoggerFactory> configureLogger)
-        {
-            builder.UseLoggerFactory(_ => new CustomLoggerFactory());
-            builder.ConfigureLogging(configureLogger);
-            return builder;
-        }
-    }
-
     public class SubLoggerFactory : CustomLoggerFactory { }
 
     public class NonSubLoggerFactory : ILoggerFactory

--- a/test/Microsoft.AspNetCore.Hosting.Tests/WebHostBuilderTests.cs
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/WebHostBuilderTests.cs
@@ -294,7 +294,8 @@ namespace Microsoft.AspNetCore.Hosting
         public void CanUseCustomLoggerFactory()
         {
             var hostBuilder = new WebHostBuilder()
-                .ConfigureCustomLogger(factory =>
+                .UseLoggerFactory(_ => new CustomLoggerFactory())
+                .ConfigureLogging<CustomLoggerFactory>(factory =>
                 {
                     factory.CustomConfigureMethod();
                 })


### PR DESCRIPTION
Keep all the code in the test itself, instead of in an extension method. Makes it easier to understand what's happening without having to look up the extension method's definition.