### PR TITLE
Disable restore on publish for integration tests

### DIFF
--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Common/DeploymentParameters.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Common/DeploymentParameters.cs
@@ -89,6 +89,11 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
         public string AdditionalPublishParameters { get; set; }
 
         /// <summary>
+        /// Publish restores by default, this property opts out by default.
+        /// </summary>
+        public bool RestoreOnPublish { get; set; }
+
+        /// <summary>
         /// To publish the application before deployment.
         /// </summary>
         public bool PublishApplicationBeforeDeployment { get; set; }

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/ApplicationDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/ApplicationDeployer.cs
@@ -54,7 +54,8 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
                 var parameters = $"publish "
                     + $" --output \"{DeploymentParameters.PublishedApplicationRootPath}\""
                     + $" --framework {DeploymentParameters.TargetFramework}"
-                    + $" --configuration {DeploymentParameters.Configuration}";
+                    + $" --configuration {DeploymentParameters.Configuration}"
+                    + (DeploymentParameters.RestoreOnPublish ? "" : " --no-restore");
 
                 if (DeploymentParameters.ApplicationType == ApplicationType.Standalone)
                 {


### PR DESCRIPTION
#1244 Publish in 1.x didn't restore by default, it was added in 2.0. It's causing confusion with our test projects that have already been restored with an overriden version.