### PR TITLE
Porting "Always log startup exceptions to 1.1.4"

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting/Internal/WebHost.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/WebHost.cs
@@ -154,7 +154,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
 
                 return builder.Build();
             }
-            catch (Exception ex) when (_options.CaptureStartupErrors)
+            catch (Exception ex)
             {
                 // EnsureApplicationServices may have failed due to a missing or throwing Startup class.
                 if (_applicationServices == null)
@@ -162,12 +162,17 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                     _applicationServices = _applicationServiceCollection.BuildServiceProvider();
                 }
 
-                EnsureServer();
-
                 // Write errors to standard out so they can be retrieved when not in development mode.
                 Console.Out.WriteLine("Application startup exception: " + ex.ToString());
                 var logger = _applicationServices.GetRequiredService<ILogger<WebHost>>();
                 logger.ApplicationError(ex);
+
+                if (!_options.CaptureStartupErrors)
+                {
+                    throw;
+                }
+
+                EnsureServer();
 
                 // Generate an HTML error page.
                 var hostingEnv = _applicationServices.GetRequiredService<IHostingEnvironment>();

--- a/test/Microsoft.AspNetCore.Hosting.Tests/WebHostBuilderTests.cs
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/WebHostBuilderTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
@@ -16,6 +17,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging.Testing;
 using Microsoft.Extensions.ObjectPool;
 using Microsoft.Extensions.PlatformAbstractions;
 using Xunit;
@@ -573,6 +575,47 @@ namespace Microsoft.AspNetCore.Hosting
             Assert.Equal(factory, factoryFromHost);
         }
 
+        [Fact]
+        public void StartupErrorsAreLoggedIfCaptureStartupErrorsIsTrue()
+        {
+            var testSink = new TestSink();
+            var factory = new TestLoggerFactory(testSink, enabled: true);
+            var builder = CreateWebHostBuilder()
+                .CaptureStartupErrors(true)
+                .ConfigureServices(services => services.AddSingleton<ILoggerFactory>(factory))
+                .Configure(app =>
+                {
+                    throw new InvalidOperationException("Startup exception");
+                })
+                .UseServer(new TestServer());
+
+            using (var host = (WebHost)builder.Build())
+            {
+                Assert.True(testSink.Writes.Any(w => w.Exception?.Message == "Startup exception"));
+            }
+        }
+
+        [Fact]
+        public void StartupErrorsAreLoggedIfCaptureStartupErrorsIsFalse()
+        {
+            var testSink = new TestSink();
+            var factory = new TestLoggerFactory(testSink, enabled: true);
+
+            var builder = CreateWebHostBuilder()
+                .CaptureStartupErrors(false)
+                .ConfigureServices(collection => collection.AddSingleton<ILoggerFactory>(factory))
+
+                .Configure(app =>
+                {
+                    throw new InvalidOperationException("Startup exception");
+                })
+                .UseServer(new TestServer());
+
+            Assert.Throws<InvalidOperationException>(() => builder.Build());
+
+            Assert.True(testSink.Writes.Any(w => w.Exception?.Message == "Startup exception"));
+        }
+
         private static void StaticConfigureMethod(IApplicationBuilder app)
         { }
 
@@ -649,7 +692,7 @@ namespace Microsoft.AspNetCore.Hosting
 
             public ILogger CreateLogger(string categoryName)
             {
-                return NullLogger.Instance;
+                return Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance;
             }
 
             public void AddProvider(ILoggerProvider provider)

--- a/test/Microsoft.AspNetCore.Hosting.Tests/project.json
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/project.json
@@ -20,6 +20,7 @@
     "Microsoft.AspNetCore.Testing": "1.1.1",
     "Microsoft.Extensions.Options": "1.1.2",
     "Microsoft.Extensions.PlatformAbstractions": "1.1.0",
+    "Microsoft.Extensions.Logging.Testing": "1.1.1",
     "xunit": "2.2.0-*"
   },
   "frameworks": {


### PR DESCRIPTION
Fix for https://github.com/aspnet/Hosting/issues/1160
Had to modify tests to work with 1.1.x