### PR TITLE
Run IHostingStartup's before materializing IConfiguration

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting/WebHostBuilder.cs
+++ b/src/Microsoft.AspNetCore.Hosting/WebHostBuilder.cs
@@ -280,14 +280,6 @@ namespace Microsoft.AspNetCore.Hosting
             _hostingEnvironment.Initialize(applicationName, contentRootPath, _options);
             _context.HostingEnvironment = _hostingEnvironment;
 
-            var services = new ServiceCollection();
-            services.AddSingleton(_hostingEnvironment);
-            services.AddSingleton(_context);
-
-            var builder = new ConfigurationBuilder()
-                .SetBasePath(_hostingEnvironment.ContentRootPath)
-                .AddInMemoryCollection(_config.AsEnumerable());
-
             if (!_options.PreventHostingStartup)
             {
                 var exceptions = new List<Exception>();
@@ -323,6 +315,14 @@ namespace Microsoft.AspNetCore.Hosting
                     }
                 }
             }
+
+            var services = new ServiceCollection();
+            services.AddSingleton(_hostingEnvironment);
+            services.AddSingleton(_context);
+
+            var builder = new ConfigurationBuilder()
+                .SetBasePath(_hostingEnvironment.ContentRootPath)
+                .AddInMemoryCollection(_config.AsEnumerable());
 
             foreach (var configureAppConfiguration in _configureAppConfigurationBuilderDelegates)
             {

--- a/src/Microsoft.AspNetCore.Hosting/WebHostBuilder.cs
+++ b/src/Microsoft.AspNetCore.Hosting/WebHostBuilder.cs
@@ -338,8 +338,6 @@ namespace Microsoft.AspNetCore.Hosting
             services.AddSingleton(loggerFactory);
             _context.LoggerFactory = loggerFactory;
 
-
-
             foreach (var configureLogging in _configureLoggingDelegates)
             {
                 configureLogging(_context, loggerFactory);

--- a/src/Microsoft.AspNetCore.Hosting/WebHostBuilder.cs
+++ b/src/Microsoft.AspNetCore.Hosting/WebHostBuilder.cs
@@ -288,20 +288,6 @@ namespace Microsoft.AspNetCore.Hosting
                 .SetBasePath(_hostingEnvironment.ContentRootPath)
                 .AddInMemoryCollection(_config.AsEnumerable());
 
-            foreach (var configureAppConfiguration in _configureAppConfigurationBuilderDelegates)
-            {
-                configureAppConfiguration(_context, builder);
-            }
-
-            var configuration = builder.Build();
-            services.AddSingleton<IConfiguration>(configuration);
-            _context.Configuration = configuration;
-
-            // The configured ILoggerFactory is added as a singleton here. AddLogging below will not add an additional one.
-            var loggerFactory = _createLoggerFactoryDelegate?.Invoke(_context) ?? new LoggerFactory(configuration.GetSection("Logging"));
-            services.AddSingleton(loggerFactory);
-            _context.LoggerFactory = loggerFactory;
-
             if (!_options.PreventHostingStartup)
             {
                 var exceptions = new List<Exception>();
@@ -337,6 +323,22 @@ namespace Microsoft.AspNetCore.Hosting
                     }
                 }
             }
+
+            foreach (var configureAppConfiguration in _configureAppConfigurationBuilderDelegates)
+            {
+                configureAppConfiguration(_context, builder);
+            }
+
+            var configuration = builder.Build();
+            services.AddSingleton<IConfiguration>(configuration);
+            _context.Configuration = configuration;
+
+            // The configured ILoggerFactory is added as a singleton here. AddLogging below will not add an additional one.
+            var loggerFactory = _createLoggerFactoryDelegate?.Invoke(_context) ?? new LoggerFactory(configuration.GetSection("Logging"));
+            services.AddSingleton(loggerFactory);
+            _context.LoggerFactory = loggerFactory;
+
+
 
             foreach (var configureLogging in _configureLoggingDelegates)
             {

--- a/src/Microsoft.AspNetCore.Hosting/WebHostBuilder.cs
+++ b/src/Microsoft.AspNetCore.Hosting/WebHostBuilder.cs
@@ -273,13 +273,6 @@ namespace Microsoft.AspNetCore.Hosting
 
             _options = new WebHostOptions(_config);
 
-            var contentRootPath = ResolveContentRootPath(_options.ContentRootPath, AppContext.BaseDirectory);
-            var applicationName = _options.ApplicationName;
-
-            // Initialize the hosting environment
-            _hostingEnvironment.Initialize(applicationName, contentRootPath, _options);
-            _context.HostingEnvironment = _hostingEnvironment;
-
             if (!_options.PreventHostingStartup)
             {
                 var exceptions = new List<Exception>();
@@ -315,6 +308,13 @@ namespace Microsoft.AspNetCore.Hosting
                     }
                 }
             }
+
+            var contentRootPath = ResolveContentRootPath(_options.ContentRootPath, AppContext.BaseDirectory);
+            var applicationName = _options.ApplicationName;
+
+            // Initialize the hosting environment
+            _hostingEnvironment.Initialize(applicationName, contentRootPath, _options);
+            _context.HostingEnvironment = _hostingEnvironment;
 
             var services = new ServiceCollection();
             services.AddSingleton(_hostingEnvironment);

--- a/test/Microsoft.AspNetCore.Hosting.Tests/WebHostBuilderTests.cs
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/WebHostBuilderTests.cs
@@ -932,6 +932,21 @@ namespace Microsoft.AspNetCore.Hosting
         }
 
         [Fact]
+        public void Build_ConfigureAppConfigurationInHostingStartupWorks()
+        {
+            var builder = CreateWebHostBuilder()
+                .CaptureStartupErrors(false)
+                .Configure(app => { })
+                .UseServer(new TestServer());
+
+            using (var host = (WebHost)builder.Build())
+            {
+                var configuration = host.Services.GetRequiredService<IConfiguration>();
+                Assert.Equal("value", configuration["testhostingstartup:config"]);
+            }
+        }
+
+        [Fact]
         public void Build_DoesRunHostingStartupFromPrimaryAssemblyEvenIfNotSpecified()
         {
             var builder = CreateWebHostBuilder()
@@ -1089,7 +1104,12 @@ namespace Microsoft.AspNetCore.Hosting
                        .UseSetting("testhostingstartup_chain", builder.GetSetting("testhostingstartup_chain") + "0")
                        .ConfigureServices(services => services.AddSingleton<ServiceA>())
                        .ConfigureServices(services => services.AddSingleton<ITestSink>(loggerProvider.Sink))
-                       .ConfigureLogging(lf => lf.AddProvider(loggerProvider));
+                       .ConfigureLogging(lf => lf.AddProvider(loggerProvider))
+                       .ConfigureAppConfiguration((context, configurationBuilder) => configurationBuilder.AddInMemoryCollection(
+                           new []
+                           {
+                               new KeyValuePair<string,string>("testhostingstartup:config", "value")
+                           }));
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/aspnet/Hosting/issues/1050

This change should be safe because we don't have any hosting startups that register configuration (or they would have found this bug before) and we are not passing ``IConfiguration into `IHostingStartup` in any way.

/cc @muratg -  approval required