### PR TITLE
Always log startup exceptions

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting/Internal/WebHost.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/WebHost.cs
@@ -191,7 +191,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
 
                 return builder.Build();
             }
-            catch (Exception ex) when (_options.CaptureStartupErrors)
+            catch (Exception ex)
             {
                 // EnsureApplicationServices may have failed due to a missing or throwing Startup class.
                 if (_applicationServices == null)
@@ -199,12 +199,17 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                     _applicationServices = _applicationServiceCollection.BuildServiceProvider();
                 }
 
-                EnsureServer();
-
                 // Write errors to standard out so they can be retrieved when not in development mode.
                 Console.Out.WriteLine("Application startup exception: " + ex.ToString());
                 var logger = _applicationServices.GetRequiredService<ILogger<WebHost>>();
                 logger.ApplicationError(ex);
+
+                if (!_options.CaptureStartupErrors)
+                {
+                    throw;
+                }
+
+                EnsureServer();
 
                 // Generate an HTML error page.
                 var hostingEnv = _applicationServices.GetRequiredService<IHostingEnvironment>();


### PR DESCRIPTION
The following sample currently does not send the exception to the logger:

```csharp
public class Program
{
    public static void Main(string[] args)
    {
        new WebHostBuilder()
            .UseKestrel()
            .ConfigureLogging(logging =>
             {
                 logging.AddConsole();
             })
            .Configure(app =>
            {
                throw new InvalidOperationException("Something went wrong!");
            })
            .Build()
            .Run();
    }
}
```
It will send it if `CaptureStartupErrors(true)` is called. However, this will also keep the application running and display an error to the user. 

I'm using Service Fabric so I want the application to crash in order to let Service Fabric know that something is wrong. And I also want the exception in my logger.

Before logging was using DI, I created my own logger factory and caught startup exceptions manually (with some ugly code). This is no longer possible/reasonable now.

This PR would always send startup exceptions to the logger, no matter what value `CaptureStartupErrors` has.

We already discussed this in #622 and one concern was that this is a case of a "logging and re-throw anti-pattern" however I think that this is acceptable in this case as this is a very common use-case (IMO). Also, due to recent changes (e.g. logging DI) there's less and less reasons to have logic outside of the WebHostBuilder that would want to prevent that log message.