### PR TITLE
Fix tests not running as expected

### DIFF
--- a/test/Microsoft.AspNetCore.Hosting.Tests/WebHostTests.cs
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/WebHostTests.cs
@@ -203,10 +203,12 @@ namespace Microsoft.AspNetCore.Hosting
 
             var server = new Mock<IServer>();
             server.Setup(s => s.StopAsync(It.IsAny<CancellationToken>()))
-                .Returns(Task.CompletedTask)
-                .Callback<CancellationToken>(token =>
+                .Returns<CancellationToken>(token =>
                 {
-                    token.WaitHandle.WaitOne();
+                    return Task.Run(() =>
+                    {
+                        token.WaitHandle.WaitOne();
+                    });
                 });
 
             using (var host = CreateBuilder(config)
@@ -240,10 +242,12 @@ namespace Microsoft.AspNetCore.Hosting
 
             var server = new Mock<IServer>();
             server.Setup(s => s.StopAsync(It.IsAny<CancellationToken>()))
-                .Returns(Task.CompletedTask)
-                .Callback<CancellationToken>(token =>
+                .Returns<CancellationToken>(token =>
                 {
-                    token.WaitHandle.WaitOne();
+                    return Task.Run(() =>
+                    {
+                        token.WaitHandle.WaitOne();
+                    });
                 });
 
             using (var host = CreateBuilder(config)
@@ -274,10 +278,12 @@ namespace Microsoft.AspNetCore.Hosting
 
             var server = new Mock<IServer>();
             server.Setup(s => s.StopAsync(It.IsAny<CancellationToken>()))
-                .Returns(Task.CompletedTask)
-                .Callback<CancellationToken>(token =>
+                .Returns<CancellationToken>(token =>
                 {
-                    token.WaitHandle.WaitOne();
+                    return Task.Run(() =>
+                    {
+                        token.WaitHandle.WaitOne();
+                    });
                 });
 
             using (var host = CreateBuilder(config)


### PR DESCRIPTION
The `Callback` in Moq was locking until the default timeout occurred which meant `IWebHost.StopAsync` wasn't returning until after the callback finished. Defeating the whole point of the tests.