### PR TITLE
[Fixes #1012] Make it possible to override services when using UseStartup

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/IStartupConfigureContainerFilter.cs
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/IStartupConfigureContainerFilter.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.Hosting
+{
+    public interface IStartupConfigureContainerFilter<TContainerBuilder>
+    {
+        Action<TContainerBuilder> ConfigureContainer(Action<TContainerBuilder> container);
+    }
+}

--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/IStartupConfigureServicesFilter.cs
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/IStartupConfigureServicesFilter.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.AspNetCore.Hosting
+{
+    public interface IStartupConfigureServicesFilter
+    {
+        Action<IServiceCollection> ConfigureServices(Action<IServiceCollection> next);
+    }
+}

--- a/src/Microsoft.AspNetCore.Hosting/Internal/ConfigureContainerBuilder.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/ConfigureContainerBuilder.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
 using System.Reflection;
 
 namespace Microsoft.AspNetCore.Hosting.Internal
@@ -15,6 +14,8 @@ namespace Microsoft.AspNetCore.Hosting.Internal
         }
 
         public MethodInfo MethodInfo { get; }
+
+        public Func<Action<object>, Action<object>> ConfigureContainerFilters { get; set; }
 
         public Action<object> Build(object instance) => container => Invoke(instance, container);
 
@@ -30,6 +31,13 @@ namespace Microsoft.AspNetCore.Hosting.Internal
         }
 
         private void Invoke(object instance, object container)
+        {
+            ConfigureContainerFilters(StartupConfigureContainer)(container);
+
+            void StartupConfigureContainer(object containerBuilder) => InvokeCore(instance, containerBuilder);
+        }
+
+        private void InvokeCore(object instance, object container)
         {
             if (MethodInfo == null)
             {

--- a/src/Microsoft.AspNetCore.Hosting/Internal/ConfigureServicesBuilder.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/ConfigureServicesBuilder.cs
@@ -17,9 +17,18 @@ namespace Microsoft.AspNetCore.Hosting.Internal
 
         public MethodInfo MethodInfo { get; }
 
+        public Func<Func<IServiceCollection, IServiceProvider>, Func<IServiceCollection, IServiceProvider>> StartupServiceFilters { get; set; }
+
         public Func<IServiceCollection, IServiceProvider> Build(object instance) => services => Invoke(instance, services);
 
         private IServiceProvider Invoke(object instance, IServiceCollection services)
+        {
+            return StartupServiceFilters(Startup)(services);
+
+            IServiceProvider Startup(IServiceCollection serviceCollection) => InvokeCore(instance, serviceCollection);
+        }
+
+        private IServiceProvider InvokeCore(object instance, IServiceCollection services)
         {
             if (MethodInfo == null)
             {

--- a/src/Microsoft.AspNetCore.Hosting/Internal/StartupLoader.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/StartupLoader.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
@@ -11,9 +12,35 @@ namespace Microsoft.AspNetCore.Hosting.Internal
 {
     public class StartupLoader
     {
+        // Creates an <see cref="StartupMethods"/> instance with the actions to run for configuring the application services and the
+        // request pipeline of the application.
+        // When using convention based startup, the process for initializing the services is as follows:
+        // The host looks for a method with the signature <see cref="IServiceProvider"/> ConfigureServices(<see cref="IServiceCollection"/> services).
+        // If it can't find one, it looks for a method with the signature <see cref="void"/> ConfigureServices(<see cref="IServiceCollection"/> services).
+        // When the configure services method is void returning, the host builds a services configuration function that runs all the <see cref="IStartupConfigureServicesFilter"/>
+        // instances registered on the host, along with the ConfigureServices method following a decorator pattern.
+        // Additionally to the ConfigureServices method, the Startup class can define a <see cref="void"/> ConfigureContainer&lt;TContainerBuilder&gt;(TContainerBuilder builder)
+        // method that further configures services into the container. If the ConfigureContainer method is defined, the services configuration function
+        // creates a TContainerBuilder <see cref="IServiceProviderFactory{TContainerBuilder}"/> and runs all the <see cref="IStartupConfigureContainerFilter{TContainerBuilder}"/>
+        // instances registered on the host, along with the ConfigureContainer method following a decorator pattern.
+        // For example:
+        // StartupFilter1
+        //   StartupFilter2
+        //     ConfigureServices
+        //   StartupFilter2
+        // StartupFilter1
+        // ConfigureContainerFilter1
+        //   ConfigureContainerFilter2
+        //     ConfigureContainer
+        //   ConfigureContainerFilter2
+        // ConfigureContainerFilter1
+        // 
+        // If the Startup class ConfigureServices returns an <see cref="IServiceProvider"/> and there is at least an <see cref="IStartupConfigureServicesFilter"/> registered we
+        // throw as the filters can't be applied.
         public static StartupMethods LoadMethods(IServiceProvider hostingServiceProvider, Type startupType, string environmentName)
         {
             var configureMethod = FindConfigureDelegate(startupType, environmentName);
+
             var servicesMethod = FindConfigureServicesDelegate(startupType, environmentName);
             var configureContainerMethod = FindConfigureContainerDelegate(startupType, environmentName);
 
@@ -23,44 +50,170 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                 instance = ActivatorUtilities.GetServiceOrCreateInstance(hostingServiceProvider, startupType);
             }
 
-            var configureServicesCallback = servicesMethod.Build(instance);
-            var configureContainerCallback = configureContainerMethod.Build(instance);
+            // The type of the TContainerBuilder. If there is no ConfigureContainer method we can just use object as it's not
+            // going to be used for anything.
+            var type = configureContainerMethod.MethodInfo != null ? configureContainerMethod.GetContainerType() : typeof(object);
 
-            Func<IServiceCollection, IServiceProvider> configureServices = services =>
+            var builder = (ConfigureServicesDelegateBuilder) Activator.CreateInstance(
+                typeof(ConfigureServicesDelegateBuilder<>).MakeGenericType(type),
+                hostingServiceProvider,
+                servicesMethod,
+                configureContainerMethod,
+                instance);
+
+            return new StartupMethods(instance, configureMethod.Build(instance), builder.Build());
+        }
+
+        private abstract class ConfigureServicesDelegateBuilder
+        {
+            public abstract Func<IServiceCollection, IServiceProvider> Build();
+        }
+
+        private class ConfigureServicesDelegateBuilder<TContainerBuilder> : ConfigureServicesDelegateBuilder
+        {
+            public ConfigureServicesDelegateBuilder(
+                IServiceProvider hostingServiceProvider,
+                ConfigureServicesBuilder configureServicesBuilder,
+                ConfigureContainerBuilder configureContainerBuilder,
+                object instance)
             {
-                // Call ConfigureServices, if that returned an IServiceProvider, we're done
-                IServiceProvider applicationServiceProvider = configureServicesCallback.Invoke(services);
+                HostingServiceProvider = hostingServiceProvider;
+                ConfigureServicesBuilder = configureServicesBuilder;
+                ConfigureContainerBuilder = configureContainerBuilder;
+                Instance = instance;
+            }
 
-                if (applicationServiceProvider != null)
+            public IServiceProvider HostingServiceProvider { get; }
+            public ConfigureServicesBuilder ConfigureServicesBuilder { get; }
+            public ConfigureContainerBuilder ConfigureContainerBuilder { get; }
+            public object Instance { get; }
+
+            public override Func<IServiceCollection, IServiceProvider> Build()
+            {
+                ConfigureServicesBuilder.StartupServiceFilters = BuildStartupServicesFilterPipeline;
+                var configureServicesCallback = ConfigureServicesBuilder.Build(Instance);
+
+                ConfigureContainerBuilder.ConfigureContainerFilters = ConfigureContainerPipeline;
+                var configureContainerCallback = ConfigureContainerBuilder.Build(Instance);
+
+                return ConfigureServices(configureServicesCallback, configureContainerCallback);
+
+                Action<object> ConfigureContainerPipeline(Action<object> action)
                 {
-                    return applicationServiceProvider;
-                }
+                    return Target;
 
-                // If there's a ConfigureContainer method
-                if (configureContainerMethod.MethodInfo != null)
+                    // The ConfigureContainer pipeline needs an Action<TContainerBuilder> as source, so we just adapt the
+                    // signature with this function.
+                    void Source(TContainerBuilder containerBuilder) => 
+                        action(containerBuilder);
+
+                    // The ConfigureContainerBuilder.ConfigureContainerFilters expects an Action<object> as value, but our pipeline
+                    // produces an Action<TContainerBuilder> given a source, so we wrap it on an Action<object> that internally casts
+                    // the object containerBuilder to TContainerBuilder to match the expected signature of our ConfigureContainer pipeline.
+                    void Target(object containerBuilder) => 
+                        BuildStartupConfigureContainerFiltersPipeline(Source)((TContainerBuilder)containerBuilder);
+                }
+            }
+
+            Func<IServiceCollection, IServiceProvider> ConfigureServices(
+                Func<IServiceCollection, IServiceProvider> configureServicesCallback,
+                Action<object> configureContainerCallback)
+            {
+                return ConfigureServicesWithContainerConfiguration;
+
+                IServiceProvider ConfigureServicesWithContainerConfiguration(IServiceCollection services)
                 {
-                    // We have a ConfigureContainer method, get the IServiceProviderFactory<TContainerBuilder>
-                    var serviceProviderFactoryType = typeof(IServiceProviderFactory<>).MakeGenericType(configureContainerMethod.GetContainerType());
-                    var serviceProviderFactory = hostingServiceProvider.GetRequiredService(serviceProviderFactoryType);
-                    // var builder = serviceProviderFactory.CreateBuilder(services);
-                    var builder = serviceProviderFactoryType.GetMethod(nameof(DefaultServiceProviderFactory.CreateBuilder)).Invoke(serviceProviderFactory, new object[] { services });
-                    configureContainerCallback.Invoke(builder);
-                    // applicationServiceProvider = serviceProviderFactory.CreateServiceProvider(builder);
-                    applicationServiceProvider = (IServiceProvider)serviceProviderFactoryType.GetMethod(nameof(DefaultServiceProviderFactory.CreateServiceProvider)).Invoke(serviceProviderFactory, new object[] { builder });
+                    // Call ConfigureServices, if that returned an IServiceProvider, we're done
+                    IServiceProvider applicationServiceProvider = configureServicesCallback.Invoke(services);
+
+                    if (applicationServiceProvider != null)
+                    {
+                        return applicationServiceProvider;
+                    }
+
+                    // If there's a ConfigureContainer method
+                    if (ConfigureContainerBuilder.MethodInfo != null)
+                    {
+                        var serviceProviderFactory = HostingServiceProvider.GetRequiredService<IServiceProviderFactory<TContainerBuilder>>();
+                        var builder = serviceProviderFactory.CreateBuilder(services);
+                        configureContainerCallback(builder);
+                        applicationServiceProvider = serviceProviderFactory.CreateServiceProvider(builder);
+                    }
+                    else
+                    {
+                        // Get the default factory
+                        var serviceProviderFactory = HostingServiceProvider.GetRequiredService<IServiceProviderFactory<IServiceCollection>>();
+
+                        // Don't bother calling CreateBuilder since it just returns the default service collection
+                        applicationServiceProvider = serviceProviderFactory.CreateServiceProvider(services);
+                    }
+
+                    return applicationServiceProvider ?? services.BuildServiceProvider();
                 }
-                else
+            }
+
+            private Func<IServiceCollection, IServiceProvider> BuildStartupServicesFilterPipeline(Func<IServiceCollection, IServiceProvider> startup)
+            {
+                return RunPipeline;
+
+                IServiceProvider RunPipeline(IServiceCollection services)
                 {
-                    // Get the default factory
-                    var serviceProviderFactory = hostingServiceProvider.GetRequiredService<IServiceProviderFactory<IServiceCollection>>();
+                    var filters = HostingServiceProvider.GetRequiredService<IEnumerable<IStartupConfigureServicesFilter>>().Reverse().ToArray();
 
-                    // Don't bother calling CreateBuilder since it just returns the default service collection
-                    applicationServiceProvider = serviceProviderFactory.CreateServiceProvider(services);
+                    // If there are no filters just run startup (makes IServiceProvider ConfigureServices(IServiceCollection services) work.
+                    if (filters.Length == 0)
+                    {
+                        return startup(services);
+                    }
+
+                    Action<IServiceCollection> pipeline = InvokeStartup;
+                    for (int i = 0; i < filters.Length; i++)
+                    {
+                        pipeline = filters[i].ConfigureServices(pipeline);
+                    }
+
+                    pipeline(services);
+
+                    // We return null so that the host here builds the container (same result as void ConfigureServices(IServiceCollection services);
+                    return null;
+
+                    void InvokeStartup(IServiceCollection serviceCollection)
+                    {
+                        var result = startup(serviceCollection);
+                        if (filters.Length > 0 && result != null)
+                        {
+                            // public IServiceProvider ConfigureServices(IServiceCollection serviceCollection) is not compatible with IStartupServicesFilter;
+                            var message = $"A ConfigureServices method that returns an {nameof(IServiceProvider)} is " +
+                                $"not compatible with the use of one or more {nameof(IStartupConfigureServicesFilter)}. " +
+                                $"Use a void returning ConfigureServices method instead or a ConfigureContainer method.";
+                            throw new InvalidOperationException(message);
+                        };
+                    }
                 }
+            }
 
-                return applicationServiceProvider ?? services.BuildServiceProvider();
-            };
+            private Action<TContainerBuilder> BuildStartupConfigureContainerFiltersPipeline(Action<TContainerBuilder> configureContainer)
+            {
+                return RunPipeline;
 
-            return new StartupMethods(instance, configureMethod.Build(instance), configureServices);
+                void RunPipeline(TContainerBuilder containerBuilder)
+                {
+                    var filters = HostingServiceProvider
+                        .GetRequiredService<IEnumerable<IStartupConfigureContainerFilter<TContainerBuilder>>>()
+                        .Reverse()
+                        .ToArray();
+
+                    Action<TContainerBuilder> pipeline = InvokeConfigureContainer;
+                    for (int i = 0; i < filters.Length; i++)
+                    {
+                        pipeline = filters[i].ConfigureContainer(pipeline);
+                    }
+
+                    pipeline(containerBuilder);
+
+                    void InvokeConfigureContainer(TContainerBuilder builder) => configureContainer(builder);
+                }
+            }
         }
 
         public static Type FindStartupType(string startupAssemblyName, string environmentName)

--- a/src/Microsoft.AspNetCore.TestHost/WebHostBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.TestHost/WebHostBuilderExtensions.cs
@@ -1,0 +1,94 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.AspNetCore.TestHost
+{
+    public static class WebHostBuilderExtensions
+    {
+        public static IWebHostBuilder ConfigureTestServices(this IWebHostBuilder webHostBuilder, Action<IServiceCollection> servicesConfiguration)
+        {
+            if (webHostBuilder == null)
+            {
+                throw new ArgumentNullException(nameof(webHostBuilder));
+            }
+
+            if (servicesConfiguration == null)
+            {
+                throw new ArgumentNullException(nameof(servicesConfiguration));
+            }
+
+            webHostBuilder.ConfigureServices(
+                s => s.AddSingleton<IStartupConfigureServicesFilter>(
+                    new ConfigureTestServicesStartupConfigureServicesFilter(servicesConfiguration)));
+
+            return webHostBuilder;
+        }
+
+        public static IWebHostBuilder ConfigureTestContainer<TContainer>(this IWebHostBuilder webHostBuilder, Action<TContainer> servicesConfiguration)
+        {
+            if (webHostBuilder == null)
+            {
+                throw new ArgumentNullException(nameof(webHostBuilder));
+            }
+
+            if (servicesConfiguration == null)
+            {
+                throw new ArgumentNullException(nameof(servicesConfiguration));
+            }
+
+            webHostBuilder.ConfigureServices(
+                s => s.AddSingleton<IStartupConfigureContainerFilter<TContainer>>(
+                    new ConfigureTestServicesStartupConfigureContainerFilter<TContainer>(servicesConfiguration)));
+
+            return webHostBuilder;
+        }
+
+        private class ConfigureTestServicesStartupConfigureServicesFilter : IStartupConfigureServicesFilter
+        {
+            private readonly Action<IServiceCollection> _servicesConfiguration;
+
+            public ConfigureTestServicesStartupConfigureServicesFilter(Action<IServiceCollection> servicesConfiguration)
+            {
+                if (servicesConfiguration == null)
+                {
+                    throw new ArgumentNullException(nameof(servicesConfiguration));
+                }
+
+                _servicesConfiguration = servicesConfiguration;
+            }
+
+            public Action<IServiceCollection> ConfigureServices(Action<IServiceCollection> next) =>
+                serviceCollection =>
+                {
+                    next(serviceCollection);
+                    _servicesConfiguration(serviceCollection);
+                };
+        }
+
+        private class ConfigureTestServicesStartupConfigureContainerFilter<TContainer> : IStartupConfigureContainerFilter<TContainer>
+        {
+            private readonly Action<TContainer> _servicesConfiguration;
+
+            public ConfigureTestServicesStartupConfigureContainerFilter(Action<TContainer> containerConfiguration)
+            {
+                if (containerConfiguration == null)
+                {
+                    throw new ArgumentNullException(nameof(containerConfiguration));
+                }
+
+                _servicesConfiguration = containerConfiguration;
+            }
+
+            public Action<TContainer> ConfigureContainer(Action<TContainer> next) =>
+                containerBuilder =>
+                {
+                    next(containerBuilder);
+                    _servicesConfiguration(containerBuilder);
+                };
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Hosting.Tests/Internal/MyContainer.cs
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/Internal/MyContainer.cs
@@ -13,6 +13,8 @@ namespace Microsoft.AspNetCore.Hosting.Tests.Internal
 
         public bool FancyMethodCalled { get; private set; }
 
+        public IServiceCollection Services => _services;
+
         public string Environment { get; set; }
 
         public object GetService(Type serviceType)


### PR DESCRIPTION
* Add IStartupConfigureServicesFilter to wrap ConfigureServices.
* Add IStartupConfigureContainerFilter<TContainerBuilder> to wrap
  ConfigureContainer.
* Make StartupLoader build a thunk for configure services that
  resolves all instances of IStartupConfigureServicesFilter and
  IStartupConfigureContainerFilter<TContainerBuilder> and wraps
  invocations to ConfigureServices and ConfigureContainer respectively.
* Refactor building the ConfigureServices callback into a private
  builder class due to the increased complexity in the process.