### PR TITLE
Porting "Always log startup exceptions" to 1.0.6

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting/Internal/WebHost.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/WebHost.cs
@@ -150,7 +150,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
 
                 return builder.Build();
             }
-            catch (Exception ex) when (_options.CaptureStartupErrors)
+            catch (Exception ex)
             {
                 // EnsureApplicationServices may have failed due to a missing or throwing Startup class.
                 if (_applicationServices == null)
@@ -158,12 +158,17 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                     _applicationServices = _applicationServiceCollection.BuildServiceProvider();
                 }
 
-                EnsureServer();
-
                 // Write errors to standard out so they can be retrieved when not in development mode.
                 Console.Out.WriteLine("Application startup exception: " + ex.ToString());
                 var logger = _applicationServices.GetRequiredService<ILogger<WebHost>>();
                 logger.ApplicationError(ex);
+
+                if (!_options.CaptureStartupErrors)
+                {
+                    throw;
+                }
+
+                EnsureServer();
 
                 // Generate an HTML error page.
                 var hostingEnv = _applicationServices.GetRequiredService<IHostingEnvironment>();

--- a/test/Microsoft.AspNetCore.Hosting.Tests/WebHostBuilderTests.cs
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/WebHostBuilderTests.cs
@@ -16,11 +16,8 @@ using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-<<<<<<< HEAD
-=======
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging.Testing;
->>>>>>> 3f7cb64... Always log startup exceptions
 using Microsoft.Extensions.ObjectPool;
 using Microsoft.Extensions.PlatformAbstractions;
 using Xunit;

--- a/test/Microsoft.AspNetCore.Hosting.Tests/WebHostBuilderTests.cs
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/WebHostBuilderTests.cs
@@ -498,84 +498,6 @@ namespace Microsoft.AspNetCore.Hosting
         }
 
         [Fact]
-        public void Build_DoesNotAllowBuildingMuiltipleTimes()
-        {
-            var builder = CreateWebHostBuilder();
-            var server = new TestServer();
-            builder.UseServer(server)
-                .UseStartup<StartupNoServices>()
-                .Build();
-
-            var ex = Assert.Throws<InvalidOperationException>(() => builder.Build());
-
-            Assert.Equal("WebHostBuilder allows creation only of a single instance of WebHost", ex.Message);
-        }
-
-        [Fact]
-        public void Build_PassesSameAutoCreatedILoggerFactoryEverywhere()
-        {
-            var builder = CreateWebHostBuilder();
-            var server = new TestServer();
-            var host = builder.UseServer(server)
-                .UseStartup<StartupWithILoggerFactory>()
-                .Build();
-
-            var startup = host.Services.GetService<StartupWithILoggerFactory>();
-
-            Assert.Equal(startup.ConfigureLoggerFactory, startup.ConstructorLoggerFactory);
-        }
-
-        [Fact]
-        public void Build_PassesSamePassedILoggerFactoryEverywhere()
-        {
-            var factory = new LoggerFactory();
-            var builder = CreateWebHostBuilder();
-            var server = new TestServer();
-            var host = builder.UseServer(server)
-                .UseLoggerFactory(factory)
-                .UseStartup<StartupWithILoggerFactory>()
-                .Build();
-
-            var startup = host.Services.GetService<StartupWithILoggerFactory>();
-
-            Assert.Equal(factory, startup.ConfigureLoggerFactory);
-            Assert.Equal(factory, startup.ConstructorLoggerFactory);
-        }
-
-        [Fact]
-        public void Build_PassedILoggerFactoryNotDisposed()
-        {
-            var factory = new DisposableLoggerFactory();
-            var builder = CreateWebHostBuilder();
-            var server = new TestServer();
-
-            var host = builder.UseServer(server)
-                .UseLoggerFactory(factory)
-                .UseStartup<StartupWithILoggerFactory>()
-                .Build();
-
-            host.Dispose();
-
-            Assert.Equal(false, factory.Disposed);
-        }
-
-        [Fact]
-        public void Build_DoesNotOverrideILoggerFactorySetByConfigureServices()
-        {
-            var factory = new DisposableLoggerFactory();
-            var builder = CreateWebHostBuilder();
-            var server = new TestServer();
-
-            var host = builder.UseServer(server)
-                .ConfigureServices(collection => collection.AddSingleton<ILoggerFactory>(factory))
-                .UseStartup<StartupWithILoggerFactory>()
-                .Build();
-
-            var factoryFromHost = host.Services.GetService<ILoggerFactory>();
-            Assert.Equal(factory, factoryFromHost);
-        }
-
-        [Fact]
         public void StartupErrorsAreLoggedIfCaptureStartupErrorsIsTrue()
         {
             var testSink = new TestSink();
@@ -680,8 +602,6 @@ namespace Microsoft.AspNetCore.Hosting
         {
 
         }
-<<<<<<< HEAD
-=======
 
         private class DisposableLoggerFactory : ILoggerFactory
         {
@@ -701,6 +621,5 @@ namespace Microsoft.AspNetCore.Hosting
             {
             }
         }
->>>>>>> 3f7cb64... Always log startup exceptions
     }
 }

--- a/test/Microsoft.AspNetCore.Hosting.Tests/project.json
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/project.json
@@ -20,8 +20,10 @@
     "Microsoft.AspNetCore.Owin": "1.0.3",
     "Microsoft.AspNetCore.Testing": "1.0.1",
     "Microsoft.Extensions.Options": "1.0.2",
+    "Microsoft.Extensions.Logging.Testing": "1.0.3",
     "Microsoft.Extensions.PlatformAbstractions": "1.0.0",
     "xunit": "2.1.0"
+
   },
   "frameworks": {
     "netcoreapp1.0": {


### PR DESCRIPTION
Fix for https://github.com/aspnet/Hosting/issues/1159.
@pranavkm I was running into errors when I ran build.cmd from scratch. Said I didn't have the 1.0.5 runtime installed even though I did. 