### PR TITLE
react to removal of PlatformAbstractions

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting/Microsoft.AspNetCore.Hosting.csproj
+++ b/src/Microsoft.AspNetCore.Hosting/Microsoft.AspNetCore.Hosting.csproj
@@ -26,7 +26,6 @@
     <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.RazorViews.Sources" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.RuntimeEnvironment.Sources" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.StackTrace.Sources" Version="$(AspNetCoreVersion)" PrivateAssets="All" />

--- a/src/Microsoft.AspNetCore.Hosting/WebHostBuilder.cs
+++ b/src/Microsoft.AspNetCore.Hosting/WebHostBuilder.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -15,7 +15,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.ObjectPool;
-using Microsoft.Extensions.PlatformAbstractions;
 
 namespace Microsoft.AspNetCore.Hosting
 {
@@ -274,9 +273,8 @@ namespace Microsoft.AspNetCore.Hosting
 
             _options = new WebHostOptions(_config);
 
-            var appEnvironment = PlatformServices.Default.Application;
-            var contentRootPath = ResolveContentRootPath(_options.ContentRootPath, appEnvironment.ApplicationBasePath);
-            var applicationName = _options.ApplicationName ?? appEnvironment.ApplicationName;
+            var contentRootPath = ResolveContentRootPath(_options.ContentRootPath, AppContext.BaseDirectory);
+            var applicationName = _options.ApplicationName;
 
             // Initialize the hosting environment
             _hostingEnvironment.Initialize(applicationName, contentRootPath, _options);

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/ApplicationDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/ApplicationDeployer.cs
@@ -5,11 +5,11 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Internal;
 using Microsoft.Extensions.Logging;
-using PlatformAbstractions = Microsoft.DotNet.PlatformAbstractions;
 
 namespace Microsoft.AspNetCore.Server.IntegrationTesting
 {
@@ -214,18 +214,35 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
 
         private string GetRuntimeIdentifier()
         {
-            var architecture = PlatformAbstractions.RuntimeEnvironment.RuntimeArchitecture;
-            switch (PlatformAbstractions.RuntimeEnvironment.OperatingSystemPlatform)
+            var architecture = GetArchitecture();
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                case PlatformAbstractions.Platform.Windows:
-                    return "win7-" + architecture;
-                case PlatformAbstractions.Platform.Linux:
-                    return "linux-" + architecture;
-                case PlatformAbstractions.Platform.Darwin:
-                    return "osx.10.12-" + architecture;
+                return "win7-" + architecture;
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return "linux-" + architecture;
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return "osx.10.12-" + architecture;
+            }
+            else
+            {
+                throw new InvalidOperationException("Unrecognized operation system platform");
+            }
+        }
+
+        private string GetArchitecture()
+        {
+            switch (RuntimeInformation.OSArchitecture)
+            {
+                case Architecture.X86:
+                    return "x86";
+                case Architecture.X64:
+                    return "x64";
                 default:
-                    throw new InvalidOperationException(
-                        "Unrecognized operation system platform: " + PlatformAbstractions.RuntimeEnvironment.OperatingSystemPlatform);
+                    throw new NotSupportedException($"Unsupported architecture: {RuntimeInformation.OSArchitecture}");
             }
         }
     }

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Microsoft.AspNetCore.Server.IntegrationTesting.csproj
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Microsoft.AspNetCore.Server.IntegrationTesting.csproj
@@ -23,8 +23,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Testing" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="$(DotNetPlatformAbstractionsVersion)" />
-    <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Process.Sources" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.RuntimeEnvironment.Sources" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETCore.Windows.ApiSets" Version="$(WindowsApiSetsVersion)" />

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/xunit/TestProjectHelpers.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/xunit/TestProjectHelpers.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.IO;
-using Microsoft.Extensions.PlatformAbstractions;
 
 namespace Microsoft.AspNetCore.Server.IntegrationTesting.xunit
 {
@@ -13,8 +12,7 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting.xunit
 
         public static string GetSolutionRoot()
         {
-            var applicationName = PlatformServices.Default.Application.ApplicationName;
-            var applicationBasePath = PlatformServices.Default.Application.ApplicationBasePath;
+            var applicationBasePath = AppContext.BaseDirectory;
 
             var directoryInfo = new DirectoryInfo(applicationBasePath);
             do

--- a/test/Microsoft.AspNetCore.Hosting.Tests/Microsoft.AspNetCore.Hosting.Tests.csproj
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/Microsoft.AspNetCore.Hosting.Tests.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Testing" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Testing" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />


### PR DESCRIPTION
Now ready to merge!

See the test changes for the major impact of this change. If you don't specify either `Configure` or `UseStartup`, you're going to get an exception that says "A valid non-empty application name must be provided.". If you work around this with `UseSetting` you'll still get an error because `IStartup` isn't present in the container. 

The only way to get in the situation where the "non-empty application name" message occurs when the app would otherwise start is if you manually insert an `IStartup` into the container. In which case, you should still get this error because we need an application name in order to proceed.