### PR TITLE
Temporarily remove `dotnet run` argument separator

### DIFF
--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/ApplicationDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/ApplicationDeployer.cs
@@ -22,7 +22,9 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
 
         // This is the argument that separates the dotnet arguments for the args being passed to the
         // app being run when running dotnet run
-        public static readonly string DotnetArgumentSeparator = "--";
+        // Temporarily remove separator to workaround "dotnet run no longer passes additional arguments
+        // to application" (https://github.com/dotnet/sdk/issues/1118)
+        public static readonly string DotnetArgumentSeparator = "";
 
         private readonly Stopwatch _stopwatch = new Stopwatch();
 


### PR DESCRIPTION
- Workaround for "dotnet run no longer passes additional arguments to application" (https://github.com/dotnet/sdk/issues/1118)