### PR TITLE
Ignore global environment variable ASPNETCORE_ENVIRONMENT for environment-specific tests

### DIFF
--- a/test/Microsoft.AspNetCore.Hosting.Tests/WebHostBuilderTests.cs
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/WebHostBuilderTests.cs
@@ -332,6 +332,7 @@ namespace Microsoft.AspNetCore.Hosting
         public void DoNotCaptureStartupErrorsByDefault()
         {
             var hostBuilder = new WebHostBuilder()
+                .UseEnvironment(EnvironmentName.Production)
                 .UseServer(new TestServer())
                 .UseStartup<StartupBoom>();
 
@@ -344,6 +345,7 @@ namespace Microsoft.AspNetCore.Hosting
         {
             var hostBuilder = new WebHostBuilder()
                 .CaptureStartupErrors(false)
+                .UseEnvironment(EnvironmentName.Production)
                 .UseServer(new TestServer())
                 .UseStartup<StartupBoom>();
 

--- a/test/Microsoft.AspNetCore.Hosting.Tests/WebHostTests.cs
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/WebHostTests.cs
@@ -768,6 +768,9 @@ namespace Microsoft.AspNetCore.Hosting
         [Fact]
         public void EnvDefaultsToProductionIfNoConfig()
         {
+            // Users might have a global environment variable set.
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "");
+
             using (var host = CreateBuilder().UseFakeServer().Build())
             {
                 var env = host.Services.GetService<IHostingEnvironment>();
@@ -817,7 +820,11 @@ namespace Microsoft.AspNetCore.Hosting
         [Fact]
         public async Task IsEnvironment_Extension_Is_Case_Insensitive()
         {
-            using (var host = CreateBuilder().UseFakeServer().Build())
+            var builder = CreateBuilder()
+                .UseEnvironment(EnvironmentName.Production)
+                .UseFakeServer();
+
+            using (var host = builder.Build())
             {
                 await host.StartAsync();
                 var env = host.Services.GetRequiredService<IHostingEnvironment>();


### PR DESCRIPTION
Fixes #1152. It just sets the environment it expects in the Assert outputs.