### PR TITLE
Add BackgroundService, a base class for long running HostedServices

### DIFF
--- a/samples/GenericHostSample/MyServiceA.cs
+++ b/samples/GenericHostSample/MyServiceA.cs
@@ -5,38 +5,22 @@ using Microsoft.Extensions.Hosting;
 
 namespace GenericHostSample
 {
-    public class MyServiceA : IHostedService
+    public class MyServiceA : BackgroundService
     {
-        private bool _stopping;
-        private Task _backgroundTask;
-
-        public Task StartAsync(CancellationToken cancellationToken)
+        protected override async Task ExecuteAsync(CancellationToken cancellationToken)
         {
             Console.WriteLine("MyServiceA is starting.");
-            _backgroundTask = BackgroundTask();
-            return Task.CompletedTask;
-        }
 
-        private async Task BackgroundTask()
-        {
-            while (!_stopping)
+            cancellationToken.Register(() => Console.WriteLine("MyServiceA is stopping."));
+
+            while (!cancellationToken.IsCancellationRequested)
             {
-                await Task.Delay(TimeSpan.FromSeconds(5));
                 Console.WriteLine("MyServiceA is doing background work.");
+
+                await Task.Delay(TimeSpan.FromSeconds(5));
             }
 
             Console.WriteLine("MyServiceA background task is stopping.");
-        }
-
-        public async Task StopAsync(CancellationToken cancellationToken)
-        {
-            Console.WriteLine("MyServiceA is stopping.");
-            _stopping = true;
-            if (_backgroundTask != null)
-            {
-                // TODO: cancellation
-                await _backgroundTask;
-            }
         }
     }
 }

--- a/samples/GenericHostSample/MyServiceA.cs
+++ b/samples/GenericHostSample/MyServiceA.cs
@@ -17,7 +17,7 @@ namespace GenericHostSample
             {
                 Console.WriteLine("MyServiceA is doing background work.");
 
-                await Task.Delay(TimeSpan.FromSeconds(5));
+                await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
             }
 
             Console.WriteLine("MyServiceA background task is stopping.");

--- a/samples/GenericHostSample/MyServiceA.cs
+++ b/samples/GenericHostSample/MyServiceA.cs
@@ -7,13 +7,13 @@ namespace GenericHostSample
 {
     public class MyServiceA : BackgroundService
     {
-        protected override async Task ExecuteAsync(CancellationToken cancellationToken)
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
             Console.WriteLine("MyServiceA is starting.");
 
-            cancellationToken.Register(() => Console.WriteLine("MyServiceA is stopping."));
+            stoppingToken.Register(() => Console.WriteLine("MyServiceA is stopping."));
 
-            while (!cancellationToken.IsCancellationRequested)
+            while (!stoppingToken.IsCancellationRequested)
             {
                 Console.WriteLine("MyServiceA is doing background work.");
 

--- a/src/Microsoft.Extensions.Hosting.Abstractions/BackgroundService.cs
+++ b/src/Microsoft.Extensions.Hosting.Abstractions/BackgroundService.cs
@@ -36,6 +36,10 @@ namespace Microsoft.Extensions.Hosting
         /// </summary>
         public CancellationToken CancelledToken { get; }
 
+        /// <summary>
+        /// Triggered when the application host is ready to start the service.
+        /// </summary>
+        /// <param name="cancellationToken">Indicates that the start process has been aborted.</param>
         public virtual Task StartAsync(CancellationToken cancellationToken)
         {
             using (cancellationToken.Register(_cancelToken, _cancelledCts))
@@ -54,6 +58,10 @@ namespace Microsoft.Extensions.Hosting
             }
         }
 
+        /// <summary>
+        /// Triggered when the application host is performing a graceful shutdown.
+        /// </summary>
+        /// <param name="cancellationToken">Indicates that the shutdown process should no longer be graceful.</param>
         public virtual async Task StopAsync(CancellationToken cancellationToken)
         {
             // Stop called without start

--- a/src/Microsoft.Extensions.Hosting.Abstractions/BackgroundService.cs
+++ b/src/Microsoft.Extensions.Hosting.Abstractions/BackgroundService.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Extensions.Hosting
+{
+    /// <summary>
+    /// Base class for implementing a long running <see cref="IHostedService"/>.
+    /// </summary>
+    public abstract class BackgroundService : IHostedService
+    {
+        private Task _executingTask;
+        private CancellationTokenSource _cts;
+
+        /// <summary>
+        /// This method is called when the <see cref="IHostedService"/> starts. The implementation should return a task that represents
+        /// the lifetime of the long running operation(s) being performed.
+        /// </summary>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> that fires when the <see cref="IHostedService"/> is stopped or cancelled.</param>
+        /// <returns>A <see cref="Task"/> that represents the long running operations.</returns>
+        protected abstract Task ExecuteAsync(CancellationToken cancellationToken);
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            // If the token is cancellable, create a linked token so we can trigger cancellation 
+            // on shutdown and based on the incoming token
+            _cts = cancellationToken.CanBeCanceled ?
+                CancellationTokenSource.CreateLinkedTokenSource(cancellationToken) :
+                new CancellationTokenSource();
+
+            // Store the task we're executing
+            _executingTask = ExecuteAsync(_cts.Token);
+
+            // If the task is completed then return it, this will bubble cancellation and failure to the caller
+            if (_executingTask.IsFaulted)
+            {
+                return _executingTask;
+            }
+
+            // Otherwise it's running
+            return Task.CompletedTask;
+        }
+
+        public async Task StopAsync(CancellationToken cancellationToken)
+        {
+            // Stop called without start
+            if (_executingTask == null)
+            {
+                return;
+            }
+
+            try
+            {
+                // Signal cancellation to the executing method
+                _cts.Cancel();
+            }
+            finally
+            {
+                // Wait until the task completes or the stop token triggers
+                await Task.WhenAny(_executingTask, Task.Delay(-1, cancellationToken));
+            }
+        }
+    }
+}

--- a/src/Microsoft.Extensions.Hosting.Abstractions/BackgroundService.cs
+++ b/src/Microsoft.Extensions.Hosting.Abstractions/BackgroundService.cs
@@ -70,8 +70,6 @@ namespace Microsoft.Extensions.Hosting
         public virtual void Dispose()
         {
             _stoppingCts.Cancel();
-
-            _stoppingCts.Dispose();
         }
     }
 }

--- a/src/Microsoft.Extensions.Hosting.Abstractions/BackgroundService.cs
+++ b/src/Microsoft.Extensions.Hosting.Abstractions/BackgroundService.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Extensions.Hosting
             finally
             {
                 // Wait until the task completes or the stop token triggers
-                await Task.WhenAny(_executingTask, Task.Delay(-1, cancellationToken));
+                await Task.WhenAny(_executingTask, Task.Delay(Timeout.Infinite, cancellationToken));
             }
 
         }

--- a/test/Microsoft.Extensions.Hosting.Tests/BackgroundHostedServiceTests.cs
+++ b/test/Microsoft.Extensions.Hosting.Tests/BackgroundHostedServiceTests.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Extensions.Hosting.Tests
         {
             protected override Task ExecuteAsync(CancellationToken stoppingToken)
             {
-                return Task.Delay(-1, stoppingToken);
+                return Task.Delay(Timeout.Infinite, stoppingToken);
             }
         }
 
@@ -162,7 +162,7 @@ namespace Microsoft.Extensions.Hosting.Tests
 
             private async Task ExecuteCore(CancellationToken stoppingToken)
             {
-                var task = await Task.WhenAny(_task, Task.Delay(-1, stoppingToken));
+                var task = await Task.WhenAny(_task, Task.Delay(Timeout.Infinite, stoppingToken));
 
                 await task;
             }

--- a/test/Microsoft.Extensions.Hosting.Tests/BackgroundHostedServiceTests.cs
+++ b/test/Microsoft.Extensions.Hosting.Tests/BackgroundHostedServiceTests.cs
@@ -94,7 +94,6 @@ namespace Microsoft.Extensions.Hosting.Tests
             await Assert.ThrowsAsync<AggregateException>(() => service.StopAsync(cts.Token));
 
             Assert.Equal(2, service.TokenCalls);
-            Assert.True(service.CancelledToken.IsCancellationRequested);
         }
 
         [Fact]
@@ -105,15 +104,13 @@ namespace Microsoft.Extensions.Hosting.Tests
             await service.StartAsync(CancellationToken.None);
 
             service.Dispose();
-
-            Assert.True(service.CancelledToken.IsCancellationRequested);
         }
 
         private class WaitForCancelledTokenService : BackgroundService
         {
             protected override Task ExecuteAsync(CancellationToken stoppingToken)
             {
-                return Task.Delay(-1, CancelledToken);
+                return Task.Delay(-1, stoppingToken);
             }
         }
 

--- a/test/Microsoft.Extensions.Hosting.Tests/BackgroundHostedServiceTests.cs
+++ b/test/Microsoft.Extensions.Hosting.Tests/BackgroundHostedServiceTests.cs
@@ -1,0 +1,169 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Extensions.Hosting.Tests
+{
+    public class BackgroundHostedServiceTests
+    {
+        [Fact]
+        public void StartReturnsCompletedTaskIfLongRunningTaskIsIncomplete()
+        {
+            var tcs = new TaskCompletionSource<object>();
+            var service = new MyBackgroundService(tcs.Task);
+
+            var task = service.StartAsync(CancellationToken.None);
+
+            Assert.True(task.IsCompleted);
+            Assert.False(tcs.Task.IsCompleted);
+
+            // Complete the tsk
+            tcs.TrySetResult(null);
+        }
+
+        [Fact]
+        public void StartReturnsCompletedTaskIfCancelled()
+        {
+            var tcs = new TaskCompletionSource<object>();
+            tcs.TrySetCanceled();
+            var service = new MyBackgroundService(tcs.Task);
+
+            var task = service.StartAsync(CancellationToken.None);
+
+            Assert.True(task.IsCompleted);
+        }
+
+        [Fact]
+        public async Task StartReturnsLongRunningTaskIfFailed()
+        {
+            var tcs = new TaskCompletionSource<object>();
+            tcs.TrySetException(new Exception("fail!"));
+            var service = new MyBackgroundService(tcs.Task);
+
+            var exception = await Assert.ThrowsAsync<Exception>(() => service.StartAsync(CancellationToken.None));
+
+            Assert.Equal("fail!", exception.Message);
+        }
+
+        [Fact]
+        public async Task StartYieldToken()
+        {
+            var tcs = new TaskCompletionSource<object>();
+            var cts = new CancellationTokenSource();
+            var service = new MyBackgroundService(tcs.Task);
+
+            var task = service.StartAsync(cts.Token);
+
+            cts.Cancel();
+
+            await task;
+
+            await Assert.ThrowsAsync<TaskCanceledException>(() => service.ExecuteTask);
+        }
+
+        [Fact]
+        public async Task StopAsyncWithoutStartAsyncNoops()
+        {
+            var tcs = new TaskCompletionSource<object>();
+            var service = new MyBackgroundService(tcs.Task);
+
+            await service.StopAsync(CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task StopAsyncStopsBackgroundService()
+        {
+            var tcs = new TaskCompletionSource<object>();
+            var service = new MyBackgroundService(tcs.Task);
+
+            await service.StartAsync(CancellationToken.None);
+
+            Assert.False(service.ExecuteTask.IsCompleted);
+
+            await service.StopAsync(CancellationToken.None);
+
+            Assert.True(service.ExecuteTask.IsCompleted);
+        }
+
+        [Fact]
+        public async Task StopAsyncStopsEvenIfTaskNeverEnds()
+        {
+            var service = new IgnoreCancellationService();
+
+            await service.StartAsync(CancellationToken.None);
+
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+            await service.StopAsync(cts.Token);
+        }
+
+        [Fact]
+        public async Task StopAsyncThrowsIfCancellationCallbackThrows()
+        {
+            var service = new ThrowOnCancellationService();
+
+            await service.StartAsync(CancellationToken.None);
+
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+            await Assert.ThrowsAsync<AggregateException>(() => service.StopAsync(cts.Token));
+
+            Assert.Equal(2, service.TokenCalls);
+        }
+
+        private class ThrowOnCancellationService : BackgroundService
+        {
+            public int TokenCalls { get; set; }
+
+            protected override Task ExecuteAsync(CancellationToken cancellationToken)
+            {
+                cancellationToken.Register(() =>
+                {
+                    TokenCalls++;
+                    throw new InvalidOperationException();
+                });
+
+                cancellationToken.Register(() =>
+                {
+                    TokenCalls++;
+                });
+
+                return new TaskCompletionSource<object>().Task;
+            }
+        }
+
+        private class IgnoreCancellationService : BackgroundService
+        {
+            protected override Task ExecuteAsync(CancellationToken cancellationToken)
+            {
+                return new TaskCompletionSource<object>().Task;
+            }
+        }
+
+        private class MyBackgroundService : BackgroundService
+        {
+            private readonly Task _task;
+
+            public Task ExecuteTask { get; set; }
+
+            public MyBackgroundService(Task task)
+            {
+                _task = task;
+            }
+
+            protected override async Task ExecuteAsync(CancellationToken cancellationToken)
+            {
+                ExecuteTask = ExecuteCore(cancellationToken);
+                await ExecuteTask;
+            }
+
+            private async Task ExecuteCore(CancellationToken cancellationToken)
+            {
+                var task = await Task.WhenAny(_task, Task.Delay(-1, cancellationToken));
+
+                await task;
+            }
+        }
+    }
+}

--- a/test/Microsoft.Extensions.Hosting.Tests/BackgroundHostedServiceTests.cs
+++ b/test/Microsoft.Extensions.Hosting.Tests/BackgroundHostedServiceTests.cs
@@ -49,22 +49,6 @@ namespace Microsoft.Extensions.Hosting.Tests
         }
 
         [Fact]
-        public async Task StartYieldToken()
-        {
-            var tcs = new TaskCompletionSource<object>();
-            var cts = new CancellationTokenSource();
-            var service = new MyBackgroundService(tcs.Task);
-
-            var task = service.StartAsync(cts.Token);
-
-            cts.Cancel();
-
-            await task;
-
-            await Assert.ThrowsAsync<TaskCanceledException>(() => service.ExecuteTask);
-        }
-
-        [Fact]
         public async Task StopAsyncWithoutStartAsyncNoops()
         {
             var tcs = new TaskCompletionSource<object>();

--- a/test/Microsoft.Extensions.Hosting.Tests/BackgroundHostedServiceTests.cs
+++ b/test/Microsoft.Extensions.Hosting.Tests/BackgroundHostedServiceTests.cs
@@ -94,6 +94,7 @@ namespace Microsoft.Extensions.Hosting.Tests
             await Assert.ThrowsAsync<AggregateException>(() => service.StopAsync(cts.Token));
 
             Assert.Equal(2, service.TokenCalls);
+            Assert.True(service.ShutdownToken.IsCancellationRequested);
         }
 
         private class ThrowOnCancellationService : BackgroundService


### PR DESCRIPTION
- Today the IHostedService pattern is a StartAsync/StopAsync pattern. Neither of these
methods are supposed to return a long running task that represents an execution. If
you wanted to have some logic run on a timer every 5 minutes, it's unnatural to do so
with simple async idioms. This base class implements IHostedService and exposes
a pattern where a long running async Task can be returned.
- Added tests

/cc @glennc 