### PR TITLE
Remove PreferHostingUrls from options and read from config instead

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting/Internal/WebHost.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/WebHost.cs
@@ -261,7 +261,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                     var urls = _config[WebHostDefaults.ServerUrlsKey] ?? _config[DeprecatedServerUrlsKey];
                     if (!string.IsNullOrEmpty(urls))
                     {
-                        serverAddressesFeature.PreferHostingUrls = _options.PreferHostingUrls;
+                        serverAddressesFeature.PreferHostingUrls = WebHostUtilities.ParseBool(_config, WebHostDefaults.PreferHostingUrlsKey);
 
                         foreach (var value in urls.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries))
                         {

--- a/src/Microsoft.AspNetCore.Hosting/Internal/WebHostOptions.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/WebHostOptions.cs
@@ -21,16 +21,15 @@ namespace Microsoft.AspNetCore.Hosting.Internal
 
             ApplicationName = configuration[WebHostDefaults.ApplicationKey];
             StartupAssembly = configuration[WebHostDefaults.StartupAssemblyKey];
-            DetailedErrors = ParseBool(configuration, WebHostDefaults.DetailedErrorsKey);
-            CaptureStartupErrors = ParseBool(configuration, WebHostDefaults.CaptureStartupErrorsKey);
+            DetailedErrors = WebHostUtilities.ParseBool(configuration, WebHostDefaults.DetailedErrorsKey);
+            CaptureStartupErrors = WebHostUtilities.ParseBool(configuration, WebHostDefaults.CaptureStartupErrorsKey);
             Environment = configuration[WebHostDefaults.EnvironmentKey];
             WebRoot = configuration[WebHostDefaults.WebRootKey];
             ContentRootPath = configuration[WebHostDefaults.ContentRootKey];
-            PreventHostingStartup = ParseBool(configuration, WebHostDefaults.PreventHostingStartupKey);
+            PreventHostingStartup = WebHostUtilities.ParseBool(configuration, WebHostDefaults.PreventHostingStartupKey);
             // Search the primary assembly and configured assemblies.
             HostingStartupAssemblies = $"{ApplicationName};{configuration[WebHostDefaults.HostingStartupAssembliesKey]}"
                 .Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries) ?? new string[0];
-            PreferHostingUrls = ParseBool(configuration, WebHostDefaults.PreferHostingUrlsKey);
 
             var timeout = configuration[WebHostDefaults.ShutdownTimeoutKey];
             if (!string.IsNullOrEmpty(timeout)
@@ -58,14 +57,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
 
         public string ContentRootPath { get; set; }
 
-        public bool PreferHostingUrls { get; set; }
-
         public TimeSpan ShutdownTimeout { get; set; } = TimeSpan.FromSeconds(5);
 
-        private static bool ParseBool(IConfiguration configuration, string key)
-        {
-            return string.Equals("true", configuration[key], StringComparison.OrdinalIgnoreCase)
-                || string.Equals("1", configuration[key], StringComparison.OrdinalIgnoreCase);
-        }
     }
 }

--- a/src/Microsoft.AspNetCore.Hosting/Internal/WebHostUtilities.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/WebHostUtilities.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.Configuration;
+
+namespace Microsoft.AspNetCore.Hosting.Internal
+{
+    public class WebHostUtilities
+    {
+        public static bool ParseBool(IConfiguration configuration, string key)
+        {
+            return string.Equals("true", configuration[key], StringComparison.OrdinalIgnoreCase)
+                || string.Equals("1", configuration[key], StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Hosting.Tests/WebHostConfigurationsTests.cs
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/WebHostConfigurationsTests.cs
@@ -20,8 +20,7 @@ namespace Microsoft.AspNetCore.Hosting.Tests
                 { "startupAssembly", "MyProjectReference" },
                 { "environment", "Development"},
                 { "detailederrors", "true"},
-                { "captureStartupErrors", "true" },
-                { "preferHostingUrls", "true" }
+                { "captureStartupErrors", "true" }
             };
 
             var config = new WebHostOptions(new ConfigurationBuilder().AddInMemoryCollection(parameters).Build());
@@ -32,7 +31,6 @@ namespace Microsoft.AspNetCore.Hosting.Tests
             Assert.Equal("Development", config.Environment);
             Assert.True(config.CaptureStartupErrors);
             Assert.True(config.DetailedErrors);
-            Assert.True(config.PreferHostingUrls);
         }
 
         [Fact]


### PR DESCRIPTION
https://github.com/aspnet/Hosting/issues/1045

From the issue:
Now that UseIISIntegration is planned to be called from the hosting startup assembly, this means that the options will be out of date when we read from it in EnsureServer(). The config is always up to date so we should use that to set the PreferHostingUrls property on the IServerAddressesFeature instead. This is currently what we do for server urls due to the same reason and it works.