### PR TITLE
Add "--no-restore" parameter to "dotnet publish"

### DIFF
--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/ApplicationDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/ApplicationDeployer.cs
@@ -56,6 +56,11 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
                     + $" --framework {DeploymentParameters.TargetFramework}"
                     + $" --configuration {DeploymentParameters.Configuration}";
 
+                // Workaround for:
+                //   "dotnet publish -f" fails on app with project reference to netstandard2.0 class library
+                //   https://github.com/dotnet/cli/issues/6843
+                parameters += " --no-restore"
+
                 if (DeploymentParameters.ApplicationType == ApplicationType.Standalone)
                 {
                     parameters += $" --runtime {GetRuntimeIdentifier()}";

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/ApplicationDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/ApplicationDeployer.cs
@@ -59,7 +59,7 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
                 // Workaround for:
                 //   Publish fails on app with project reference to netstandard2.0 class library
                 //   https://github.com/dotnet/cli/issues/6843
-                parameters += " --no-restore"
+                parameters += " --no-restore";
 
                 if (DeploymentParameters.ApplicationType == ApplicationType.Standalone)
                 {

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/ApplicationDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/ApplicationDeployer.cs
@@ -57,7 +57,7 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
                     + $" --configuration {DeploymentParameters.Configuration}";
 
                 // Workaround for:
-                //   "dotnet publish -f" fails on app with project reference to netstandard2.0 class library
+                //   Publish fails on app with project reference to netstandard2.0 class library
                 //   https://github.com/dotnet/cli/issues/6843
                 parameters += " --no-restore"
 


### PR DESCRIPTION
- Workaround for "Publish fails on app with project reference to netstandard2.0 class library" (https://github.com/dotnet/cli/issues/6843)