### PR TITLE
Support the Extensions.Abstractions from Hosting.Abstractions

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting/Internal/ApplicationLifetime.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/ApplicationLifetime.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
     /// <summary>
     /// Allows consumers to perform cleanup during a graceful shutdown.
     /// </summary>
-    public class ApplicationLifetime : IApplicationLifetime
+    public class ApplicationLifetime : IApplicationLifetime, Extensions.Hosting.IApplicationLifetime
     {
         private readonly CancellationTokenSource _startedSource = new CancellationTokenSource();
         private readonly CancellationTokenSource _stoppingSource = new CancellationTokenSource();

--- a/src/Microsoft.AspNetCore.Hosting/Internal/HostingEnvironment.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/HostingEnvironment.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.FileProviders;
 
 namespace Microsoft.AspNetCore.Hosting.Internal
 {
-    public class HostingEnvironment : IHostingEnvironment
+    public class HostingEnvironment : IHostingEnvironment, Extensions.Hosting.IHostingEnvironment
     {
         public string EnvironmentName { get; set; } = Hosting.EnvironmentName.Production;
 

--- a/src/Microsoft.AspNetCore.Hosting/Internal/WebHost.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/WebHost.cs
@@ -76,6 +76,11 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             _applicationServiceCollection = appServices;
             _hostingServiceProvider = hostingServiceProvider;
             _applicationServiceCollection.AddSingleton<IApplicationLifetime, ApplicationLifetime>();
+            // There's no way to to register multiple service types per definition. See https://github.com/aspnet/DependencyInjection/issues/360
+            _applicationServiceCollection.AddSingleton(sp =>
+            {
+                return sp.GetRequiredService<IApplicationLifetime>() as Extensions.Hosting.IApplicationLifetime;
+            });
             _applicationServiceCollection.AddSingleton<HostedServiceExecutor>();
         }
 

--- a/src/Microsoft.AspNetCore.Hosting/Microsoft.AspNetCore.Hosting.csproj
+++ b/src/Microsoft.AspNetCore.Hosting/Microsoft.AspNetCore.Hosting.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.AspNetCore.Hosting.Abstractions\Microsoft.AspNetCore.Hosting.Abstractions.csproj" />
+    <ProjectReference Include="..\Microsoft.Extensions.Hosting.Abstractions\Microsoft.Extensions.Hosting.Abstractions.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.AspNetCore.Hosting/WebHostBuilder.cs
+++ b/src/Microsoft.AspNetCore.Hosting/WebHostBuilder.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.Hosting
     /// </summary>
     public class WebHostBuilder : IWebHostBuilder
     {
-        private readonly IHostingEnvironment _hostingEnvironment;
+        private readonly HostingEnvironment _hostingEnvironment;
         private readonly List<Action<WebHostBuilderContext, IServiceCollection>> _configureServicesDelegates;
 
         private IConfiguration _config;
@@ -239,7 +239,8 @@ namespace Microsoft.AspNetCore.Hosting
 
             var services = new ServiceCollection();
             services.AddSingleton(_options);
-            services.AddSingleton(_hostingEnvironment);
+            services.AddSingleton<IHostingEnvironment>(_hostingEnvironment);
+            services.AddSingleton<Extensions.Hosting.IHostingEnvironment>(_hostingEnvironment);
             services.AddSingleton(_context);
 
             var builder = new ConfigurationBuilder()

--- a/test/Microsoft.AspNetCore.Hosting.Tests/WebHostBuilderTests.cs
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/WebHostBuilderTests.cs
@@ -526,6 +526,7 @@ namespace Microsoft.AspNetCore.Hosting
                 .Build())
             {
                 Assert.Equal(expected, host.Services.GetService<IHostingEnvironment>().EnvironmentName);
+                Assert.Equal(expected, host.Services.GetService<Extensions.Hosting.IHostingEnvironment>().EnvironmentName);
             }
         }
 
@@ -568,6 +569,7 @@ namespace Microsoft.AspNetCore.Hosting
                 .Build())
             {
                 Assert.Equal("/", host.Services.GetService<IHostingEnvironment>().ContentRootPath);
+                Assert.Equal("/", host.Services.GetService<Extensions.Hosting.IHostingEnvironment>().ContentRootPath);
             }
         }
 
@@ -581,8 +583,13 @@ namespace Microsoft.AspNetCore.Hosting
                 .Build())
             {
                 var basePath = host.Services.GetRequiredService<IHostingEnvironment>().ContentRootPath;
+                var basePath2 = host.Services.GetService<Extensions.Hosting.IHostingEnvironment>().ContentRootPath;
+
                 Assert.True(Path.IsPathRooted(basePath));
                 Assert.EndsWith(Path.DirectorySeparatorChar + "testroot", basePath);
+
+                Assert.True(Path.IsPathRooted(basePath2));
+                Assert.EndsWith(Path.DirectorySeparatorChar + "testroot", basePath2);
             }
         }
 
@@ -596,6 +603,7 @@ namespace Microsoft.AspNetCore.Hosting
             {
                 var appBase = AppContext.BaseDirectory;
                 Assert.Equal(appBase, host.Services.GetService<IHostingEnvironment>().ContentRootPath);
+                Assert.Equal(appBase, host.Services.GetService<Extensions.Hosting.IHostingEnvironment>().ContentRootPath);
             }
         }
 
@@ -620,7 +628,9 @@ namespace Microsoft.AspNetCore.Hosting
                 .Build())
             {
                 var hostingEnv = host.Services.GetService<IHostingEnvironment>();
+                var hostingEnv2 = host.Services.GetService<Extensions.Hosting.IHostingEnvironment>();
                 Assert.Equal(typeof(Startup).Assembly.GetName().Name, hostingEnv.ApplicationName);
+                Assert.Equal(typeof(Startup).Assembly.GetName().Name, hostingEnv2.ApplicationName);
             }
         }
 
@@ -634,7 +644,9 @@ namespace Microsoft.AspNetCore.Hosting
                 .Build())
             {
                 var hostingEnv = host.Services.GetService<IHostingEnvironment>();
+                var hostingEnv2 = host.Services.GetService<Extensions.Hosting.IHostingEnvironment>();
                 Assert.Equal(typeof(StartupNoServices).Assembly.GetName().Name, hostingEnv.ApplicationName);
+                Assert.Equal(typeof(StartupNoServices).Assembly.GetName().Name, hostingEnv2.ApplicationName);
             }
         }
 
@@ -1046,7 +1058,7 @@ namespace Microsoft.AspNetCore.Hosting
                        .ConfigureServices(services => services.AddSingleton<ITestSink>(loggerProvider.Sink))
                        .ConfigureLogging((_, lf) => lf.AddProvider(loggerProvider))
                        .ConfigureAppConfiguration((context, configurationBuilder) => configurationBuilder.AddInMemoryCollection(
-                           new []
+                           new[]
                            {
                                new KeyValuePair<string,string>("testhostingstartup:config", "value")
                            }));


### PR DESCRIPTION
- The goal here is to enable components that use hosting abstractions to use
the web host. It lets us start to decouple components from the web host abstractions
where possible while not breaking any existing components. This will allow things
to work in both the generic host and the web host. The one snafu is the WebHostBuilderContext
which has an IHostingEnvironment typed as the AspNetCore.Abstractions type.
- Updated tests.

#1218