### PR TITLE
Preserve state in HostBuilder.Properties

### DIFF
--- a/src/Microsoft.Extensions.Hosting/HostBuilder.cs
+++ b/src/Microsoft.Extensions.Hosting/HostBuilder.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Extensions.Hosting
         /// <summary>
         /// A central location for sharing state between components during the host building process.
         /// </summary>
-        public IDictionary<object, object> Properties => new Dictionary<object, object>();
+        public IDictionary<object, object> Properties { get; } = new Dictionary<object, object>();
 
         /// <summary>
         /// Set up the configuration for the builder itself. This will be used to initialize the <see cref="IHostingEnvironment"/>

--- a/test/Microsoft.Extensions.Hosting.Tests/HostBuilderTests.cs
+++ b/test/Microsoft.Extensions.Hosting.Tests/HostBuilderTests.cs
@@ -444,6 +444,22 @@ namespace Microsoft.Extensions.Hosting
             Assert.Equal(Path.GetFullPath("."), env.ContentRootPath);
             Assert.IsAssignableFrom<PhysicalFileProvider>(env.ContentRootFileProvider);
         }
+
+        [Fact]
+        public void BuilderPropertiesAreAvailableInBuilderAndContext()
+        {
+            var hostBuilder = new HostBuilder()
+                .ConfigureServices((hostContext, services) =>
+                {
+                    Assert.Equal("value", hostContext.Properties["key"]);
+                });
+
+            hostBuilder.Properties.Add("key", "value");
+            
+            Assert.Equal("value", hostBuilder.Properties["key"]);
+
+            using (hostBuilder.Build()) { }
+        }
         
         private class ServiceC
         {


### PR DESCRIPTION
`HostBuilder.Properties` was returning a new Dictionary on every access