### PR TITLE
Add TestServer support for directly constructing HttpContexts

### DIFF
--- a/src/Microsoft.AspNetCore.TestHost/HttpContextBuilder.cs
+++ b/src/Microsoft.AspNetCore.TestHost/HttpContextBuilder.cs
@@ -1,0 +1,124 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using static Microsoft.AspNetCore.Hosting.Internal.HostingApplication;
+
+namespace Microsoft.AspNetCore.TestHost
+{
+    internal class HttpContextBuilder
+    {
+        private readonly IHttpApplication<Context> _application;
+        private readonly HttpContext _httpContext;
+        
+        private TaskCompletionSource<HttpContext> _responseTcs = new TaskCompletionSource<HttpContext>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private ResponseStream _responseStream;
+        private ResponseFeature _responseFeature = new ResponseFeature();
+        private CancellationTokenSource _requestAbortedSource = new CancellationTokenSource();
+        private bool _pipelineFinished;
+        private Context _testContext;
+
+        internal HttpContextBuilder(IHttpApplication<Context> application)
+        {
+            _application = application ?? throw new ArgumentNullException(nameof(application));
+            _httpContext = new DefaultHttpContext();
+
+            var request = _httpContext.Request;
+            request.Protocol = "HTTP/1.1";
+            request.Method = HttpMethods.Get;
+
+            _httpContext.Features.Set<IHttpResponseFeature>(_responseFeature);
+            var requestLifetimeFeature = new HttpRequestLifetimeFeature();
+            requestLifetimeFeature.RequestAborted = _requestAbortedSource.Token;
+            _httpContext.Features.Set<IHttpRequestLifetimeFeature>(requestLifetimeFeature);
+            
+            _responseStream = new ResponseStream(ReturnResponseMessageAsync, AbortRequest);
+            _responseFeature.Body = _responseStream;
+        }
+
+        internal void Configure(Action<HttpContext> configureContext)
+        {
+            if (configureContext == null)
+            {
+                throw new ArgumentNullException(nameof(configureContext));
+            }
+
+            configureContext(_httpContext);
+        }
+
+        /// <summary>
+        /// Start processing the request.
+        /// </summary>
+        /// <returns></returns>
+        internal Task<HttpContext> SendAsync(CancellationToken cancellationToken)
+        {
+            var registration = cancellationToken.Register(AbortRequest);
+
+            _testContext = _application.CreateContext(_httpContext.Features);
+
+            // Async offload, don't let the test code block the caller.
+            _ = Task.Factory.StartNew(async () =>
+            {
+                try
+                {
+                    await _application.ProcessRequestAsync(_testContext);
+                    await CompleteResponseAsync();
+                    _application.DisposeContext(_testContext, exception: null);
+                }
+                catch (Exception ex)
+                {
+                    Abort(ex);
+                    _application.DisposeContext(_testContext, ex);
+                }
+                finally
+                {
+                    registration.Dispose();
+                }
+            });
+
+            return _responseTcs.Task;
+        }
+
+        internal void AbortRequest()
+        {
+            if (!_pipelineFinished)
+            {
+                _requestAbortedSource.Cancel();
+            }
+            _responseStream.Complete();
+        }
+
+        internal async Task CompleteResponseAsync()
+        {
+            _pipelineFinished = true;
+            await ReturnResponseMessageAsync();
+            _responseStream.Complete();
+            await _responseFeature.FireOnResponseCompletedAsync();
+        }
+
+        internal async Task ReturnResponseMessageAsync()
+        {
+            // Check if the response has already started because the TrySetResult below could happen a bit late
+            // (as it happens on a different thread) by which point the CompleteResponseAsync could run and calls this
+            // method again.
+            if (!_responseFeature.HasStarted)
+            {
+                // Sets HasStarted
+                await _responseFeature.FireOnSendingHeadersAsync();
+                _responseTcs.TrySetResult(_httpContext);
+            }
+        }
+
+        internal void Abort(Exception exception)
+        {
+            _pipelineFinished = true;
+            _responseStream.Abort(exception);
+            _responseTcs.TrySetException(exception);
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.TestHost.Tests/ClientHandlerTests.cs
+++ b/test/Microsoft.AspNetCore.TestHost.Tests/ClientHandlerTests.cs
@@ -87,8 +87,7 @@ namespace Microsoft.AspNetCore.TestHost
             return httpClient.GetAsync("https://example.com/");
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
+        [Fact]
         public async Task ResubmitRequestWorks()
         {
             int requestCount = 1;
@@ -112,8 +111,7 @@ namespace Microsoft.AspNetCore.TestHost
             Assert.Equal("TestValue:2", response.Headers.GetValues("TestHeader").First());
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
+        [Fact]
         public async Task MiddlewareOnlySetsHeaders()
         {
             var handler = new ClientHandler(PathString.Empty, new DummyApplication(context =>
@@ -126,8 +124,7 @@ namespace Microsoft.AspNetCore.TestHost
             Assert.Equal("TestValue", response.Headers.GetValues("TestHeader").First());
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
+        [Fact]
         public async Task BlockingMiddlewareShouldNotBlockClient()
         {
             ManualResetEvent block = new ManualResetEvent(false);
@@ -144,8 +141,7 @@ namespace Microsoft.AspNetCore.TestHost
             HttpResponseMessage response = await task;
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
+        [Fact]
         public async Task HeadersAvailableBeforeBodyFinished()
         {
             ManualResetEvent block = new ManualResetEvent(false);
@@ -164,8 +160,7 @@ namespace Microsoft.AspNetCore.TestHost
             Assert.Equal("BodyStarted,BodyFinished", await response.Content.ReadAsStringAsync());
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
+        [Fact]
         public async Task FlushSendsHeaders()
         {
             ManualResetEvent block = new ManualResetEvent(false);
@@ -184,8 +179,7 @@ namespace Microsoft.AspNetCore.TestHost
             Assert.Equal("BodyFinished", await response.Content.ReadAsStringAsync());
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
+        [Fact]
         public async Task ClientDisposalCloses()
         {
             ManualResetEvent block = new ManualResetEvent(false);
@@ -210,8 +204,7 @@ namespace Microsoft.AspNetCore.TestHost
             block.Set();
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
+        [Fact]
         public async Task ClientCancellationAborts()
         {
             ManualResetEvent block = new ManualResetEvent(false);
@@ -249,8 +242,7 @@ namespace Microsoft.AspNetCore.TestHost
                 HttpCompletionOption.ResponseHeadersRead));
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
+        [Fact]
         public async Task ExceptionAfterFirstWriteIsReported()
         {
             ManualResetEvent block = new ManualResetEvent(false);
@@ -326,10 +318,8 @@ namespace Microsoft.AspNetCore.TestHost
                 return Task.FromResult(0);
             }
         }
-
-
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
+        
+        [Fact]
         public async Task ClientHandlerCreateContextWithDefaultRequestParameters()
         {
             // This logger will attempt to access information from HttpRequest once the HttpContext is created

--- a/test/Microsoft.AspNetCore.TestHost.Tests/HttpContextBuilderTests.cs
+++ b/test/Microsoft.AspNetCore.TestHost.Tests/HttpContextBuilderTests.cs
@@ -1,0 +1,302 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Microsoft.AspNetCore.TestHost
+{
+    public class HttpContextBuilderTests
+    {
+        [Fact]
+        public async Task ExpectedValuesAreAvailable()
+        {
+            var builder = new WebHostBuilder().Configure(app => { });
+            var server = new TestServer(builder);
+            server.BaseAddress = new Uri("https://example.com/A/Path/");
+            var context = await server.SendAsync(c =>
+            {
+                c.Request.Method = HttpMethods.Post;
+                c.Request.Path = "/and/file.txt";
+                c.Request.QueryString = new QueryString("?and=query");
+            });
+
+            Assert.True(context.RequestAborted.CanBeCanceled);
+            Assert.Equal("HTTP/1.1", context.Request.Protocol);
+            Assert.Equal("POST", context.Request.Method);
+            Assert.Equal("https", context.Request.Scheme);
+            Assert.Equal("example.com", context.Request.Host.Value);
+            Assert.Equal("/A/Path", context.Request.PathBase.Value);
+            Assert.Equal("/and/file.txt", context.Request.Path.Value);
+            Assert.Equal("?and=query", context.Request.QueryString.Value);
+            Assert.NotNull(context.Request.Body);
+            Assert.NotNull(context.Request.Headers);
+            Assert.NotNull(context.Response.Headers);
+            Assert.NotNull(context.Response.Body);
+            Assert.Equal(404, context.Response.StatusCode);
+            Assert.Null(context.Features.Get<IHttpResponseFeature>().ReasonPhrase);
+        }
+
+        [Fact]
+        public async Task SingleSlashNotMovedToPathBase()
+        {
+            var builder = new WebHostBuilder().Configure(app => { });
+            var server = new TestServer(builder);
+            var context = await server.SendAsync(c =>
+            {
+                c.Request.Path = "/";
+            });
+
+            Assert.Equal("", context.Request.PathBase.Value);
+            Assert.Equal("/", context.Request.Path.Value);
+        }
+
+        [Fact]
+        public async Task MiddlewareOnlySetsHeaders()
+        {
+            var builder = new WebHostBuilder().Configure(app =>
+            {
+                app.Run(c =>
+                {
+                    c.Response.Headers["TestHeader"] = "TestValue";
+                    return Task.FromResult(0);
+                });
+            });
+            var server = new TestServer(builder);
+            var context = await server.SendAsync(c => { });
+
+            Assert.Equal("TestValue", context.Response.Headers["TestHeader"]);
+        }
+
+        [Fact]
+        public async Task BlockingMiddlewareShouldNotBlockClient()
+        {
+            var block = new ManualResetEvent(false);
+            var builder = new WebHostBuilder().Configure(app =>
+            {
+                app.Run(c =>
+                {
+                    block.WaitOne();
+                    return Task.FromResult(0);
+                });
+            });
+            var server = new TestServer(builder);
+            var task = server.SendAsync(c => { });
+
+            Assert.False(task.IsCompleted);
+            Assert.False(task.Wait(50));
+            block.Set();
+            var context = await task;
+        }
+
+        [Fact]
+        public async Task HeadersAvailableBeforeBodyFinished()
+        {
+            var block = new ManualResetEvent(false);
+            var builder = new WebHostBuilder().Configure(app =>
+            {
+                app.Run(async c =>
+                {
+                    c.Response.Headers["TestHeader"] = "TestValue";
+                    await c.Response.WriteAsync("BodyStarted,");
+                    block.WaitOne();
+                    await c.Response.WriteAsync("BodyFinished");
+                });
+            });
+            var server = new TestServer(builder);
+            var context = await server.SendAsync(c => { });
+
+            Assert.Equal("TestValue", context.Response.Headers["TestHeader"]);
+            block.Set();
+            Assert.Equal("BodyStarted,BodyFinished", new StreamReader(context.Response.Body).ReadToEnd());
+        }
+
+        [Fact]
+        public async Task FlushSendsHeaders()
+        {
+            var block = new ManualResetEvent(false);
+            var builder = new WebHostBuilder().Configure(app =>
+            {
+                app.Run(async c =>
+                {
+                    c.Response.Headers["TestHeader"] = "TestValue";
+                    c.Response.Body.Flush();
+                    block.WaitOne();
+                    await c.Response.WriteAsync("BodyFinished");
+                });
+            });
+            var server = new TestServer(builder);
+            var context = await server.SendAsync(c => { });
+
+            Assert.Equal("TestValue", context.Response.Headers["TestHeader"]);
+            block.Set();
+            Assert.Equal("BodyFinished", new StreamReader(context.Response.Body).ReadToEnd());
+        }
+
+        [Fact]
+        public async Task ClientDisposalCloses()
+        {
+            var block = new ManualResetEvent(false);
+            var builder = new WebHostBuilder().Configure(app =>
+            {
+                app.Run(async c =>
+                {
+                    c.Response.Headers["TestHeader"] = "TestValue";
+                    c.Response.Body.Flush();
+                    block.WaitOne();
+                    await c.Response.WriteAsync("BodyFinished");
+                });
+            });
+            var server = new TestServer(builder);
+            var context = await server.SendAsync(c => { });
+
+            Assert.Equal("TestValue", context.Response.Headers["TestHeader"]);
+            var responseStream = context.Response.Body;
+            Task<int> readTask = responseStream.ReadAsync(new byte[100], 0, 100);
+            Assert.False(readTask.IsCompleted);
+            responseStream.Dispose();
+            Assert.True(readTask.Wait(TimeSpan.FromSeconds(10)));
+            Assert.Equal(0, readTask.Result);
+            block.Set();
+        }
+
+        [Fact]
+        public void ClientCancellationAborts()
+        {
+            var block = new ManualResetEvent(false);
+            var builder = new WebHostBuilder().Configure(app =>
+            {
+                app.Run(c =>
+                {
+                    block.Set();
+                    Assert.True(c.RequestAborted.WaitHandle.WaitOne(TimeSpan.FromSeconds(10)));
+                    c.RequestAborted.ThrowIfCancellationRequested();
+                    return Task.CompletedTask;
+                });
+            });
+            var server = new TestServer(builder);
+            var cts = new CancellationTokenSource();
+            var contextTask = server.SendAsync(c => { }, cts.Token);
+            block.WaitOne();
+            cts.Cancel();
+
+            var ex = Assert.Throws<AggregateException>(() => contextTask.Wait(TimeSpan.FromSeconds(10)));
+            Assert.IsAssignableFrom<OperationCanceledException>(ex.GetBaseException());
+        }
+
+        [Fact]
+        public async Task ClientCancellationAbortsReadAsync()
+        {
+            var block = new ManualResetEvent(false);
+            var builder = new WebHostBuilder().Configure(app =>
+            {
+                app.Run(async c =>
+                {
+                    c.Response.Headers["TestHeader"] = "TestValue";
+                    c.Response.Body.Flush();
+                    block.WaitOne();
+                    await c.Response.WriteAsync("BodyFinished");
+                });
+            });
+            var server = new TestServer(builder);
+            var context = await server.SendAsync(c => { });
+
+            Assert.Equal("TestValue", context.Response.Headers["TestHeader"]);
+            var responseStream = context.Response.Body;
+            var cts = new CancellationTokenSource();
+            var readTask = responseStream.ReadAsync(new byte[100], 0, 100, cts.Token);
+            Assert.False(readTask.IsCompleted);
+            cts.Cancel();
+            var ex = Assert.Throws<AggregateException>(() => readTask.Wait(TimeSpan.FromSeconds(10)));
+            Assert.IsAssignableFrom<OperationCanceledException>(ex.GetBaseException().InnerException);
+            block.Set();
+        }
+
+        [Fact]
+        public Task ExceptionBeforeFirstWriteIsReported()
+        {
+            var builder = new WebHostBuilder().Configure(app =>
+            {
+                app.Run(c =>
+                {
+                    throw new InvalidOperationException("Test Exception");
+                });
+            });
+            var server = new TestServer(builder);
+            return Assert.ThrowsAsync<InvalidOperationException>(() => server.SendAsync(c => { }));
+        }
+
+        [Fact]
+        public async Task ExceptionAfterFirstWriteIsReported()
+        {
+            var block = new ManualResetEvent(false);
+            var builder = new WebHostBuilder().Configure(app =>
+            {
+                app.Run(async c =>
+                {
+                    c.Response.Headers["TestHeader"] = "TestValue";
+                    await c.Response.WriteAsync("BodyStarted");
+                    block.WaitOne();
+                    throw new InvalidOperationException("Test Exception");
+                });
+            });
+            var server = new TestServer(builder);
+            var context = await server.SendAsync(c => { });
+
+            Assert.Equal("TestValue", context.Response.Headers["TestHeader"]);
+            Assert.Equal(11, context.Response.Body.Read(new byte[100], 0, 100));
+            block.Set();
+            var ex = Assert.Throws<IOException>(() => context.Response.Body.Read(new byte[100], 0, 100));
+            Assert.IsAssignableFrom<InvalidOperationException>(ex.InnerException);
+        }
+
+        [Fact]
+        public async Task ClientHandlerCreateContextWithDefaultRequestParameters()
+        {
+            // This logger will attempt to access information from HttpRequest once the HttpContext is created
+            var logger = new VerifierLogger();
+            var builder = new WebHostBuilder()
+                .ConfigureServices(services =>
+                {
+                    services.AddSingleton<ILogger<IWebHost>>(logger);
+                })
+                .Configure(app =>
+                {
+                    app.Run(context =>
+                    {
+                        return Task.FromResult(0);
+                    });
+                });
+            var server = new TestServer(builder);
+
+            // The HttpContext will be created and the logger will make sure that the HttpRequest exists and contains reasonable values
+            var ctx = await server.SendAsync(c => { });
+        }
+
+        private class VerifierLogger : ILogger<IWebHost>
+        {
+            public IDisposable BeginScope<TState>(TState state) => new NoopDispoasble();
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            // This call verifies that fields of HttpRequest are accessed and valid
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter) => formatter(state, exception);
+
+            class NoopDispoasble : IDisposable
+            {
+                public void Dispose()
+                {
+                }
+            }
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.TestHost.Tests/RequestBuilderTests.cs
+++ b/test/Microsoft.AspNetCore.TestHost.Tests/RequestBuilderTests.cs
@@ -2,16 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Testing.xunit;
 using Xunit;
 
 namespace Microsoft.AspNetCore.TestHost
 {
     public class RequestBuilderTests
     {
-        // c.f. https://github.com/mono/mono/pull/1832
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        [Fact]
         public void AddRequestHeader()
         {
             var builder = new WebHostBuilder().Configure(app => { });

--- a/test/Microsoft.AspNetCore.TestHost.Tests/TestClientTests.cs
+++ b/test/Microsoft.AspNetCore.TestHost.Tests/TestClientTests.cs
@@ -267,14 +267,8 @@ namespace Microsoft.AspNetCore.TestHost
                 }
             };
             var builder = new WebHostBuilder()
-                .ConfigureServices(services =>
-                {
-                    services.AddSingleton<ILogger<IWebHost>>(logger);
-                })
-                .Configure(app =>
-                {
-                    app.Run(appDelegate);
-                });
+                .ConfigureServices(services => services.AddSingleton<ILogger<IWebHost>>(logger))
+                .Configure(app => app.Run(appDelegate));
             var server = new TestServer(builder);
 
             // Act
@@ -283,7 +277,7 @@ namespace Microsoft.AspNetCore.TestHost
             tokenSource.Cancel();
 
             // Assert
-            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await client.ConnectAsync(new System.Uri("http://localhost"), tokenSource.Token));
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await client.ConnectAsync(new Uri("http://localhost"), tokenSource.Token));
         }
 
         private class VerifierLogger : ILogger<IWebHost>


### PR DESCRIPTION
#816, #1135 Customers frequently ask how to test aspects of their application not exposed from HttpClient/HttpRequestMessage. These include client certificates, local and remote IPs and ports, windows auth user, adding/removing or manipulating features, etc.. This capability used to exist in Katana but was dropped when refactoring for Core.

This adds a new HttpContextBuilder that constructs the test context, lets you modify it as you see fit, and then send it. This gives you deep control over the request state for testing.

I've also moved ClientHandler and WebSocketClient to use this new layer to reduce duplication.

/cc: @blowdart 