### PR TITLE
More WebHostBuilderContext overloads

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/HostingAbstractionsWebHostBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/HostingAbstractionsWebHostBuilderExtensions.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -58,8 +57,8 @@ namespace Microsoft.AspNetCore.Hosting
 
 
             return hostBuilder
-                    .UseSetting(WebHostDefaults.ApplicationKey, startupAssemblyName)
-                    .UseSetting(WebHostDefaults.StartupAssemblyKey, startupAssemblyName);
+                .UseSetting(WebHostDefaults.ApplicationKey, startupAssemblyName)
+                .UseSetting(WebHostDefaults.StartupAssemblyKey, startupAssemblyName);
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/IWebHostBuilder.cs
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/IWebHostBuilder.cs
@@ -14,6 +14,15 @@ namespace Microsoft.AspNetCore.Hosting
     public interface IWebHostBuilder
     {
         /// <summary>
+        /// The <see cref="WebHostBuilderContext"/> used during building.
+        /// </summary>
+        /// <remarks>
+        /// Some properties of this type will be null whilst it is being built, most noteably the <see cref="ILoggerFactory"/> will
+        /// be null inside the <see cref="ConfigureAppConfiguration(Action{WebHostBuilderContext, IConfigurationBuilder})"/> method.
+        /// </remarks>
+        WebHostBuilderContext Context { get; }
+
+        /// <summary>
         /// Builds an <see cref="IWebHost"/> which hosts a web application.
         /// </summary>
         IWebHost Build();
@@ -33,6 +42,13 @@ namespace Microsoft.AspNetCore.Hosting
         IWebHostBuilder ConfigureServices(Action<IServiceCollection> configureServices);
 
         /// <summary>
+        /// Specify the delegate that is used to configure the services of the web application.
+        /// </summary>
+        /// <param name="configureServices">The delegate that configures the <see cref="IServiceCollection"/>.</param>
+        /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
+        IWebHostBuilder ConfigureServices(Action<WebHostBuilderContext, IServiceCollection> configureServices);
+
+        /// <summary>
         /// Adds a delegate for configuring the provided <see cref="ILoggerFactory"/>. This may be called multiple times.
         /// </summary>
         /// <param name="configureLogging">The delegate that configures the <see cref="ILoggerFactory"/>.</param>
@@ -44,7 +60,7 @@ namespace Microsoft.AspNetCore.Hosting
         /// </summary>
         /// <param name="configureLogging">The delegate that configures the <see cref="ILoggerFactory"/>.</param>
         /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
-        IWebHostBuilder ConfigureLogging<T>(Action<T> configureLogging) where T : ILoggerFactory;
+        IWebHostBuilder ConfigureLogging<T>(Action<WebHostBuilderContext, T> configureLogging) where T : ILoggerFactory;
 
         /// <summary>
         /// Add or replace a setting in the configuration.
@@ -75,6 +91,6 @@ namespace Microsoft.AspNetCore.Hosting
         /// </summary>
         /// <param name="configureDelegate">The delegate for configuring the <see cref="IConfigurationBuilder" /> that will be used to construct an <see cref="IConfiguration" />.</param>
         /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
-        IWebHostBuilder ConfigureConfiguration(Action<WebHostBuilderContext, IConfigurationBuilder> configureDelegate);
+        IWebHostBuilder ConfigureAppConfiguration(Action<WebHostBuilderContext, IConfigurationBuilder> configureDelegate);
     }
 }

--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/IWebHostBuilder.cs
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/IWebHostBuilder.cs
@@ -14,39 +14,20 @@ namespace Microsoft.AspNetCore.Hosting
     public interface IWebHostBuilder
     {
         /// <summary>
-        /// The <see cref="WebHostBuilderContext"/> used during building.
-        /// </summary>
-        /// <remarks>
-        /// Some properties of this type will be null whilst it is being built, most noteably the <see cref="ILoggerFactory"/> will
-        /// be null inside the <see cref="ConfigureAppConfiguration(Action{WebHostBuilderContext, IConfigurationBuilder})"/> method.
-        /// </remarks>
-        WebHostBuilderContext Context { get; }
-
-        /// <summary>
         /// Builds an <see cref="IWebHost"/> which hosts a web application.
         /// </summary>
         IWebHost Build();
 
         /// <summary>
-        /// Specify the <see cref="ILoggerFactory"/> to be used by the web host.
+        /// Adds a delegate for configuring the <see cref="IConfigurationBuilder"/> that will construct an <see cref="IConfiguration"/>.
         /// </summary>
-        /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to be used.</param>
+        /// <param name="configureDelegate">The delegate for configuring the <see cref="IConfigurationBuilder" /> that will be used to construct an <see cref="IConfiguration" />.</param>
         /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
-        IWebHostBuilder UseLoggerFactory(ILoggerFactory loggerFactory);
-
-        /// <summary>
-        /// Specify the delegate that is used to configure the services of the web application.
-        /// </summary>
-        /// <param name="configureServices">The delegate that configures the <see cref="IServiceCollection"/>.</param>
-        /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
-        IWebHostBuilder ConfigureServices(Action<IServiceCollection> configureServices);
-
-        /// <summary>
-        /// Specify the delegate that is used to configure the services of the web application.
-        /// </summary>
-        /// <param name="configureServices">The delegate that configures the <see cref="IServiceCollection"/>.</param>
-        /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
-        IWebHostBuilder ConfigureServices(Action<WebHostBuilderContext, IServiceCollection> configureServices);
+        /// <remarks>
+        /// The <see cref="IConfiguration"/> and <see cref="ILoggerFactory"/> on the <see cref="WebHostBuilderContext"/> are uninitialized at this stage.
+        /// The <see cref="IConfigurationBuilder"/> is pre-populated with the settings of the <see cref="IWebHostBuilder"/>.
+        /// </remarks>
+        IWebHostBuilder ConfigureAppConfiguration(Action<WebHostBuilderContext, IConfigurationBuilder> configureDelegate);
 
         /// <summary>
         /// Adds a delegate for configuring the provided <see cref="ILoggerFactory"/>. This may be called multiple times.
@@ -59,8 +40,38 @@ namespace Microsoft.AspNetCore.Hosting
         /// Adds a delegate for configuring the provided <see cref="ILoggerFactory"/>. This may be called multiple times.
         /// </summary>
         /// <param name="configureLogging">The delegate that configures the <see cref="ILoggerFactory"/>.</param>
+        /// <typeparam name="T">
+        /// The type of <see cref="ILoggerFactory"/> to configure.
+        /// The delegate will not execute if the type provided does not match the <see cref="ILoggerFactory"/> used by the <see cref="IWebHostBuilder"/>
+        /// </typeparam>
         /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
+        /// <remarks>
+        /// The <see cref="ILoggerFactory"/> on the <see cref="WebHostBuilderContext"/> is uninitialized at this stage.
+        /// </remarks>
         IWebHostBuilder ConfigureLogging<T>(Action<WebHostBuilderContext, T> configureLogging) where T : ILoggerFactory;
+
+        /// <summary>
+        /// Adds a delegate for configuring additional services for the host or web application. This may be called
+        /// multiple times.
+        /// </summary>
+        /// <param name="configureServices">A delegate for configuring the <see cref="IServiceCollection"/>.</param>
+        /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
+        IWebHostBuilder ConfigureServices(Action<IServiceCollection> configureServices);
+
+        /// <summary>
+        /// Adds a delegate for configuring additional services for the host or web application. This may be called
+        /// multiple times.
+        /// </summary>
+        /// <param name="configureServices">A delegate for configuring the <see cref="IServiceCollection"/>.</param>
+        /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
+        IWebHostBuilder ConfigureServices(Action<WebHostBuilderContext, IServiceCollection> configureServices);
+
+        /// <summary>
+        /// Get the setting value from the configuration.
+        /// </summary>
+        /// <param name="key">The key of the setting to look up.</param>
+        /// <returns>The value the setting currently contains.</returns>
+        string GetSetting(string key);
 
         /// <summary>
         /// Add or replace a setting in the configuration.
@@ -71,11 +82,11 @@ namespace Microsoft.AspNetCore.Hosting
         IWebHostBuilder UseSetting(string key, string value);
 
         /// <summary>
-        /// Get the setting value from the configuration.
+        /// Specify the <see cref="ILoggerFactory"/> to be used by the web host.
         /// </summary>
-        /// <param name="key">The key of the setting to look up.</param>
-        /// <returns>The value the setting currently contains.</returns>
-        string GetSetting(string key);
+        /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to be used.</param>
+        /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
+        IWebHostBuilder UseLoggerFactory(ILoggerFactory loggerFactory);
 
         /// <summary>
         /// Adds a delegate to construct the <see cref="ILoggerFactory"/> that will be registered
@@ -83,14 +94,9 @@ namespace Microsoft.AspNetCore.Hosting
         /// </summary>
         /// <param name="createLoggerFactory">The delegate that constructs an <see cref="IConfigurationBuilder" /></param>
         /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
+        /// <remarks>
+        /// The <see cref="ILoggerFactory"/> on the <see cref="WebHostBuilderContext"/> is uninitialized at this stage.
+        /// </remarks>
         IWebHostBuilder UseLoggerFactory(Func<WebHostBuilderContext, ILoggerFactory> createLoggerFactory);
-
-
-        /// <summary>
-        /// Adds a delegate for configuring the <see cref="IConfigurationBuilder"/> that will construct an <see cref="IConfiguration"/>.
-        /// </summary>
-        /// <param name="configureDelegate">The delegate for configuring the <see cref="IConfigurationBuilder" /> that will be used to construct an <see cref="IConfiguration" />.</param>
-        /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
-        IWebHostBuilder ConfigureAppConfiguration(Action<WebHostBuilderContext, IConfigurationBuilder> configureDelegate);
     }
 }

--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/exceptions.net45.json
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/exceptions.net45.json
@@ -2,7 +2,7 @@
   {
     "OldTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHostBuilder",
     "NewTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHostBuilder",
-    "NewMemberId": "Microsoft.AspNetCore.Hosting.IWebHostBuilder ConfigureLogging<T0>(System.Action<T0> configureLogging) where T0 : Microsoft.Extensions.Logging.ILoggerFactory",
+    "NewMemberId": "Microsoft.AspNetCore.Hosting.IWebHostBuilder ConfigureLogging<T0>(System.Action<Microsoft.AspNetCore.Hosting.WebHostBuilderContext, T0> configureLogging) where T0 : Microsoft.Extensions.Logging.ILoggerFactory",
     "Kind": "Addition"
   },
   {
@@ -34,6 +34,18 @@
     "OldTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHost : System.IDisposable",
     "NewTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHost : System.IDisposable",
     "NewMemberId": "System.Threading.Tasks.Task StopAsync(System.Threading.CancellationToken cancellationToken)",
+    "Kind": "Addition"
+  },
+  {
+    "OldTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHostBuilder",
+    "NewTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHostBuilder",
+    "NewMemberId": "Microsoft.AspNetCore.Hosting.WebHostBuilderContext get_Context()",
+    "Kind": "Addition"
+  },
+  {
+    "OldTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHostBuilder",
+    "NewTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHostBuilder",
+    "NewMemberId": "Microsoft.AspNetCore.Hosting.IWebHostBuilder ConfigureServices(System.Action<Microsoft.AspNetCore.Hosting.WebHostBuilderContext, Microsoft.Extensions.DependencyInjection.IServiceCollection> configureServices)",
     "Kind": "Addition"
   }
 ]

--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/exceptions.net45.json
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/exceptions.net45.json
@@ -39,12 +39,6 @@
   {
     "OldTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHostBuilder",
     "NewTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHostBuilder",
-    "NewMemberId": "Microsoft.AspNetCore.Hosting.WebHostBuilderContext get_Context()",
-    "Kind": "Addition"
-  },
-  {
-    "OldTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHostBuilder",
-    "NewTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHostBuilder",
     "NewMemberId": "Microsoft.AspNetCore.Hosting.IWebHostBuilder ConfigureServices(System.Action<Microsoft.AspNetCore.Hosting.WebHostBuilderContext, Microsoft.Extensions.DependencyInjection.IServiceCollection> configureServices)",
     "Kind": "Addition"
   }

--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/exceptions.netcore.json
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/exceptions.netcore.json
@@ -2,7 +2,7 @@
   {
     "OldTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHostBuilder",
     "NewTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHostBuilder",
-    "NewMemberId": "Microsoft.AspNetCore.Hosting.IWebHostBuilder ConfigureLogging<T0>(System.Action<T0> configureLogging) where T0 : Microsoft.Extensions.Logging.ILoggerFactory",
+    "NewMemberId": "Microsoft.AspNetCore.Hosting.IWebHostBuilder ConfigureLogging<T0>(System.Action<Microsoft.AspNetCore.Hosting.WebHostBuilderContext, T0> configureLogging) where T0 : Microsoft.Extensions.Logging.ILoggerFactory",
     "Kind": "Addition"
   },
   {
@@ -14,7 +14,7 @@
   {
     "OldTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHostBuilder",
     "NewTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHostBuilder",
-    "NewMemberId": "Microsoft.AspNetCore.Hosting.IWebHostBuilder ConfigureConfiguration(System.Action<Microsoft.AspNetCore.Hosting.WebHostBuilderContext, Microsoft.Extensions.Configuration.IConfigurationBuilder> configureDelegate)",
+    "NewMemberId": "Microsoft.AspNetCore.Hosting.IWebHostBuilder ConfigureAppConfiguration(System.Action<Microsoft.AspNetCore.Hosting.WebHostBuilderContext, Microsoft.Extensions.Configuration.IConfigurationBuilder> configureDelegate)",
     "Kind": "Addition"
   },
   {
@@ -34,6 +34,18 @@
     "OldTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHost : System.IDisposable",
     "NewTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHost : System.IDisposable",
     "NewMemberId": "System.Threading.Tasks.Task StopAsync(System.Threading.CancellationToken cancellationToken)",
+    "Kind": "Addition"
+  },
+  {
+    "OldTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHostBuilder",
+    "NewTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHostBuilder",
+    "NewMemberId": "Microsoft.AspNetCore.Hosting.WebHostBuilderContext get_Context()",
+    "Kind": "Addition"
+  },
+  {
+    "OldTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHostBuilder",
+    "NewTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHostBuilder",
+    "NewMemberId": "Microsoft.AspNetCore.Hosting.IWebHostBuilder ConfigureServices(System.Action<Microsoft.AspNetCore.Hosting.WebHostBuilderContext, Microsoft.Extensions.DependencyInjection.IServiceCollection> configureServices)",
     "Kind": "Addition"
   }
 ]

--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/exceptions.netcore.json
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/exceptions.netcore.json
@@ -39,12 +39,6 @@
   {
     "OldTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHostBuilder",
     "NewTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHostBuilder",
-    "NewMemberId": "Microsoft.AspNetCore.Hosting.WebHostBuilderContext get_Context()",
-    "Kind": "Addition"
-  },
-  {
-    "OldTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHostBuilder",
-    "NewTypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHostBuilder",
     "NewMemberId": "Microsoft.AspNetCore.Hosting.IWebHostBuilder ConfigureServices(System.Action<Microsoft.AspNetCore.Hosting.WebHostBuilderContext, Microsoft.Extensions.DependencyInjection.IServiceCollection> configureServices)",
     "Kind": "Addition"
   }

--- a/src/Microsoft.AspNetCore.Hosting/WebHostBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Hosting/WebHostBuilderExtensions.cs
@@ -95,26 +95,28 @@ namespace Microsoft.AspNetCore.Hosting
         }
 
         /// <summary>
-        /// Configures and use a <see cref="LoggerFactory"/> for the web host.
+        /// Adds a delegate for configuring the provided <see cref="ILoggerFactory"/>. This may be called multiple times.
         /// </summary>
-        /// <param name="hostBuilder">The <see cref="IWebHostBuilder"/> to configure.</param>
-        /// <param name="configure">A callback used to configure the <see cref="LoggerFactory"/> that will be added as a singleton and used by the application.</param>
+        /// <param name="hostBuilder">The <see cref="IWebHostBuilder" /> to configure.</param>
+        /// <param name="configureLogging">The delegate that configures the <see cref="ILoggerFactory"/>.</param>
         /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
-        public static IWebHostBuilder UseLoggerFactory(this IWebHostBuilder hostBuilder, Action<WebHostBuilderContext, LoggerFactory> configure)
+        public static IWebHostBuilder ConfigureLogging(this IWebHostBuilder hostBuilder, Action<WebHostBuilderContext, LoggerFactory> configureLogging)
         {
-            if (configure == null)
-            {
-                throw new ArgumentNullException(nameof(configure));
-            }
-
-            hostBuilder.UseLoggerFactory(context =>
-            {
-                var loggerFactory = new LoggerFactory();
-                configure(context, loggerFactory);
-                return loggerFactory;
-            });
-
+            hostBuilder.ConfigureLogging(configureLogging);
             return hostBuilder;
         }
+
+        /// <summary>
+        /// Adds a delegate for configuring the provided <see cref="ILoggerFactory"/>. This may be called multiple times.
+        /// </summary>
+        /// <param name="hostBuilder">The <see cref="IWebHostBuilder" /> to configure.</param>
+        /// <param name="configureLogging">The delegate that configures the <see cref="ILoggerFactory"/>.</param>
+        /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
+        public static IWebHostBuilder ConfigureLogging<T>(this IWebHostBuilder hostBuilder, Action<T> configureLogging) where T : ILoggerFactory
+        {
+            hostBuilder.ConfigureLogging<T>((_, factory) => configureLogging(factory));
+            return hostBuilder;
+        }
+
     }
 }

--- a/src/Microsoft.AspNetCore.Hosting/WebHostBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Hosting/WebHostBuilderExtensions.cs
@@ -28,14 +28,15 @@ namespace Microsoft.AspNetCore.Hosting
 
             var startupAssemblyName = configureApp.GetMethodInfo().DeclaringType.GetTypeInfo().Assembly.GetName().Name;
 
-            return hostBuilder.UseSetting(WebHostDefaults.ApplicationKey, startupAssemblyName)
-                              .ConfigureServices(services =>
-                              {
-                                  services.AddSingleton<IStartup>(sp =>
-                                  {
-                                      return new DelegateStartup(sp.GetRequiredService<IServiceProviderFactory<IServiceCollection>>(), configureApp);
-                                  });
-                              });
+            return hostBuilder
+                .UseSetting(WebHostDefaults.ApplicationKey, startupAssemblyName)
+                .ConfigureServices(services =>
+                {
+                    services.AddSingleton<IStartup>(sp =>
+                    {
+                        return new DelegateStartup(sp.GetRequiredService<IServiceProviderFactory<IServiceCollection>>(), configureApp);
+                    });
+                });
         }
 
 
@@ -49,22 +50,23 @@ namespace Microsoft.AspNetCore.Hosting
         {
             var startupAssemblyName = startupType.GetTypeInfo().Assembly.GetName().Name;
 
-            return hostBuilder.UseSetting(WebHostDefaults.ApplicationKey, startupAssemblyName)
-                              .ConfigureServices(services =>
-                              {
-                                  if (typeof(IStartup).GetTypeInfo().IsAssignableFrom(startupType.GetTypeInfo()))
-                                  {
-                                      services.AddSingleton(typeof(IStartup), startupType);
-                                  }
-                                  else
-                                  {
-                                      services.AddSingleton(typeof(IStartup), sp =>
-                                      {
-                                          var hostingEnvironment = sp.GetRequiredService<IHostingEnvironment>();
-                                          return new ConventionBasedStartup(StartupLoader.LoadMethods(sp, startupType, hostingEnvironment.EnvironmentName));
-                                      });
-                                  }
-                              });
+            return hostBuilder
+                .UseSetting(WebHostDefaults.ApplicationKey, startupAssemblyName)
+                .ConfigureServices(services =>
+                {
+                    if (typeof(IStartup).GetTypeInfo().IsAssignableFrom(startupType.GetTypeInfo()))
+                    {
+                        services.AddSingleton(typeof(IStartup), startupType);
+                    }
+                    else
+                    {
+                        services.AddSingleton(typeof(IStartup), sp =>
+                        {
+                            var hostingEnvironment = sp.GetRequiredService<IHostingEnvironment>();
+                            return new ConventionBasedStartup(StartupLoader.LoadMethods(sp, startupType, hostingEnvironment.EnvironmentName));
+                        });
+                    }
+                });
         }
 
         /// <summary>
@@ -102,8 +104,7 @@ namespace Microsoft.AspNetCore.Hosting
         /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
         public static IWebHostBuilder ConfigureLogging(this IWebHostBuilder hostBuilder, Action<WebHostBuilderContext, LoggerFactory> configureLogging)
         {
-            hostBuilder.ConfigureLogging(configureLogging);
-            return hostBuilder;
+            return hostBuilder.ConfigureLogging(configureLogging);
         }
 
         /// <summary>
@@ -114,9 +115,7 @@ namespace Microsoft.AspNetCore.Hosting
         /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
         public static IWebHostBuilder ConfigureLogging<T>(this IWebHostBuilder hostBuilder, Action<T> configureLogging) where T : ILoggerFactory
         {
-            hostBuilder.ConfigureLogging<T>((_, factory) => configureLogging(factory));
-            return hostBuilder;
+            return hostBuilder.ConfigureLogging<T>((_, factory) => configureLogging(factory));
         }
-
     }
 }

--- a/test/Microsoft.AspNetCore.Hosting.Tests/WebHostBuilderTests.cs
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/WebHostBuilderTests.cs
@@ -258,6 +258,29 @@ namespace Microsoft.AspNetCore.Hosting
         }
 
         [Fact]
+        public void HostingContextCanBeUsed()
+        {
+            var hostBuilder = new WebHostBuilder()
+                 .ConfigureAppConfiguration((context, configBuilder) => configBuilder
+                    .AddInMemoryCollection(
+                            new KeyValuePair<string, string>[]
+                            {
+                                new KeyValuePair<string, string>("key1", "value1")
+                            }))
+                 .ConfigureLogging((context, factory) =>
+                 {
+                     Assert.Equal("value1", context.Configuration["key1"]);
+                 })
+                 .UseServer(new TestServer())
+                 .UseStartup<StartupNoServices>();
+
+            hostBuilder.Build();
+
+            //Verify property on builder is set.
+            Assert.Equal("value1", hostBuilder.Context.Configuration["key1"]);
+        }
+
+        [Fact]
         public void ConfigureLoggingCalledIfLoggerFactoryTypeMatches()
         {
             var callCount = 0;
@@ -322,7 +345,7 @@ namespace Microsoft.AspNetCore.Hosting
         {
             var hostBuilder = new WebHostBuilder()
                 .UseSetting("key1", "value1")
-                .ConfigureConfiguration((context, configBuilder) =>
+                .ConfigureAppConfiguration((context, configBuilder) =>
                 {
                     var config = configBuilder.Build();
                     Assert.Equal("value1", config["key1"]);
@@ -336,7 +359,7 @@ namespace Microsoft.AspNetCore.Hosting
         public void CanConfigureConfigurationAndRetrieveFromDI()
         {
             var hostBuilder = new WebHostBuilder()
-                .ConfigureConfiguration((_, configBuilder) =>
+                .ConfigureAppConfiguration((_, configBuilder) =>
                 {
                     configBuilder
                         .AddInMemoryCollection(


### PR DESCRIPTION
Add Context to WebHostBuilder so that extension methods can get to it, and add some missing overloads.

I renamed `ConfigureConfiguration` here so I can get some more feedback on the name, since everyone seems to hate it but nobody has any better suggestions.