### PR TITLE
TestServer: mark response headers IsReadOnly on start

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -1,37 +1,37 @@
-<Project>
+﻿<Project>
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
   <PropertyGroup Label="Package Versions">
     <InternalAspNetCoreSdkPackageVersion>2.1.0-preview1-15549</InternalAspNetCoreSdkPackageVersion>
-    <MicrosoftAspNetCoreHttpAbstractionsPackageVersion>2.1.0-preview1-27475</MicrosoftAspNetCoreHttpAbstractionsPackageVersion>
-    <MicrosoftAspNetCoreHttpExtensionsPackageVersion>2.1.0-preview1-27475</MicrosoftAspNetCoreHttpExtensionsPackageVersion>
-    <MicrosoftAspNetCoreHttpFeaturesPackageVersion>2.1.0-preview1-27475</MicrosoftAspNetCoreHttpFeaturesPackageVersion>
-    <MicrosoftAspNetCoreHttpPackageVersion>2.1.0-preview1-27475</MicrosoftAspNetCoreHttpPackageVersion>
-    <MicrosoftAspNetCoreOwinPackageVersion>2.1.0-preview1-27475</MicrosoftAspNetCoreOwinPackageVersion>
-    <MicrosoftAspNetCoreTestingPackageVersion>2.1.0-preview1-27475</MicrosoftAspNetCoreTestingPackageVersion>
-    <MicrosoftExtensionsConfigurationAbstractionsPackageVersion>2.1.0-preview1-27475</MicrosoftExtensionsConfigurationAbstractionsPackageVersion>
-    <MicrosoftExtensionsConfigurationBinderPackageVersion>2.1.0-preview1-27475</MicrosoftExtensionsConfigurationBinderPackageVersion>
-    <MicrosoftExtensionsConfigurationCommandLinePackageVersion>2.1.0-preview1-27475</MicrosoftExtensionsConfigurationCommandLinePackageVersion>
-    <MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>2.1.0-preview1-27475</MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>
-    <MicrosoftExtensionsConfigurationFileExtensionsPackageVersion>2.1.0-preview1-27475</MicrosoftExtensionsConfigurationFileExtensionsPackageVersion>
-    <MicrosoftExtensionsConfigurationJsonPackageVersion>2.1.0-preview1-27475</MicrosoftExtensionsConfigurationJsonPackageVersion>
-    <MicrosoftExtensionsConfigurationPackageVersion>2.1.0-preview1-27475</MicrosoftExtensionsConfigurationPackageVersion>
-    <MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>2.1.0-preview1-27475</MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>
-    <MicrosoftExtensionsDependencyInjectionPackageVersion>2.1.0-preview1-27475</MicrosoftExtensionsDependencyInjectionPackageVersion>
-    <MicrosoftExtensionsDiagnosticAdapterPackageVersion>2.1.0-preview1-27475</MicrosoftExtensionsDiagnosticAdapterPackageVersion>
-    <MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>2.1.0-preview1-27475</MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>
-    <MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>2.1.0-preview1-27475</MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>
-    <MicrosoftExtensionsFileProvidersPhysicalPackageVersion>2.1.0-preview1-27475</MicrosoftExtensionsFileProvidersPhysicalPackageVersion>
-    <MicrosoftExtensionsLoggingAbstractionsPackageVersion>2.1.0-preview1-27475</MicrosoftExtensionsLoggingAbstractionsPackageVersion>
-    <MicrosoftExtensionsLoggingConsolePackageVersion>2.1.0-preview1-27475</MicrosoftExtensionsLoggingConsolePackageVersion>
-    <MicrosoftExtensionsLoggingPackageVersion>2.1.0-preview1-27475</MicrosoftExtensionsLoggingPackageVersion>
-    <MicrosoftExtensionsLoggingTestingPackageVersion>2.1.0-preview1-27475</MicrosoftExtensionsLoggingTestingPackageVersion>
-    <MicrosoftExtensionsOptionsPackageVersion>2.1.0-preview1-27475</MicrosoftExtensionsOptionsPackageVersion>
-    <MicrosoftExtensionsProcessSourcesPackageVersion>2.1.0-preview1-27475</MicrosoftExtensionsProcessSourcesPackageVersion>
-    <MicrosoftExtensionsRazorViewsSourcesPackageVersion>2.1.0-preview1-27475</MicrosoftExtensionsRazorViewsSourcesPackageVersion>
-    <MicrosoftExtensionsStackTraceSourcesPackageVersion>2.1.0-preview1-27475</MicrosoftExtensionsStackTraceSourcesPackageVersion>
-    <MicrosoftExtensionsTypeNameHelperSourcesPackageVersion>2.1.0-preview1-27475</MicrosoftExtensionsTypeNameHelperSourcesPackageVersion>
+    <MicrosoftAspNetCoreHttpAbstractionsPackageVersion>2.1.0-preview1-27518</MicrosoftAspNetCoreHttpAbstractionsPackageVersion>
+    <MicrosoftAspNetCoreHttpExtensionsPackageVersion>2.1.0-preview1-27518</MicrosoftAspNetCoreHttpExtensionsPackageVersion>
+    <MicrosoftAspNetCoreHttpFeaturesPackageVersion>2.1.0-preview1-27518</MicrosoftAspNetCoreHttpFeaturesPackageVersion>
+    <MicrosoftAspNetCoreHttpPackageVersion>2.1.0-preview1-27518</MicrosoftAspNetCoreHttpPackageVersion>
+    <MicrosoftAspNetCoreOwinPackageVersion>2.1.0-preview1-27518</MicrosoftAspNetCoreOwinPackageVersion>
+    <MicrosoftAspNetCoreTestingPackageVersion>2.1.0-preview1-27518</MicrosoftAspNetCoreTestingPackageVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsPackageVersion>2.1.0-preview1-27518</MicrosoftExtensionsConfigurationAbstractionsPackageVersion>
+    <MicrosoftExtensionsConfigurationBinderPackageVersion>2.1.0-preview1-27518</MicrosoftExtensionsConfigurationBinderPackageVersion>
+    <MicrosoftExtensionsConfigurationCommandLinePackageVersion>2.1.0-preview1-27518</MicrosoftExtensionsConfigurationCommandLinePackageVersion>
+    <MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>2.1.0-preview1-27518</MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>
+    <MicrosoftExtensionsConfigurationFileExtensionsPackageVersion>2.1.0-preview1-27518</MicrosoftExtensionsConfigurationFileExtensionsPackageVersion>
+    <MicrosoftExtensionsConfigurationJsonPackageVersion>2.1.0-preview1-27518</MicrosoftExtensionsConfigurationJsonPackageVersion>
+    <MicrosoftExtensionsConfigurationPackageVersion>2.1.0-preview1-27518</MicrosoftExtensionsConfigurationPackageVersion>
+    <MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>2.1.0-preview1-27518</MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>
+    <MicrosoftExtensionsDependencyInjectionPackageVersion>2.1.0-preview1-27518</MicrosoftExtensionsDependencyInjectionPackageVersion>
+    <MicrosoftExtensionsDiagnosticAdapterPackageVersion>2.1.0-preview1-27518</MicrosoftExtensionsDiagnosticAdapterPackageVersion>
+    <MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>2.1.0-preview1-27518</MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>
+    <MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>2.1.0-preview1-27518</MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>
+    <MicrosoftExtensionsFileProvidersPhysicalPackageVersion>2.1.0-preview1-27518</MicrosoftExtensionsFileProvidersPhysicalPackageVersion>
+    <MicrosoftExtensionsLoggingAbstractionsPackageVersion>2.1.0-preview1-27518</MicrosoftExtensionsLoggingAbstractionsPackageVersion>
+    <MicrosoftExtensionsLoggingConsolePackageVersion>2.1.0-preview1-27518</MicrosoftExtensionsLoggingConsolePackageVersion>
+    <MicrosoftExtensionsLoggingPackageVersion>2.1.0-preview1-27518</MicrosoftExtensionsLoggingPackageVersion>
+    <MicrosoftExtensionsLoggingTestingPackageVersion>2.1.0-preview1-27518</MicrosoftExtensionsLoggingTestingPackageVersion>
+    <MicrosoftExtensionsOptionsPackageVersion>2.1.0-preview1-27518</MicrosoftExtensionsOptionsPackageVersion>
+    <MicrosoftExtensionsProcessSourcesPackageVersion>2.1.0-preview1-27518</MicrosoftExtensionsProcessSourcesPackageVersion>
+    <MicrosoftExtensionsRazorViewsSourcesPackageVersion>2.1.0-preview1-27518</MicrosoftExtensionsRazorViewsSourcesPackageVersion>
+    <MicrosoftExtensionsStackTraceSourcesPackageVersion>2.1.0-preview1-27518</MicrosoftExtensionsStackTraceSourcesPackageVersion>
+    <MicrosoftExtensionsTypeNameHelperSourcesPackageVersion>2.1.0-preview1-27518</MicrosoftExtensionsTypeNameHelperSourcesPackageVersion>
     <MicrosoftNETCoreApp20PackageVersion>2.0.0</MicrosoftNETCoreApp20PackageVersion>
     <MicrosoftNETCoreWindowsApiSetsPackageVersion>1.0.1</MicrosoftNETCoreWindowsApiSetsPackageVersion>
     <MicrosoftNETTestSdkPackageVersion>15.3.0</MicrosoftNETTestSdkPackageVersion>

--- a/src/Microsoft.AspNetCore.TestHost/HttpContextBuilder.cs
+++ b/src/Microsoft.AspNetCore.TestHost/HttpContextBuilder.cs
@@ -110,7 +110,13 @@ namespace Microsoft.AspNetCore.TestHost
             {
                 // Sets HasStarted
                 await _responseFeature.FireOnSendingHeadersAsync();
-                _responseTcs.TrySetResult(_httpContext);
+                // Copy the feature collection so we're not multi-threading on the same collection.
+                var newFeatures = new FeatureCollection();
+                foreach (var pair in _httpContext.Features)
+                {
+                    newFeatures[pair.Key] = pair.Value;
+                }
+                _responseTcs.TrySetResult(new DefaultHttpContext(newFeatures));
             }
         }
 

--- a/src/Microsoft.AspNetCore.TestHost/ResponseFeature.cs
+++ b/src/Microsoft.AspNetCore.TestHost/ResponseFeature.cs
@@ -14,6 +14,8 @@ namespace Microsoft.AspNetCore.TestHost
         private Func<Task> _responseStartingAsync = () => Task.FromResult(true);
         private Func<Task> _responseCompletedAsync = () => Task.FromResult(true);
         private HeaderDictionary _headers = new HeaderDictionary();
+        private int _statusCode;
+        private string _reasonPhrase;
 
         public ResponseFeature()
         {
@@ -25,9 +27,37 @@ namespace Microsoft.AspNetCore.TestHost
             StatusCode = 200;
         }
 
-        public int StatusCode { get; set; }
+        public int StatusCode
+        {
+            get => _statusCode;
+            set
+            {
+                if (HasStarted)
+                {
+                    throw new InvalidOperationException("The status code cannot be set, the response has already started.");
+                }
+                if (value < 100)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), value, "The status code cannot be set to a value less than 100");
+                }
 
-        public string ReasonPhrase { get; set; }
+                _statusCode = value;
+            }
+        }
+
+        public string ReasonPhrase
+        {
+            get => _reasonPhrase;
+            set
+            {
+                if (HasStarted)
+                {
+                    throw new InvalidOperationException("The reason phrase cannot be set, the response has already started.");
+                }
+
+                _reasonPhrase = value;
+            }
+        }
 
         public IHeaderDictionary Headers { get; set; }
 

--- a/src/Microsoft.AspNetCore.TestHost/ResponseFeature.cs
+++ b/src/Microsoft.AspNetCore.TestHost/ResponseFeature.cs
@@ -13,10 +13,11 @@ namespace Microsoft.AspNetCore.TestHost
     {
         private Func<Task> _responseStartingAsync = () => Task.FromResult(true);
         private Func<Task> _responseCompletedAsync = () => Task.FromResult(true);
+        private HeaderDictionary _headers = new HeaderDictionary();
 
         public ResponseFeature()
         {
-            Headers = new HeaderDictionary();
+            Headers = _headers;
             Body = new MemoryStream();
 
             // 200 is the default status code all the way down to the host, so we set it
@@ -69,6 +70,7 @@ namespace Microsoft.AspNetCore.TestHost
         {
             await _responseStartingAsync();
             HasStarted = true;
+            _headers.IsReadOnly = true;
         }
 
         public Task FireOnResponseCompletedAsync()

--- a/test/Microsoft.AspNetCore.TestHost.Tests/ResponseFeatureTests.cs
+++ b/test/Microsoft.AspNetCore.TestHost.Tests/ResponseFeatureTests.cs
@@ -22,6 +22,7 @@ namespace Microsoft.AspNetCore.TestHost
             await responseInformation.FireOnSendingHeadersAsync();
 
             Assert.True(responseInformation.HasStarted);
+            Assert.True(responseInformation.Headers.IsReadOnly);
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.TestHost.Tests/ResponseFeatureTests.cs
+++ b/test/Microsoft.AspNetCore.TestHost.Tests/ResponseFeatureTests.cs
@@ -41,5 +41,28 @@ namespace Microsoft.AspNetCore.TestHost
                 }, state: "string");
             });
         }
+
+        [Fact]
+        public void StatusCode_ThrowsWhenHasStarted()
+        {
+            var responseInformation = new ResponseFeature();
+            responseInformation.HasStarted = true;
+
+            Assert.Throws<InvalidOperationException>(() => responseInformation.StatusCode = 400);
+            Assert.Throws<InvalidOperationException>(() => responseInformation.ReasonPhrase = "Hello World");
+        }
+
+        [Fact]
+        public void StatusCode_MustBeGreaterThan99()
+        {
+            var responseInformation = new ResponseFeature();
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => responseInformation.StatusCode = 99);
+            Assert.Throws<ArgumentOutOfRangeException>(() => responseInformation.StatusCode = 0);
+            Assert.Throws<ArgumentOutOfRangeException>(() => responseInformation.StatusCode = -200);
+            responseInformation.StatusCode = 100;
+            responseInformation.StatusCode = 200;
+            responseInformation.StatusCode = 1000;
+        }
     }
 }


### PR DESCRIPTION
#1253 This makes TestServer act more like a real server and will help us find potential product bugs.