### PR TITLE
Flaky hosting functional tests

### DIFF
--- a/test/Microsoft.AspNetCore.Hosting.FunctionalTests/Properties/AssemblyInfo.cs
+++ b/test/Microsoft.AspNetCore.Hosting.FunctionalTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly)]


### PR DESCRIPTION
Fixes #1213. The fix is to filter out application startup messsages so tests only examine the application output.