### PR TITLE
Remove the hosting dependency on WebHostBuilderFactory shared sources

### DIFF
--- a/shared/Microsoft.AspNetCore.Hosting.WebHostBuilderFactory.Sources/FactoryResolutionResult.cs
+++ b/shared/Microsoft.AspNetCore.Hosting.WebHostBuilderFactory.Sources/FactoryResolutionResult.cs
@@ -5,46 +5,50 @@ using System;
 
 namespace Microsoft.AspNetCore.Hosting.WebHostBuilderFactory
 {
-    internal class FactoryResolutionResult
+    internal class FactoryResolutionResult<TWebHost,TWebHostBuilder>
     {
         public FactoryResolutionResultKind ResultKind { get; set; }
         public Type ProgramType { get; set; }
-        public Func<string[], IWebHost> WebHostFactory { get; set; }
-        public Func<string[], IWebHostBuilder> WebHostBuilderFactory { get; set; }
+        public Func<string[], TWebHost> WebHostFactory { get; set; }
+        public Func<string[], TWebHostBuilder> WebHostBuilderFactory { get; set; }
 
-        internal static FactoryResolutionResult NoBuildWebHost(Type programType) =>
-            new FactoryResolutionResult
+        internal static FactoryResolutionResult<TWebHost, TWebHostBuilder> NoBuildWebHost(Type programType) =>
+            new FactoryResolutionResult<TWebHost, TWebHostBuilder>
             {
                 ProgramType = programType,
                 ResultKind = FactoryResolutionResultKind.NoBuildWebHost
             };
 
-        internal static FactoryResolutionResult NoCreateWebHostBuilder(Type programType) =>
-            new FactoryResolutionResult
+        internal static FactoryResolutionResult<TWebHost, TWebHostBuilder> NoCreateWebHostBuilder(Type programType) =>
+            new FactoryResolutionResult<TWebHost, TWebHostBuilder>
             {
                 ProgramType = programType,
                 ResultKind = FactoryResolutionResultKind.NoCreateWebHostBuilder
             };
 
-        internal static FactoryResolutionResult NoEntryPoint() =>
-            new FactoryResolutionResult
+        internal static FactoryResolutionResult<TWebHost, TWebHostBuilder> NoEntryPoint() =>
+            new FactoryResolutionResult<TWebHost, TWebHostBuilder>
             {
                 ResultKind = FactoryResolutionResultKind.NoEntryPoint
             };
 
-        internal static FactoryResolutionResult Succeded(Func<string[], IWebHost> factory, Type programType) => new FactoryResolutionResult
+        internal static FactoryResolutionResult<TWebHost, TWebHostBuilder> Succeded(Func<string[], TWebHost> factory, Type programType) => new FactoryResolutionResult<TWebHost, TWebHostBuilder>
         {
             ProgramType = programType,
             ResultKind = FactoryResolutionResultKind.Success,
             WebHostFactory = factory
         };
 
-        internal static FactoryResolutionResult Succeded(Func<string[], IWebHostBuilder> factory, Type programType) => new FactoryResolutionResult
+        internal static FactoryResolutionResult<TWebHost, TWebHostBuilder> Succeded(Func<string[], TWebHostBuilder> factory, Type programType) => new FactoryResolutionResult<TWebHost, TWebHostBuilder>
         {
             ProgramType = programType,
             ResultKind = FactoryResolutionResultKind.Success,
             WebHostBuilderFactory = factory,
-            WebHostFactory = args => factory(args).Build()
+            WebHostFactory = args =>
+            {
+                var builder = factory(args);
+                return (TWebHost)builder.GetType().GetMethod("Build").Invoke(builder, Array.Empty<object>());
+            }
         };
     }
 }

--- a/src/Microsoft.AspNetCore.TestHost/WebHostBuilderFactory.cs
+++ b/src/Microsoft.AspNetCore.TestHost/WebHostBuilderFactory.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.TestHost
     {
         public static IWebHostBuilder CreateFromAssemblyEntryPoint(Assembly assembly, string [] args)
         {
-            var result = WebHostFactoryResolver.ResolveWebHostBuilderFactory(assembly);
+            var result = WebHostFactoryResolver.ResolveWebHostBuilderFactory<IWebHost,IWebHostBuilder>(assembly);
             if (result.ResultKind != FactoryResolutionResultKind.Success)
             {
                 return null;

--- a/test/Microsoft.AspNetCore.Hosting.WebHostBuilderFactory.Tests/WebHostFactoryResolverTests.cs
+++ b/test/Microsoft.AspNetCore.Hosting.WebHostBuilderFactory.Tests/WebHostFactoryResolverTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNetCore.Hosting.WebHostBuilderFactory.Tests
         public void CanFindWebHostBuilder_CreateWebHostBuilderPattern()
         {
             // Arrange & Act
-            var resolverResult = WebHostFactoryResolver.ResolveWebHostBuilderFactory(typeof(IStartupInjectionAssemblyName.Startup).Assembly);
+            var resolverResult = WebHostFactoryResolver.ResolveWebHostBuilderFactory<IWebHost,IWebHostBuilder>(typeof(IStartupInjectionAssemblyName.Startup).Assembly);
 
             // Assert
             Assert.Equal(FactoryResolutionResultKind.Success, resolverResult.ResultKind);
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Hosting.WebHostBuilderFactory.Tests
         public void CanFindWebHost_CreateWebHostBuilderPattern()
         {
             // Arrange & Act
-            var resolverResult = WebHostFactoryResolver.ResolveWebHostFactory(typeof(IStartupInjectionAssemblyName.Startup).Assembly);
+            var resolverResult = WebHostFactoryResolver.ResolveWebHostFactory<IWebHost, IWebHostBuilder>(typeof(IStartupInjectionAssemblyName.Startup).Assembly);
 
             // Assert
             Assert.Equal(FactoryResolutionResultKind.Success, resolverResult.ResultKind);
@@ -37,7 +37,7 @@ namespace Microsoft.AspNetCore.Hosting.WebHostBuilderFactory.Tests
         public void CanNotFindWebHostBuilder_BuildWebHostPattern()
         {
             // Arrange & Act
-            var resolverResult = WebHostFactoryResolver.ResolveWebHostBuilderFactory(typeof(BuildWebHostPatternTestSite.Startup).Assembly);
+            var resolverResult = WebHostFactoryResolver.ResolveWebHostBuilderFactory<IWebHost, IWebHostBuilder>(typeof(BuildWebHostPatternTestSite.Startup).Assembly);
 
             // Assert
             Assert.Equal(FactoryResolutionResultKind.NoCreateWebHostBuilder, resolverResult.ResultKind);
@@ -49,7 +49,7 @@ namespace Microsoft.AspNetCore.Hosting.WebHostBuilderFactory.Tests
         public void CanFindWebHost_BuildWebHostPattern()
         {
             // Arrange & Act
-            var resolverResult = WebHostFactoryResolver.ResolveWebHostFactory(typeof(BuildWebHostPatternTestSite.Startup).Assembly);
+            var resolverResult = WebHostFactoryResolver.ResolveWebHostFactory<IWebHost, IWebHostBuilder>(typeof(BuildWebHostPatternTestSite.Startup).Assembly);
 
             // Assert
             Assert.Equal(FactoryResolutionResultKind.Success, resolverResult.ResultKind);


### PR DESCRIPTION
We need to do this because https://github.com/aspnet/EntityFrameworkCore/tree/f4c9f4c4be0e6f159506e583eda0ba68536356b2/src/EFCore.Design does not have a dependency in hosting and I don't want to introduce it.

This change does not affect any public API.