### PR TITLE
Prevent IISExpressDeployer.Dispose nullref if the process failed to start

### DIFF
--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/IISExpressDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/IISExpressDeployer.cs
@@ -301,7 +301,7 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
 
             // If by this point, the host process is still running (somehow), throw an error.
             // A test failure is better than a silent hang and unknown failure later on
-            if (!_hostProcess.HasExited)
+            if (_hostProcess != null && !_hostProcess.HasExited)
             {
                 throw new Exception($"iisexpress Process {_hostProcess.Id} failed to shutdown");
             }


### PR DESCRIPTION
#1053 This is a secondary exception that's hiding the real error when we failed to start the IISExpress process. We need to fix this so we can find out what the original failure was.