### PR TITLE
Target NETStandard2.0 TFM

### DIFF
--- a/Hosting.sln
+++ b/Hosting.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26228.9
+VisualStudioVersion = 15.0.26510.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E0497F39-AFFB-4819-A116-E39E361915AB}"
 EndProject
@@ -31,6 +31,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestStartupAssembly1", "test\TestStartupAssembly1\TestStartupAssembly1.csproj", "{39D3B138-37DB-4D03-A5A0-3F2B02EFC671}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Hosting.Abstractions", "src\Microsoft.Extensions.Hosting.Abstractions\Microsoft.Extensions.Hosting.Abstractions.csproj", "{96BC7EEA-64D9-4DA5-8E87-1C18CBFE7D12}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Hosting.WindowsServices", "src\Microsoft.AspNetCore.Hosting.WindowsServices\Microsoft.AspNetCore.Hosting.WindowsServices.csproj", "{9C93A93B-270A-4785-8F41-46C38DC33825}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -178,6 +180,18 @@ Global
 		{96BC7EEA-64D9-4DA5-8E87-1C18CBFE7D12}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{96BC7EEA-64D9-4DA5-8E87-1C18CBFE7D12}.Release|x86.ActiveCfg = Release|Any CPU
 		{96BC7EEA-64D9-4DA5-8E87-1C18CBFE7D12}.Release|x86.Build.0 = Release|Any CPU
+		{9C93A93B-270A-4785-8F41-46C38DC33825}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9C93A93B-270A-4785-8F41-46C38DC33825}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9C93A93B-270A-4785-8F41-46C38DC33825}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{9C93A93B-270A-4785-8F41-46C38DC33825}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{9C93A93B-270A-4785-8F41-46C38DC33825}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9C93A93B-270A-4785-8F41-46C38DC33825}.Debug|x86.Build.0 = Debug|Any CPU
+		{9C93A93B-270A-4785-8F41-46C38DC33825}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9C93A93B-270A-4785-8F41-46C38DC33825}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9C93A93B-270A-4785-8F41-46C38DC33825}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{9C93A93B-270A-4785-8F41-46C38DC33825}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{9C93A93B-270A-4785-8F41-46C38DC33825}.Release|x86.ActiveCfg = Release|Any CPU
+		{9C93A93B-270A-4785-8F41-46C38DC33825}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -195,5 +209,6 @@ Global
 		{542D4600-B232-4B17-A08C-E31EBFA0D74E} = {FEB39027-9158-4DE2-997F-7ADAEF8188D0}
 		{39D3B138-37DB-4D03-A5A0-3F2B02EFC671} = {FEB39027-9158-4DE2-997F-7ADAEF8188D0}
 		{96BC7EEA-64D9-4DA5-8E87-1C18CBFE7D12} = {E0497F39-AFFB-4819-A116-E39E361915AB}
+		{9C93A93B-270A-4785-8F41-46C38DC33825} = {E0497F39-AFFB-4819-A116-E39E361915AB}
 	EndGlobalSection
 EndGlobal

--- a/build/common.props
+++ b/build/common.props
@@ -16,8 +16,8 @@
     <PackageReference Include="Internal.AspNetCore.Sdk" Version="$(InternalAspNetCoreSdkVersion)" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)'=='.NETFramework' AND '$(OutputType)'=='library'">
-    <PackageReference Include="NETStandard.Library" Version="$(BundledNETStandardPackageVersion)" />
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)'=='.NETFramework'">
+    <PackageReference Include="NETStandard.Library.NETFramework" Version="$(NETStandardLibraryNETFrameworkVersion)" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -3,6 +3,8 @@
     <AspNetCoreVersion>2.0.0-*</AspNetCoreVersion>
     <InternalAspNetCoreSdkVersion>2.1.0-*</InternalAspNetCoreSdkVersion>
     <NETStandardImplicitPackageVersion>$(BundledNETStandardPackageVersion)</NETStandardImplicitPackageVersion>
+    <NETStandardLibraryNETFrameworkVersion>2.0.0-*</NETStandardLibraryNETFrameworkVersion>
+    <SystemDiagnosticsDiagnosticSourceVersion>4.4.0-*</SystemDiagnosticsDiagnosticSourceVersion>
     <TestSdkVersion>15.3.0-*</TestSdkVersion>
     <WindowsApiSetsVersion>1.0.1</WindowsApiSetsVersion>
     <XunitVersion>2.3.0-beta2-*</XunitVersion>

--- a/samples/SampleStartups/SampleStartups.csproj
+++ b/samples/SampleStartups/SampleStartups.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\build\dependencies.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
     <StartupObject>SampleStartups.StartupInjection</StartupObject>
     <OutputType>exe</OutputType>
   </PropertyGroup>
@@ -18,4 +18,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)'=='net461'">
+    <PackageReference Include="NETStandard.Library.NETFramework" Version="$(NETStandardLibraryNETFrameworkVersion)" />
+  </ItemGroup>
 </Project>

--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/Microsoft.AspNetCore.Hosting.Abstractions.csproj
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/Microsoft.AspNetCore.Hosting.Abstractions.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Description>ASP.NET Core hosting and startup abstractions for web applications.</Description>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore;hosting</PackageTags>

--- a/src/Microsoft.AspNetCore.Hosting.Server.Abstractions/Microsoft.AspNetCore.Hosting.Server.Abstractions.csproj
+++ b/src/Microsoft.AspNetCore.Hosting.Server.Abstractions/Microsoft.AspNetCore.Hosting.Server.Abstractions.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Description>ASP.NET Core hosting server abstractions for web applications.</Description>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore;hosting</PackageTags>

--- a/src/Microsoft.AspNetCore.Hosting.WindowsServices/Microsoft.AspNetCore.Hosting.WindowsServices.csproj
+++ b/src/Microsoft.AspNetCore.Hosting.WindowsServices/Microsoft.AspNetCore.Hosting.WindowsServices.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\..\build\common.props" />
+
+  <PropertyGroup>
+    <Description>ASP.NET Core hosting infrastructure and startup logic for web applications running within a Windows service.</Description>
+    <TargetFramework>net461</TargetFramework>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageTags>aspnetcore;hosting</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.AspNetCore.Hosting\Microsoft.AspNetCore.Hosting.csproj" />
+    <PackageReference Include="NETStandard.Library.NETFramework" Version="$(NETStandardLibraryNETFrameworkVersion)" />
+    <Reference Include="System.ServiceProcess" />
+  </ItemGroup>
+
+</Project>

--- a/src/Microsoft.AspNetCore.Hosting.WindowsServices/WebHostService.cs
+++ b/src/Microsoft.AspNetCore.Hosting.WindowsServices/WebHostService.cs
@@ -1,0 +1,76 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.ServiceProcess;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.AspNetCore.Hosting.WindowsServices
+{
+    /// <summary>
+    ///     Provides an implementation of a Windows service that hosts ASP.NET Core.
+    /// </summary>
+    public class WebHostService : ServiceBase
+    {
+        private IWebHost _host;
+        private bool _stopRequestedByWindows;
+
+        /// <summary>
+        /// Creates an instance of <c>WebHostService</c> which hosts the specified web application.
+        /// </summary>
+        /// <param name="host">The configured web host containing the web application to host in the Windows service.</param>
+        public WebHostService(IWebHost host)
+        {
+            _host = host;
+        }
+
+        protected sealed override void OnStart(string[] args)
+        {
+            OnStarting(args);
+
+            _host
+                .Services
+                .GetRequiredService<IApplicationLifetime>()
+                .ApplicationStopped
+                .Register(() =>
+                {
+                    if (!_stopRequestedByWindows)
+                    {
+                        Stop();
+                    }
+                });
+
+            _host.Start();
+
+            OnStarted();
+        }
+
+        protected sealed override void OnStop()
+        {
+            _stopRequestedByWindows = true;
+            OnStopping();
+            _host?.Dispose();
+            OnStopped();
+        }
+
+        /// <summary>
+        /// Executes before ASP.NET Core starts.
+        /// </summary>
+        /// <param name="args">The command line arguments passed to the service.</param>
+        protected virtual void OnStarting(string[] args) { }
+
+        /// <summary>
+        /// Executes after ASP.NET Core starts.
+        /// </summary>
+        protected virtual void OnStarted() { }
+
+        /// <summary>
+        /// Executes before ASP.NET Core shuts down.
+        /// </summary>
+        protected virtual void OnStopping() { }
+
+        /// <summary>
+        /// Executes after ASP.NET Core shuts down.
+        /// </summary>
+        protected virtual void OnStopped() { }
+    }
+}

--- a/src/Microsoft.AspNetCore.Hosting.WindowsServices/WebHostWindowsServiceExtensions.cs
+++ b/src/Microsoft.AspNetCore.Hosting.WindowsServices/WebHostWindowsServiceExtensions.cs
@@ -1,0 +1,42 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.ServiceProcess;
+
+namespace Microsoft.AspNetCore.Hosting.WindowsServices
+{
+    /// <summary>
+    ///     Extensions to <see cref="IWebHost"/> for hosting inside a Windows service.
+    /// </summary>
+    public static class WebHostWindowsServiceExtensions
+    {
+        /// <summary>
+        ///     Runs the specified web application inside a Windows service and blocks until the service is stopped.
+        /// </summary>
+        /// <param name="host">An instance of the <see cref="IWebHost"/> to host in the Windows service.</param>
+        /// <example>
+        ///     This example shows how to use <see cref="RunAsService"/>.
+        ///     <code>
+        ///         public class Program
+        ///         {
+        ///             public static void Main(string[] args)
+        ///             {
+        ///                 var config = WebHostConfiguration.GetDefault(args);
+        ///                 
+        ///                 var host = new WebHostBuilder()
+        ///                     .UseConfiguration(config)
+        ///                     .Build();
+        ///          
+        ///                 // This call will block until the service is stopped.
+        ///                 host.RunAsService();
+        ///             }
+        ///         }
+        ///     </code>
+        /// </example>
+        public static void RunAsService(this IWebHost host)
+        {
+            var webHostService = new WebHostService(host);
+            ServiceBase.Run(webHostService);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Hosting.WindowsServices/baseline.netframework.json
+++ b/src/Microsoft.AspNetCore.Hosting.WindowsServices/baseline.netframework.json
@@ -1,0 +1,122 @@
+{
+  "AssemblyIdentity": "Microsoft.AspNetCore.Hosting.WindowsServices, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60",
+  "Types": [
+    {
+      "Name": "Microsoft.AspNetCore.Hosting.WindowsServices.WebHostService",
+      "Visibility": "Public",
+      "Kind": "Class",
+      "BaseType": "System.ServiceProcess.ServiceBase",
+      "ImplementedInterfaces": [],
+      "Members": [
+        {
+          "Kind": "Method",
+          "Name": "OnStart",
+          "Parameters": [
+            {
+              "Name": "args",
+              "Type": "System.String[]"
+            }
+          ],
+          "ReturnType": "System.Void",
+          "Sealed": true,
+          "Virtual": true,
+          "Override": true,
+          "Visibility": "Protected",
+          "GenericParameter": []
+        },
+        {
+          "Kind": "Method",
+          "Name": "OnStop",
+          "Parameters": [],
+          "ReturnType": "System.Void",
+          "Sealed": true,
+          "Virtual": true,
+          "Override": true,
+          "Visibility": "Protected",
+          "GenericParameter": []
+        },
+        {
+          "Kind": "Method",
+          "Name": "OnStarting",
+          "Parameters": [
+            {
+              "Name": "args",
+              "Type": "System.String[]"
+            }
+          ],
+          "ReturnType": "System.Void",
+          "Virtual": true,
+          "Visibility": "Protected",
+          "GenericParameter": []
+        },
+        {
+          "Kind": "Method",
+          "Name": "OnStarted",
+          "Parameters": [],
+          "ReturnType": "System.Void",
+          "Virtual": true,
+          "Visibility": "Protected",
+          "GenericParameter": []
+        },
+        {
+          "Kind": "Method",
+          "Name": "OnStopping",
+          "Parameters": [],
+          "ReturnType": "System.Void",
+          "Virtual": true,
+          "Visibility": "Protected",
+          "GenericParameter": []
+        },
+        {
+          "Kind": "Method",
+          "Name": "OnStopped",
+          "Parameters": [],
+          "ReturnType": "System.Void",
+          "Virtual": true,
+          "Visibility": "Protected",
+          "GenericParameter": []
+        },
+        {
+          "Kind": "Constructor",
+          "Name": ".ctor",
+          "Parameters": [
+            {
+              "Name": "host",
+              "Type": "Microsoft.AspNetCore.Hosting.IWebHost"
+            }
+          ],
+          "Visibility": "Public",
+          "GenericParameter": []
+        }
+      ],
+      "GenericParameters": []
+    },
+    {
+      "Name": "Microsoft.AspNetCore.Hosting.WindowsServices.WebHostWindowsServiceExtensions",
+      "Visibility": "Public",
+      "Kind": "Class",
+      "Abstract": true,
+      "Static": true,
+      "Sealed": true,
+      "ImplementedInterfaces": [],
+      "Members": [
+        {
+          "Kind": "Method",
+          "Name": "RunAsService",
+          "Parameters": [
+            {
+              "Name": "host",
+              "Type": "Microsoft.AspNetCore.Hosting.IWebHost"
+            }
+          ],
+          "ReturnType": "System.Void",
+          "Static": true,
+          "Extension": true,
+          "Visibility": "Public",
+          "GenericParameter": []
+        }
+      ],
+      "GenericParameters": []
+    }
+  ]
+}

--- a/src/Microsoft.AspNetCore.Hosting/Microsoft.AspNetCore.Hosting.csproj
+++ b/src/Microsoft.AspNetCore.Hosting/Microsoft.AspNetCore.Hosting.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Description>ASP.NET Core hosting infrastructure and startup logic for web applications.</Description>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore;hosting</PackageTags>
@@ -29,6 +29,7 @@
     <PackageReference Include="Microsoft.Extensions.RazorViews.Sources" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.StackTrace.Sources" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.TypeNameHelper.Sources" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(SystemDiagnosticsDiagnosticSourceVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.AspNetCore.Hosting/WebHostExtensions.cs
+++ b/src/Microsoft.AspNetCore.Hosting/WebHostExtensions.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Reflection;
-using System.Runtime.Loader;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting.Server.Features;
@@ -90,8 +89,7 @@ namespace Microsoft.AspNetCore.Hosting
                     done.Wait();
                 };
 
-                var assemblyLoadContext = AssemblyLoadContext.GetLoadContext(typeof(WebHostExtensions).GetTypeInfo().Assembly);
-                assemblyLoadContext.Unloading += context => shutdown();
+                AppDomain.CurrentDomain.ProcessExit += (sender, eventArgs) => shutdown();
                 Console.CancelKeyPress += (sender, eventArgs) =>
                 {
                     shutdown();

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Microsoft.AspNetCore.Server.IntegrationTesting.csproj
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Microsoft.AspNetCore.Server.IntegrationTesting.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <Description>ASP.NET Core helpers to deploy applications to IIS Express, IIS, WebListener and Kestrel for testing.</Description>
     <VersionPrefix>0.4.0</VersionPrefix>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore;testing</PackageTags>

--- a/src/Microsoft.AspNetCore.TestHost/Microsoft.AspNetCore.TestHost.csproj
+++ b/src/Microsoft.AspNetCore.TestHost/Microsoft.AspNetCore.TestHost.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Description>ASP.NET Core web server for writing and running tests.</Description>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore;hosting;testing</PackageTags>

--- a/src/Microsoft.Extensions.Hosting.Abstractions/Microsoft.Extensions.Hosting.Abstractions.csproj
+++ b/src/Microsoft.Extensions.Hosting.Abstractions/Microsoft.Extensions.Hosting.Abstractions.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Description>.NET Core hosting and startup abstractions for applications.</Description>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>hosting</PackageTags>

--- a/test/Microsoft.AspNetCore.Hosting.FunctionalTests/Microsoft.AspNetCore.Hosting.FunctionalTests.csproj
+++ b/test/Microsoft.AspNetCore.Hosting.FunctionalTests/Microsoft.AspNetCore.Hosting.FunctionalTests.csproj
@@ -3,7 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.AspNetCore.Hosting.TestSites/Microsoft.AspNetCore.Hosting.TestSites.csproj
+++ b/test/Microsoft.AspNetCore.Hosting.TestSites/Microsoft.AspNetCore.Hosting.TestSites.csproj
@@ -3,7 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/test/Microsoft.AspNetCore.Hosting.Tests/Microsoft.AspNetCore.Hosting.Tests.csproj
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/Microsoft.AspNetCore.Hosting.Tests.csproj
@@ -3,7 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.AspNetCore.TestHost.Tests/Microsoft.AspNetCore.TestHost.Tests.csproj
+++ b/test/Microsoft.AspNetCore.TestHost.Tests/Microsoft.AspNetCore.TestHost.Tests.csproj
@@ -3,7 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/TestStartupAssembly1/TestStartupAssembly1.csproj
+++ b/test/TestStartupAssembly1/TestStartupAssembly1.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Bringing back Microsoft.AspNetCore.Hosting.WindowsServices. (Will update coherence packages.csv)
Cross-compiling M.A.Hosting for `netcoreapp2.0` and `netstandard2.0` since it needs System.Runtime.Loader which is a netcoreapp only package.

cc @Eilon @DamianEdwards 