### PR TITLE
Cross-compile Windows Services hosting package

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -40,6 +40,7 @@
     <SerilogSinksFilePackageVersion>3.2.0</SerilogSinksFilePackageVersion>
     <SystemDiagnosticsDiagnosticSourcePackageVersion>4.4.1</SystemDiagnosticsDiagnosticSourcePackageVersion>
     <SystemReflectionMetadataPackageVersion>1.5.0</SystemReflectionMetadataPackageVersion>
+    <SystemServiceProcessVersion>4.5.0-preview1-25914-04</SystemServiceProcessVersion>
     <XunitPackageVersion>2.3.0</XunitPackageVersion>
     <XunitRunnerVisualStudioPackageVersion>2.3.0</XunitRunnerVisualStudioPackageVersion>
   </PropertyGroup>

--- a/src/Microsoft.AspNetCore.Hosting.WindowsServices/Microsoft.AspNetCore.Hosting.WindowsServices.csproj
+++ b/src/Microsoft.AspNetCore.Hosting.WindowsServices/Microsoft.AspNetCore.Hosting.WindowsServices.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>ASP.NET Core hosting infrastructure and startup logic for web applications running within a Windows service.</Description>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore;hosting</PackageTags>
@@ -10,7 +10,12 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.AspNetCore.Hosting\Microsoft.AspNetCore.Hosting.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <Reference Include="System.ServiceProcess" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="System.ServiceProcess.ServiceController" Version="$(SystemServiceProcessVersion)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Cross-compile `Microsoft.AspNetCore.Hosting.WindowsServices` for .NET 4.6.1 and .NET Core 2.0.

I had the use the .NET Core MyGet feed as the `ServiceBase` API is only available in version `4.5.0-*`. Perhaps   the package in the ASP.NET Core MyGet feed can be updated as well?

Resolves #904 

/cc @muratg @JunTaoLuo