### PR TITLE
Decouple ApplicationName from any assembly names

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/HostingAbstractionsWebHostBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/HostingAbstractionsWebHostBuilderExtensions.cs
@@ -58,7 +58,7 @@ namespace Microsoft.AspNetCore.Hosting
 
 
             return hostBuilder
-                .UseSetting(WebHostDefaults.ApplicationKey, startupAssemblyName)
+                .UseSetting(WebHostDefaults.FindStartupTypeKey, "true")
                 .UseSetting(WebHostDefaults.StartupAssemblyKey, startupAssemblyName);
         }
 

--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/HostingAbstractionsWebHostBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/HostingAbstractionsWebHostBuilderExtensions.cs
@@ -90,6 +90,27 @@ namespace Microsoft.AspNetCore.Hosting
         }
 
         /// <summary>
+        /// Specify the application name. This can be retrieved from <see cref="IHostingEnvironment.ApplicationName"/>.
+        /// </summary>
+        /// <param name="hostBuilder">The <see cref="IWebHostBuilder"/> to configure.</param>
+        /// <param name="applicationName">The name of the application.</param>
+        /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
+        public static IWebHostBuilder UseApplicationName(this IWebHostBuilder hostBuilder, string applicationName)
+        {
+            if (applicationName == null)
+            {
+                throw new ArgumentNullException(nameof(applicationName));
+            }
+
+            if (applicationName.Length == 0)
+            {
+                throw new ArgumentException("Application name must not be empty.", nameof(applicationName));
+            }
+
+            return hostBuilder.UseSetting(WebHostDefaults.ApplicationKey, applicationName);
+        }
+
+        /// <summary>
         /// Specify the server to be used by the web host.
         /// </summary>
         /// <param name="hostBuilder">The <see cref="IWebHostBuilder"/> to configure.</param>

--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/HostingAbstractionsWebHostBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/HostingAbstractionsWebHostBuilderExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Globalization;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.Extensions.Configuration;
@@ -51,11 +52,37 @@ namespace Microsoft.AspNetCore.Hosting
         /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
         public static IWebHostBuilder UseStartup(this IWebHostBuilder hostBuilder, string startupAssemblyName)
         {
+            return hostBuilder.UseStartupAssembly(startupAssemblyName);
+        }
+
+        /// <summary>
+        /// Specify the assembly containing the startup type to be used by the web host.
+        /// </summary>
+        /// <param name="hostBuilder">The <see cref="IWebHostBuilder"/> to configure.</param>
+        /// <param name="assembly">The assembly containing the startup type.</param>
+        /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
+        public static IWebHostBuilder UseStartupAssembly(this IWebHostBuilder hostBuilder, Assembly assembly)
+        {
+            if (assembly == null)
+            {
+                throw new ArgumentNullException(nameof(assembly));
+            }
+
+            return hostBuilder.UseStartupAssembly(assembly.GetName().Name);
+        }
+
+        /// <summary>
+        /// Specify the assembly containing the startup type to be used by the web host.
+        /// </summary>
+        /// <param name="hostBuilder">The <see cref="IWebHostBuilder"/> to configure.</param>
+        /// <param name="startupAssemblyName">The name of the assembly containing the startup type.</param>
+        /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
+        public static IWebHostBuilder UseStartupAssembly(this IWebHostBuilder hostBuilder, string startupAssemblyName)
+        {
             if (startupAssemblyName == null)
             {
                 throw new ArgumentNullException(nameof(startupAssemblyName));
             }
-
 
             return hostBuilder
                 .UseSetting(WebHostDefaults.FindStartupTypeKey, "true")

--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/HostingAbstractionsWebHostBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/HostingAbstractionsWebHostBuilderExtensions.cs
@@ -50,6 +50,7 @@ namespace Microsoft.AspNetCore.Hosting
         /// <param name="hostBuilder">The <see cref="IWebHostBuilder"/> to configure.</param>
         /// <param name="startupAssemblyName">The name of the assembly containing the startup type.</param>
         /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
+        [Obsolete("This method is obsolete and will be removed in a future version. Use UseStartupAssembly instead.")]
         public static IWebHostBuilder UseStartup(this IWebHostBuilder hostBuilder, string startupAssemblyName)
         {
             return hostBuilder.UseStartupAssembly(startupAssemblyName);

--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/WebHostDefaults.cs
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/WebHostDefaults.cs
@@ -7,6 +7,7 @@ namespace Microsoft.AspNetCore.Hosting
     {
         public static readonly string ApplicationKey = "applicationName";
         public static readonly string StartupAssemblyKey = "startupAssembly";
+        public static readonly string FindStartupTypeKey = "findStartupType";
         public static readonly string HostingStartupAssembliesKey = "hostingStartupAssemblies";
 
         public static readonly string DetailedErrorsKey = "detailedErrors";

--- a/src/Microsoft.AspNetCore.Hosting/Internal/HostingEnvironmentExtensions.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/HostingEnvironmentExtensions.cs
@@ -15,10 +15,6 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             {
                 throw new ArgumentNullException(nameof(options));
             }
-            if (string.IsNullOrEmpty(applicationName))
-            {
-                throw new ArgumentException("A valid non-empty application name must be provided.", nameof(applicationName));
-            }
             if (string.IsNullOrEmpty(contentRootPath))
             {
                 throw new ArgumentException("A valid non-empty content root must be provided.", nameof(contentRootPath));

--- a/src/Microsoft.AspNetCore.Hosting/Internal/WebHostOptions.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/WebHostOptions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Reflection;
 using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.AspNetCore.Hosting.Internal
@@ -19,13 +20,19 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                 throw new ArgumentNullException(nameof(configuration));
             }
 
-            var applicationName = configuration[WebHostDefaults.ApplicationKey];
             var startupAssembly = configuration[WebHostDefaults.StartupAssemblyKey];
+
+            if (string.IsNullOrEmpty(startupAssembly))
+            {
+                // Fall back to entry assembly name if startup assembly hasn't been set.
+                startupAssembly = Assembly.GetEntryAssembly().GetName().Name;
+            }
+
+            var applicationName = configuration[WebHostDefaults.ApplicationKey];
 
             if (string.IsNullOrEmpty(applicationName))
             {
-                // Fall back to name of Startup assembly if
-                // application name hasn't been overridden.
+                // Fall back to name of Startup assembly if application name hasn't been overridden.
                 applicationName = startupAssembly;
             }
 

--- a/src/Microsoft.AspNetCore.Hosting/Internal/WebHostOptions.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/WebHostOptions.cs
@@ -38,7 +38,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             ContentRootPath = configuration[WebHostDefaults.ContentRootKey];
             PreventHostingStartup = WebHostUtilities.ParseBool(configuration, WebHostDefaults.PreventHostingStartupKey);
             // Search the primary assembly and configured assemblies.
-            HostingStartupAssemblies = $"{ApplicationName};{configuration[WebHostDefaults.HostingStartupAssembliesKey]}"
+            HostingStartupAssemblies = $"{StartupAssembly};{configuration[WebHostDefaults.HostingStartupAssembliesKey]}"
                 .Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries) ?? new string[0];
 
             var timeout = configuration[WebHostDefaults.ShutdownTimeoutKey];

--- a/src/Microsoft.AspNetCore.Hosting/Internal/WebHostOptions.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/WebHostOptions.cs
@@ -31,6 +31,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
 
             ApplicationName = applicationName;
             StartupAssembly = startupAssembly;
+            FindStartupType = WebHostUtilities.ParseBool(configuration, WebHostDefaults.FindStartupTypeKey);
             DetailedErrors = WebHostUtilities.ParseBool(configuration, WebHostDefaults.DetailedErrorsKey);
             CaptureStartupErrors = WebHostUtilities.ParseBool(configuration, WebHostDefaults.CaptureStartupErrorsKey);
             Environment = configuration[WebHostDefaults.EnvironmentKey];
@@ -50,6 +51,8 @@ namespace Microsoft.AspNetCore.Hosting.Internal
         }
 
         public string ApplicationName { get; set; }
+
+        public bool FindStartupType { get; set; }
 
         public bool PreventHostingStartup { get; set; }
 

--- a/src/Microsoft.AspNetCore.Hosting/Internal/WebHostOptions.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/WebHostOptions.cs
@@ -19,8 +19,18 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                 throw new ArgumentNullException(nameof(configuration));
             }
 
-            ApplicationName = configuration[WebHostDefaults.ApplicationKey];
-            StartupAssembly = configuration[WebHostDefaults.StartupAssemblyKey];
+            var applicationName = configuration[WebHostDefaults.ApplicationKey];
+            var startupAssembly = configuration[WebHostDefaults.StartupAssemblyKey];
+
+            if (string.IsNullOrEmpty(applicationName))
+            {
+                // Fall back to name of Startup assembly if
+                // application name hasn't been overridden.
+                applicationName = startupAssembly;
+            }
+
+            ApplicationName = applicationName;
+            StartupAssembly = startupAssembly;
             DetailedErrors = WebHostUtilities.ParseBool(configuration, WebHostDefaults.DetailedErrorsKey);
             CaptureStartupErrors = WebHostUtilities.ParseBool(configuration, WebHostDefaults.CaptureStartupErrorsKey);
             Environment = configuration[WebHostDefaults.EnvironmentKey];

--- a/src/Microsoft.AspNetCore.Hosting/Internal/WebHostOptions.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/WebHostOptions.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             if (string.IsNullOrEmpty(startupAssembly))
             {
                 // Fall back to entry assembly name if startup assembly hasn't been set.
-                startupAssembly = Assembly.GetEntryAssembly().GetName().Name;
+                startupAssembly = Assembly.GetEntryAssembly()?.GetName().Name;
             }
 
             var applicationName = configuration[WebHostDefaults.ApplicationKey];

--- a/src/Microsoft.AspNetCore.Hosting/WebHostBuilder.cs
+++ b/src/Microsoft.AspNetCore.Hosting/WebHostBuilder.cs
@@ -261,7 +261,7 @@ namespace Microsoft.AspNetCore.Hosting
             // Ensure object pooling is available everywhere.
             services.AddSingleton<ObjectPoolProvider, DefaultObjectPoolProvider>();
 
-            if (!string.IsNullOrEmpty(_options.StartupAssembly))
+            if (_options.FindStartupType)
             {
                 try
                 {

--- a/src/Microsoft.AspNetCore.Hosting/WebHostBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Hosting/WebHostBuilderExtensions.cs
@@ -30,7 +30,7 @@ namespace Microsoft.AspNetCore.Hosting
             var startupAssemblyName = configureApp.GetMethodInfo().DeclaringType.GetTypeInfo().Assembly.GetName().Name;
 
             return hostBuilder
-                .UseSetting(WebHostDefaults.ApplicationKey, startupAssemblyName)
+                .UseSetting(WebHostDefaults.StartupAssemblyKey, startupAssemblyName)
                 .ConfigureServices(services =>
                 {
                     services.AddSingleton<IStartup>(sp =>
@@ -52,7 +52,7 @@ namespace Microsoft.AspNetCore.Hosting
             var startupAssemblyName = startupType.GetTypeInfo().Assembly.GetName().Name;
 
             return hostBuilder
-                .UseSetting(WebHostDefaults.ApplicationKey, startupAssemblyName)
+                .UseSetting(WebHostDefaults.StartupAssemblyKey, startupAssemblyName)
                 .ConfigureServices(services =>
                 {
                     if (typeof(IStartup).GetTypeInfo().IsAssignableFrom(startupType.GetTypeInfo()))

--- a/test/Microsoft.AspNetCore.Hosting.TestSites/Program.cs
+++ b/test/Microsoft.AspNetCore.Hosting.TestSites/Program.cs
@@ -31,7 +31,7 @@ namespace ServerComparison.TestSites
                     factory.AddConsole();
                     factory.AddFilter<ConsoleLoggerProvider>(level => level >= LogLevel.Warning);
                 })
-                .UseStartup("Microsoft.AspNetCore.Hosting.TestSites");
+                .UseStartupAssembly("Microsoft.AspNetCore.Hosting.TestSites");
 
             if (config["STARTMECHANIC"] == "Run")
             {

--- a/test/Microsoft.AspNetCore.Hosting.Tests/WebHostBuilderTests.cs
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/WebHostBuilderTests.cs
@@ -632,7 +632,7 @@ namespace Microsoft.AspNetCore.Hosting
                 .Build())
             {
                 var hostingEnv = host.Services.GetService<IHostingEnvironment>();
-                Assert.Equal(Assembly.GetEntryAssembly().GetName().Name, hostingEnv.ApplicationName);
+                Assert.Equal(Assembly.GetEntryAssembly()?.GetName().Name, hostingEnv.ApplicationName);
             }
         }
 

--- a/test/Microsoft.AspNetCore.Hosting.Tests/WebHostBuilderTests.cs
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/WebHostBuilderTests.cs
@@ -610,6 +610,33 @@ namespace Microsoft.AspNetCore.Hosting
         }
 
         [Fact]
+        public void CustomApplicationName()
+        {
+            using (var host = new WebHostBuilder()
+                .UseServer(new TestServer())
+                .UseApplicationName("Test Application")
+                .UseStartup<StartupNoServices>()
+                .Build())
+            {
+                var hostingEnv = host.Services.GetService<IHostingEnvironment>();
+                Assert.Equal("Test Application", hostingEnv.ApplicationName);
+            }
+        }
+
+        [Fact]
+        public void DefaultApplicationNameWithInjectedIStartup()
+        {
+            using (var host = new WebHostBuilder()
+                .UseServer(new TestServer())
+                .ConfigureServices(s => s.AddSingleton<IStartup, StartupNoServices>())
+                .Build())
+            {
+                var hostingEnv = host.Services.GetService<IHostingEnvironment>();
+                Assert.Equal(Assembly.GetEntryAssembly().GetName().Name, hostingEnv.ApplicationName);
+            }
+        }
+
+        [Fact]
         public void DefaultApplicationNameWithUseStartupOfType()
         {
             var builder = new ConfigurationBuilder();

--- a/test/Microsoft.AspNetCore.Hosting.Tests/WebHostBuilderTests.cs
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/WebHostBuilderTests.cs
@@ -576,11 +576,9 @@ namespace Microsoft.AspNetCore.Hosting
             var host = new WebHostBuilder()
                 .UseServer(new TestServer());
 
-            var ex = Assert.Throws<ArgumentException>(() => host.Build());
+            var ex = Assert.Throws<InvalidOperationException>(() => host.Build());
 
-            // ArgumentException adds "Parameter name" to the message and this is the cleanest way to make sure we get the right
-            // expected string
-            Assert.Equal(new ArgumentException("A valid non-empty application name must be provided.", "applicationName").Message , ex.Message);
+            Assert.Equal("No service for type 'Microsoft.AspNetCore.Hosting.IStartup' has been registered.", ex.Message);
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Hosting.Tests/WebHostBuilderTests.cs
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/WebHostBuilderTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.AspNetCore.Hosting
         {
             var builder = CreateWebHostBuilder().UseServer(new TestServer());
 
-            using (var host = (WebHost)builder.UseStartup("MyStartupAssembly").Build())
+            using (var host = (WebHost)builder.UseStartupAssembly("MyStartupAssembly").Build())
             {
                 Assert.Equal("MyStartupAssembly", host.Options.ApplicationName);
                 Assert.Equal("MyStartupAssembly", host.Options.StartupAssembly);
@@ -46,7 +46,7 @@ namespace Microsoft.AspNetCore.Hosting
         {
             var builder = CreateWebHostBuilder();
             var server = new TestServer();
-            using (var host = builder.UseServer(server).UseStartup("MissingStartupAssembly").Build())
+            using (var host = builder.UseServer(server).UseStartupAssembly("MissingStartupAssembly").Build())
             {
                 await host.StartAsync();
                 await AssertResponseContains(server.RequestDelegate, "MissingStartupAssembly");
@@ -492,7 +492,7 @@ namespace Microsoft.AspNetCore.Hosting
                 .UseConfiguration(config)
                 .UseEnvironment(expected)
                 .UseServer(new TestServer())
-                .UseStartup("Microsoft.AspNetCore.Hosting.Tests")
+                .UseStartupAssembly("Microsoft.AspNetCore.Hosting.Tests")
                 .Build())
             {
                 Assert.Equal(expected, host.Services.GetService<IHostingEnvironment>().EnvironmentName);
@@ -515,7 +515,7 @@ namespace Microsoft.AspNetCore.Hosting
                 .UseConfiguration(config)
                 .UseEnvironment(expected)
                 .UseServer(new TestServer())
-                .UseStartup("Microsoft.AspNetCore.Hosting.Tests")
+                .UseStartupAssembly("Microsoft.AspNetCore.Hosting.Tests")
                 .Build()) { }
         }
 
@@ -534,7 +534,7 @@ namespace Microsoft.AspNetCore.Hosting
                 .UseConfiguration(config)
                 .UseContentRoot("/")
                 .UseServer(new TestServer())
-                .UseStartup("Microsoft.AspNetCore.Hosting.Tests")
+                .UseStartupAssembly("Microsoft.AspNetCore.Hosting.Tests")
                 .Build())
             {
                 Assert.Equal("/", host.Services.GetService<IHostingEnvironment>().ContentRootPath);
@@ -547,7 +547,7 @@ namespace Microsoft.AspNetCore.Hosting
             using (var host = new WebHostBuilder()
                 .UseContentRoot("testroot")
                 .UseServer(new TestServer())
-                .UseStartup("Microsoft.AspNetCore.Hosting.Tests")
+                .UseStartupAssembly("Microsoft.AspNetCore.Hosting.Tests")
                 .Build())
             {
                 var basePath = host.Services.GetRequiredService<IHostingEnvironment>().ContentRootPath;
@@ -561,7 +561,7 @@ namespace Microsoft.AspNetCore.Hosting
         {
             using (var host = new WebHostBuilder()
                 .UseServer(new TestServer())
-                .UseStartup("Microsoft.AspNetCore.Hosting.Tests")
+                .UseStartupAssembly("Microsoft.AspNetCore.Hosting.Tests")
                 .Build())
             {
                 var appBase = AppContext.BaseDirectory;
@@ -589,7 +589,7 @@ namespace Microsoft.AspNetCore.Hosting
             var builder = new ConfigurationBuilder();
             using (var host = new WebHostBuilder()
                 .UseServer(new TestServer())
-                .UseStartup(typeof(Startup).Assembly.GetName().Name)
+                .UseStartupAssembly(typeof(Startup).Assembly.GetName().Name)
                 .Build())
             {
                 var hostingEnv = host.Services.GetService<IHostingEnvironment>();

--- a/test/Microsoft.AspNetCore.Hosting.Tests/WebHostTests.cs
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/WebHostTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.AspNetCore.Hosting
         [Fact]
         public void UseStartupThrowsWithNull()
         {
-            Assert.Throws<ArgumentNullException>(() => CreateBuilder().UseStartup((string)null));
+            Assert.Throws<ArgumentNullException>(() => CreateBuilder().UseStartupAssembly((string)null));
         }
 
         [Fact]
@@ -144,7 +144,7 @@ namespace Microsoft.AspNetCore.Hosting
         {
             using (var host = CreateBuilder()
                 .UseFakeServer()
-                .UseStartup("Microsoft.AspNetCore.Hosting.Tests")
+                .UseStartupAssembly("Microsoft.AspNetCore.Hosting.Tests")
                 .Start())
             {
                 var server = (FakeServer)host.Services.GetRequiredService<IServer>();
@@ -163,7 +163,7 @@ namespace Microsoft.AspNetCore.Hosting
         {
             using (var host = CreateBuilder()
                 .UseFakeServer()
-                .UseStartup("Microsoft.AspNetCore.Hosting.Tests")
+                .UseStartupAssembly("Microsoft.AspNetCore.Hosting.Tests")
                 .Build())
             {
                 var lifetime = host.Services.GetRequiredService<IApplicationLifetime>();
@@ -216,7 +216,7 @@ namespace Microsoft.AspNetCore.Hosting
                 {
                     services.AddSingleton(server.Object);
                 })
-                .UseStartup("Microsoft.AspNetCore.Hosting.Tests")
+                .UseStartupAssembly("Microsoft.AspNetCore.Hosting.Tests")
                 .Build())
             {
                 await host.StartAsync();
@@ -255,7 +255,7 @@ namespace Microsoft.AspNetCore.Hosting
                 {
                     services.AddSingleton(server.Object);
                 })
-                .UseStartup("Microsoft.AspNetCore.Hosting.Tests")
+                .UseStartupAssembly("Microsoft.AspNetCore.Hosting.Tests")
                 .Build())
             {
                 await host.StartAsync();
@@ -291,7 +291,7 @@ namespace Microsoft.AspNetCore.Hosting
                 {
                     services.AddSingleton(server.Object);
                 })
-                .UseStartup("Microsoft.AspNetCore.Hosting.Tests")
+                .UseStartupAssembly("Microsoft.AspNetCore.Hosting.Tests")
                 .Build())
             {
                 await host.StartAsync();
@@ -310,7 +310,7 @@ namespace Microsoft.AspNetCore.Hosting
         {
             using (var host = CreateBuilder()
                 .UseFakeServer()
-                .UseStartup("Microsoft.AspNetCore.Hosting.Tests")
+                .UseStartupAssembly("Microsoft.AspNetCore.Hosting.Tests")
                 .Build())
             {
                 var lifetime = host.Services.GetRequiredService<IApplicationLifetime>();
@@ -377,7 +377,7 @@ namespace Microsoft.AspNetCore.Hosting
                     s.AddTransient<IFakeService, FakeService>();
                     s.AddSingleton<IFakeSingletonService, FakeService>();
                 })
-                .UseStartup("Microsoft.AspNetCore.Hosting.Tests")
+                .UseStartupAssembly("Microsoft.AspNetCore.Hosting.Tests")
                 .Build())
             {
                 await host.StartAsync();
@@ -683,7 +683,7 @@ namespace Microsoft.AspNetCore.Hosting
         {
             using (var host = CreateBuilder()
                 .UseFakeServer()
-                .UseStartup("Microsoft.AspNetCore.Hosting.Tests")
+                .UseStartupAssembly("Microsoft.AspNetCore.Hosting.Tests")
                 .UseEnvironment("WithHostingEnvironment")
                 .Build())
             {
@@ -702,7 +702,7 @@ namespace Microsoft.AspNetCore.Hosting
                     services.AddTransient<IStartup, TestStartup>();
                 })
                 .UseFakeServer()
-                .UseStartup("Microsoft.AspNetCore.Hosting.Tests");
+                .UseStartupAssembly("Microsoft.AspNetCore.Hosting.Tests");
 
             Assert.Throws<NotImplementedException>(() => builder.Build());
         }
@@ -947,7 +947,7 @@ namespace Microsoft.AspNetCore.Hosting
 
         private IWebHostBuilder CreateBuilder(IConfiguration config = null)
         {
-            return new WebHostBuilder().UseConfiguration(config ?? new ConfigurationBuilder().Build()).UseStartup("Microsoft.AspNetCore.Hosting.Tests");
+            return new WebHostBuilder().UseConfiguration(config ?? new ConfigurationBuilder().Build()).UseStartupAssembly("Microsoft.AspNetCore.Hosting.Tests");
         }
 
         private static bool[] RegisterCallbacksThatThrow(IServiceCollection services)


### PR DESCRIPTION
Here's a proposal to fix a couple of issues...

This PR effectively stops using `StartupAssembly` to check whether to scan for an `IStartup` type. Instead it always sets `StartupAssembly` when calling `Configure`, `UseStartup` or `UseStartupAssembly` (new), and in addition, it sets a new `FindStartupType` key when you need to scan for a startup type.

If `StartupAssembly` hasn't been set (no method above has been called), it falls back to the entry assembly name. This fixes #1137.

Instead of using `ApplicationName` in `HostingStartupAssemblies`, it now uses `StartupAssembly`.

This means that we no longer use `ApplicationName` for any assembly loading or scanning, it's simply just a string that you can set to whatever you want. This fixes #1179.

If an `ApplicationName` hasn't been provided (by the user), it falls back to `StartupAssembly` (which could've already fallen back to the entry assembly name).