### PR TITLE
Create a scoped service provider for the call to Configure

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting/Internal/StartupLoader.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/StartupLoader.cs
@@ -60,7 +60,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                 return applicationServiceProvider ?? services.BuildServiceProvider();
             };
 
-            return new StartupMethods(configureMethod.Build(instance), configureServices);
+            return new StartupMethods(instance, configureMethod.Build(instance), configureServices);
         }
 
         public static Type FindStartupType(string startupAssemblyName, string environmentName)

--- a/src/Microsoft.AspNetCore.Hosting/Internal/StartupMethods.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/StartupMethods.cs
@@ -10,15 +10,17 @@ namespace Microsoft.AspNetCore.Hosting.Internal
 {
     public class StartupMethods
     {
-        public StartupMethods(Action<IApplicationBuilder> configure, Func<IServiceCollection, IServiceProvider> configureServices)
+        public StartupMethods(object instance, Action<IApplicationBuilder> configure, Func<IServiceCollection, IServiceProvider> configureServices)
         {
             Debug.Assert(configure != null);
             Debug.Assert(configureServices != null);
 
+            StartupInstance = instance;
             ConfigureDelegate = configure;
             ConfigureServicesDelegate = configureServices;
         }
 
+        public object StartupInstance { get; }
         public Func<IServiceCollection, IServiceProvider> ConfigureServicesDelegate { get; }
         public Action<IApplicationBuilder> ConfigureDelegate { get; }
 

--- a/test/Microsoft.AspNetCore.Hosting.Tests/Fakes/StartupWithScopedServices.cs
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/Fakes/StartupWithScopedServices.cs
@@ -4,13 +4,15 @@ using System.Text;
 using Microsoft.AspNetCore.Builder;
 using static Microsoft.AspNetCore.Hosting.Tests.StartupManagerTests;
 
-namespace Microsoft.AspNetCore.Hosting.Tests.Fakes
+namespace Microsoft.AspNetCore.Hosting.Fakes
 {
     public class StartupWithScopedServices
     {
+        public DisposableService DisposableService { get; set; }
+
         public void Configure(IApplicationBuilder builder, DisposableService disposable)
         {
-
+            DisposableService = disposable;
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Hosting.Tests/Fakes/StartupWithScopedServices.cs
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/Fakes/StartupWithScopedServices.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.AspNetCore.Builder;
+using static Microsoft.AspNetCore.Hosting.Tests.StartupManagerTests;
+
+namespace Microsoft.AspNetCore.Hosting.Tests.Fakes
+{
+    public class StartupWithScopedServices
+    {
+        public void Configure(IApplicationBuilder builder, DisposableService disposable)
+        {
+
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Hosting.Tests/StartupManagerTests.cs
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/StartupManagerTests.cs
@@ -50,10 +50,15 @@ namespace Microsoft.AspNetCore.Hosting.Tests
 
             var type = StartupLoader.FindStartupType("Microsoft.AspNetCore.Hosting.Tests", "WithScopedServices");
             var startup = StartupLoader.LoadMethods(services, type, "WithScopedServices");
+            Assert.NotNull(startup.StartupInstance);
 
             var app = new ApplicationBuilder(services);
             app.ApplicationServices = startup.ConfigureServicesDelegate(serviceCollection);
             startup.ConfigureDelegate(app);
+
+            var instance = (StartupWithScopedServices)startup.StartupInstance;
+            Assert.NotNull(instance.DisposableService);
+            Assert.True(instance.DisposableService.Disposed);
         }
 
         [Theory]


### PR DESCRIPTION
- This allows scoped dependencies to be injected into the Configure method.
It means you can resolve the DbContext or any other scoped service without
the hassle of the CreateScope boiler plate. As a side effect, it also makes
Startup.Configure a bit more testable.

Inspired by issues like https://github.com/aspnet/Mvc/issues/6407 and code like in our template that needs to create a scope in order to run db init logic.

One downside of this change. If you hold onto scoped services past the `Configure` method, they'll explode later. While this would have exploded by default in the new templates, it now works.