### PR TITLE
Better message for integration tests

### DIFF
--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Common/LoggingHandler.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Common/LoggingHandler.cs
@@ -26,7 +26,7 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
             }
             catch (Exception ex)
             {
-                _logger.LogError(0, ex, "Exception while sending '{method} {url}'", request.Method, request.RequestUri, request.RequestUri);
+                _logger.LogError(0, ex, "Exception while sending '{method} {url}' : {exception}", request.Method, request.RequestUri, ex);
                 throw;
             }
         }


### PR DESCRIPTION
Although we pass the exception to the logger, it doesn't actually use it, so I've included it in the message to better inform people about what problem they've run into.