### PR TITLE
Schedule ExecuteAsync instead of running it inline

### DIFF
--- a/src/Microsoft.Extensions.Hosting.Abstractions/BackgroundService.cs
+++ b/src/Microsoft.Extensions.Hosting.Abstractions/BackgroundService.cs
@@ -12,8 +12,13 @@ namespace Microsoft.Extensions.Hosting
     /// </summary>
     public abstract class BackgroundService : IHostedService, IDisposable
     {
+        private static readonly Func<object, Task> _executeBackgroundTask = ExecuteBackgroundTaskAsync;
+
         private Task _executingTask;
         private readonly CancellationTokenSource _stoppingCts = new CancellationTokenSource();
+
+        // For testing purposes only
+        internal Task ExecutingTask => _executingTask;
 
         /// <summary>
         /// This method is called when the <see cref="IHostedService"/> starts. The implementation should return a task that represents
@@ -30,14 +35,11 @@ namespace Microsoft.Extensions.Hosting
         public virtual Task StartAsync(CancellationToken cancellationToken)
         {
             // Store the task we're executing
-            _executingTask = ExecuteAsync(_stoppingCts.Token);
-
-            // If the task is completed then return it, this will bubble cancellation and failure to the caller
-            if (_executingTask.IsCompleted)
-            {
-                return _executingTask;
-            }
-
+            _executingTask = Task.Factory.StartNew(_executeBackgroundTask,
+                                                   this,
+                                                   cancellationToken,
+                                                   TaskCreationOptions.DenyChildAttach,
+                                                   TaskScheduler.Default).Unwrap();
             // Otherwise it's running
             return Task.CompletedTask;
         }
@@ -62,14 +64,34 @@ namespace Microsoft.Extensions.Hosting
             finally
             {
                 // Wait until the task completes or the stop token triggers
-                await Task.WhenAny(_executingTask, Task.Delay(Timeout.Infinite, cancellationToken));
-            }
+                var task = await Task.WhenAny(_executingTask, Task.Delay(Timeout.Infinite, cancellationToken));
 
+                // Bubble any exceptions thrown by the executing task
+                if (task == _executingTask)
+                {
+                    try
+                    {
+                        await _executingTask;
+                    }
+                    catch (TaskCanceledException)
+                    {
+                        // Swallow task canclled exceptions since it might be by design that
+                        // the executing task is cancelled
+                    }
+                }
+            }
         }
 
         public virtual void Dispose()
         {
             _stoppingCts.Cancel();
+        }
+
+        private static Task ExecuteBackgroundTaskAsync(object state)
+        {
+            var service = (BackgroundService)state;
+
+            return service.ExecuteAsync(service._stoppingCts.Token);
         }
     }
 }

--- a/src/Microsoft.Extensions.Hosting.Abstractions/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Extensions.Hosting.Abstractions/Properties/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Microsoft.Extensions.Hosting.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100f33a29044fa9d740c9b3213a93e57c84b472c84e0b8a0e1ae48e67a9f8f6de9d5f7f3d52ac23e48ac51801f1dc950abe901da34d2a9e3baadb141a17c77ef3c565dd5ee5054b91cf63bb3c6ab83f72ab3aafe93d0fc3c2348b764fafb0b1c0733de51459aeab46580384bf9d74c4e28164b7cde247f891ba07891c9d872ad2bb")]


### PR DESCRIPTION
- This prevents bad actors from blocking start up but also comes
with a bunch of caveats. StartAsync merely schedules the ExecuteAsync call
so there's no guarantee that ExecuteAsync runs before StartAsync or Dispose
(in theory).

I'm not sure I like scheduling the work. I like the guarantee that when StartAsync returns, we know the ExecuteAsync delegate has started.