### PR TITLE
Fixes case sensitivity on Startup names

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting/Internal/StartupLoader.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/StartupLoader.cs
@@ -94,8 +94,8 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                 // Full scan
                 var definedTypes = assembly.DefinedTypes.ToList();
 
-                var startupType1 = definedTypes.Where(info => info.Name.Equals(startupNameWithEnv, StringComparison.Ordinal));
-                var startupType2 = definedTypes.Where(info => info.Name.Equals(startupNameWithoutEnv, StringComparison.Ordinal));
+                var startupType1 = definedTypes.Where(info => info.Name.Equals(startupNameWithEnv, StringComparison.OrdinalIgnoreCase));
+                var startupType2 = definedTypes.Where(info => info.Name.Equals(startupNameWithoutEnv, StringComparison.OrdinalIgnoreCase));
 
                 var typeInfo = startupType1.Concat(startupType2).FirstOrDefault();
                 if (typeInfo != null)
@@ -140,14 +140,14 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             var methodNameWithNoEnv = string.Format(CultureInfo.InvariantCulture, methodName, "");
 
             var methods = startupType.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static);
-            var selectedMethods = methods.Where(method => method.Name.Equals(methodNameWithEnv)).ToList();
+            var selectedMethods = methods.Where(method => method.Name.Equals(methodNameWithEnv, StringComparison.OrdinalIgnoreCase)).ToList();
             if (selectedMethods.Count > 1)
             {
                 throw new InvalidOperationException(string.Format("Having multiple overloads of method '{0}' is not supported.", methodNameWithEnv));
             }
             if (selectedMethods.Count == 0)
             {
-                selectedMethods = methods.Where(method => method.Name.Equals(methodNameWithNoEnv)).ToList();
+                selectedMethods = methods.Where(method => method.Name.Equals(methodNameWithNoEnv, StringComparison.OrdinalIgnoreCase)).ToList();
                 if (selectedMethods.Count > 1)
                 {
                     throw new InvalidOperationException(string.Format("Having multiple overloads of method '{0}' is not supported.", methodNameWithNoEnv));

--- a/test/Microsoft.AspNetCore.Hosting.Tests/Fakes/StartupCaseInsensitive.cs
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/Fakes/StartupCaseInsensitive.cs
@@ -15,8 +15,7 @@ namespace Microsoft.AspNetCore.Hosting.Tests.Fakes
             services.Configure<FakeOptions>(o =>
             {
                 o.Configured = true;
-                o.Environment = "CaseInsensitive";
-                o.Message = "ConfigureCaseInsensitiveServices";
+                o.Environment = "ConfigureCaseInsensitiveServices";
             });
             return services.BuildServiceProvider();
         }

--- a/test/Microsoft.AspNetCore.Hosting.Tests/Fakes/StartupCaseInsensitive.cs
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/Fakes/StartupCaseInsensitive.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using Microsoft.AspNetCore.Hosting.Fakes;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.AspNetCore.Hosting.Tests.Fakes
+{
+    class StartupCaseInsensitive
+    {
+        public StartupCaseInsensitive()
+        {
+        }
+
+        public static void ConfigureCaseInsensitiveServices(IServiceCollection services)
+        {
+            services.AddOptions();
+            services.Configure<FakeOptions>(o =>
+            {
+                o.Configured = true;
+                o.Environment = "CaseInsensitive";
+            });
+
+        }
+
+        public static void ConfigureCaseInsensitive(IServiceCollection services)
+        {
+            services.AddOptions();
+            services.Configure<FakeOptions>(o =>
+            {
+                o.Configured = true;
+                o.Environment = "CaseInsensitive";
+            });
+        }
+
+        public static IServiceProvider ConfigureCaseInsensitiveContainer(IServiceCollection services)
+        {
+            services.AddOptions();
+            services.Configure<FakeOptions>(o =>
+            {
+                o.Configured = true;
+                o.Environment = "CaseInsensitive";
+            });
+
+            return services.BuildServiceProvider();
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Hosting.Tests/Fakes/StartupCaseInsensitive.cs
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/Fakes/StartupCaseInsensitive.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting.Fakes;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -6,41 +9,20 @@ namespace Microsoft.AspNetCore.Hosting.Tests.Fakes
 {
     class StartupCaseInsensitive
     {
-        public StartupCaseInsensitive()
-        {
-        }
-
-        public static void ConfigureCaseInsensitiveServices(IServiceCollection services)
+        public static IServiceProvider ConfigureCaseInsensitiveServices(IServiceCollection services)
         {
             services.AddOptions();
             services.Configure<FakeOptions>(o =>
             {
                 o.Configured = true;
                 o.Environment = "CaseInsensitive";
+                o.Message = "ConfigureCaseInsensitiveServices";
             });
-
-        }
-
-        public static void ConfigureCaseInsensitive(IServiceCollection services)
-        {
-            services.AddOptions();
-            services.Configure<FakeOptions>(o =>
-            {
-                o.Configured = true;
-                o.Environment = "CaseInsensitive";
-            });
-        }
-
-        public static IServiceProvider ConfigureCaseInsensitiveContainer(IServiceCollection services)
-        {
-            services.AddOptions();
-            services.Configure<FakeOptions>(o =>
-            {
-                o.Configured = true;
-                o.Environment = "CaseInsensitive";
-            });
-
             return services.BuildServiceProvider();
+        }
+
+        public void ConfigureCaseInsensitive(IApplicationBuilder app)
+        {
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Hosting.Tests/StartupManagerTests.cs
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/StartupManagerTests.cs
@@ -105,6 +105,18 @@ namespace Microsoft.AspNetCore.Hosting.Tests
         [InlineData("CaseInsensitive")]
         [InlineData("CASEINSENSITIVE")]
         [InlineData("CaSEiNSENsitiVE")]
+        public void FindsStartupClassCaseInsensitive(string environment)
+        {
+            var type = StartupLoader.FindStartupType("Microsoft.AspNetCore.Hosting.Tests", environment);
+
+            Assert.Equal("StartupCaseInsensitive", type.Name);
+        }
+
+        [Theory]
+        [InlineData("caseinsensitive")]
+        [InlineData("CaseInsensitive")]
+        [InlineData("CASEINSENSITIVE")]
+        [InlineData("CaSEiNSENsitiVE")]
         public void StartupClassAddsConfigureServicesToApplicationServicesCaseInsensitive(string environment)
         {
             var services = new ServiceCollection()
@@ -115,37 +127,12 @@ namespace Microsoft.AspNetCore.Hosting.Tests
 
             var app = new ApplicationBuilder(services);
             app.ApplicationServices = startup.ConfigureServicesDelegate(new ServiceCollection());
-            startup.ConfigureDelegate(app);
+            startup.ConfigureDelegate(app); // By this not throwing, it found "ConfigureCaseInsensitive"
 
             var options = app.ApplicationServices.GetRequiredService<IOptions<FakeOptions>>().Value;
             Assert.NotNull(options);
             Assert.True(options.Configured);
-            Assert.Equal("CaseInsensitive", options.Environment);
-        }
-
-        [Theory]
-        [InlineData("caseinsensitive")]
-        [InlineData("CaseInsensitive")]
-        [InlineData("CASEINSENSITIVE")]
-        [InlineData("CaSEiNSENsitiVE")]
-        public void StartupClassAddsConfigureToApplicationServicesCaseInsensitive(string environment)
-        {
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddSingleton<IServiceProviderFactory<IServiceCollection>, DefaultServiceProviderFactory>();
-            serviceCollection.AddSingleton<IFakeStartupCallback>(new FakeStartupCallback());
-            var services = serviceCollection.BuildServiceProvider();
-
-            var type = StartupLoader.FindStartupType("Microsoft.AspNetCore.Hosting.Tests", environment);
-            var startup = StartupLoader.LoadMethods(services, type, environment);
-
-            var app = new ApplicationBuilder(services);
-            app.ApplicationServices = startup.ConfigureServicesDelegate(serviceCollection);
-            startup.ConfigureDelegate(app);
-
-            var options = app.ApplicationServices.GetRequiredService<IOptions<FakeOptions>>().Value;
-            Assert.NotNull(options);
-            Assert.True(options.Configured);
-            Assert.Equal("CaseInsensitive", options.Environment);
+            Assert.Equal("ConfigureCaseInsensitiveServices", options.Environment);
         }
 
         [Fact]


### PR DESCRIPTION
Fix for #877 
I now check when there is an environmentName that
1. The string starts with methodNameStart
2. The string has the environmentName right after methodNameStart
3. The string has the methodNameEnd right after environmentName 

Also we should add StringSegments?