### PR TITLE
Supply runtime identifier on publishing standalone apps

### DIFF
--- a/NuGetPackageVerifier.json
+++ b/NuGetPackageVerifier.json
@@ -1,7 +1,15 @@
 {
-    "Default": {
-        "rules": [
-            "DefaultCompositeRule"
-        ]
+  "nonshipping": {
+    "rules": [
+      // Don't run any rules for packages that don't ship.
+    ],
+    "packages": {
+      "Microsoft.AspNetCore.Server.IntegrationTesting": {}
     }
+  },
+  "Default": {
+    "rules": [
+      "DefaultCompositeRule"
+    ]
+  }
 }

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <AspNetCoreVersion>2.0.0-*</AspNetCoreVersion>
     <CoreFxVersion>4.3.0</CoreFxVersion>
+    <DotNetPlatformAbstractionsVersion>1.1.0</DotNetPlatformAbstractionsVersion>
     <InternalAspNetCoreSdkVersion>2.0.0-*</InternalAspNetCoreSdkVersion>
     <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
     <RuntimeFrameworkVersion>2.0.0-*</RuntimeFrameworkVersion>

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Microsoft.AspNetCore.Server.IntegrationTesting.csproj
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Microsoft.AspNetCore.Server.IntegrationTesting.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Testing" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="$(DotNetPlatformAbstractionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Process.Sources" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.RuntimeEnvironment.Sources" Version="$(AspNetCoreVersion)" PrivateAssets="All" />


### PR DESCRIPTION
I will send out reaction PRs for ServerTests and MusicStore shortly.