### PR TITLE
Add synchronous Start back to IWebHost

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/IWebHost.cs
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/IWebHost.cs
@@ -26,13 +26,18 @@ namespace Microsoft.AspNetCore.Hosting
         /// <summary>
         /// Starts listening on the configured addresses.
         /// </summary>
-        Task StartAsync(CancellationToken cancellationToken);
+        void Start();
+
+        /// <summary>
+        /// Starts listening on the configured addresses.
+        /// </summary>
+        Task StartAsync(CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Attempt to gracefully stop the host.
         /// </summary>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task StopAsync(CancellationToken cancellationToken);
+        Task StopAsync(CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/breakingchanges.netcore.json
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/breakingchanges.netcore.json
@@ -1,10 +1,5 @@
 [
   {
-    "TypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHost : System.IDisposable",
-    "MemberId": "System.Void Start()",
-    "Kind": "Removal"
-  },
-  {
     "TypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHostBuilder",
     "MemberId": "Microsoft.AspNetCore.Hosting.IWebHostBuilder ConfigureAppConfiguration(System.Action<Microsoft.AspNetCore.Hosting.WebHostBuilderContext, Microsoft.Extensions.Configuration.IConfigurationBuilder> configureDelegate)",
     "Kind": "Addition"
@@ -16,12 +11,12 @@
   },
   {
     "TypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHost : System.IDisposable",
-    "MemberId": "System.Threading.Tasks.Task StartAsync(System.Threading.CancellationToken cancellationToken)",
+    "MemberId": "System.Threading.Tasks.Task StartAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))",
     "Kind": "Addition"
   },
   {
     "TypeId": "public interface Microsoft.AspNetCore.Hosting.IWebHost : System.IDisposable",
-    "MemberId": "System.Threading.Tasks.Task StopAsync(System.Threading.CancellationToken cancellationToken)",
+    "MemberId": "System.Threading.Tasks.Task StopAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))",
     "Kind": "Addition"
   },
   {

--- a/src/Microsoft.AspNetCore.Hosting/Internal/WebHost.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/WebHost.cs
@@ -104,7 +104,12 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             }
         }
 
-        public virtual async Task StartAsync(CancellationToken cancellationToken)
+        public void Start()
+        {
+            StartAsync().GetAwaiter().GetResult();
+        }
+
+        public virtual async Task StartAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             HostingEventSource.Log.HostStart();
             _logger = _applicationServices.GetRequiredService<ILogger<WebHost>>();
@@ -267,7 +272,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             }
         }
 
-        public async Task StopAsync(CancellationToken cancellationToken)
+        public async Task StopAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             if (_stopped)
             {
@@ -313,7 +318,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             {
                 try
                 {
-                    this.StopAsync().GetAwaiter().GetResult();
+                    StopAsync().GetAwaiter().GetResult();
                 }
                 catch (Exception ex)
                 {

--- a/src/Microsoft.AspNetCore.Hosting/WebHostExtensions.cs
+++ b/src/Microsoft.AspNetCore.Hosting/WebHostExtensions.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting.Server.Features;
@@ -12,36 +11,6 @@ namespace Microsoft.AspNetCore.Hosting
 {
     public static class WebHostExtensions
     {
-        /// <summary>
-        /// Starts the host.
-        /// </summary>
-        /// <param name="host"></param>
-        /// <returns></returns>
-        public static void Start(this IWebHost host)
-        {
-            host.StartAsync().GetAwaiter().GetResult();
-        }
-
-        /// <summary>
-        /// Starts the host.
-        /// </summary>
-        /// <param name="host"></param>
-        /// <returns></returns>
-        public static Task StartAsync(this IWebHost host)
-        {
-            return host.StartAsync(CancellationToken.None);
-        }
-
-        /// <summary>
-        /// Gracefully stops the host.
-        /// </summary>
-        /// <param name="host"></param>
-        /// <returns></returns>
-        public static Task StopAsync(this IWebHost host)
-        {
-            return host.StopAsync(CancellationToken.None);
-        }
-
         /// <summary>
         /// Attempts to gracefully stop the host with the given timeout.
         /// </summary>


### PR DESCRIPTION
- Fixed extension methods to have a default(CancellationToken)
- Removed extension methods for Start, StartAsync and StopAsync

#1124 