### PR TITLE
Delay IServer and Startup.Configure until StartAsync

### DIFF
--- a/test/Microsoft.AspNetCore.Hosting.Tests/WebHostBuilderTests.cs
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/WebHostBuilderTests.cs
@@ -182,7 +182,7 @@ namespace Microsoft.AspNetCore.Hosting
                     options.ValidateScopes = true;
                 });
 
-            Assert.Throws<InvalidOperationException>(() => hostBuilder.Build());
+            Assert.Throws<InvalidOperationException>(() => hostBuilder.Build().Start());
         }
 
         [Fact]
@@ -208,7 +208,7 @@ namespace Microsoft.AspNetCore.Hosting
                     options.ValidateScopes = true;
                 });
 
-            Assert.Throws<InvalidOperationException>(() => hostBuilder.Build());
+            Assert.Throws<InvalidOperationException>(() => hostBuilder.Build().Start());
             Assert.True(configurationCallbackCalled);
         }
 
@@ -784,8 +784,9 @@ namespace Microsoft.AspNetCore.Hosting
                 })
                 .UseServer(new TestServer());
 
-            using (builder.Build())
+            using (var host = builder.Build())
             {
+                host.Start();
                 Assert.NotNull(startup.ServiceADescriptor);
                 Assert.NotNull(startup.ServiceA);
             }
@@ -823,6 +824,7 @@ namespace Microsoft.AspNetCore.Hosting
 
             using (var host = (WebHost)builder.Build())
             {
+                host.Start();
                 var sink = host.Services.GetRequiredService<ITestSink>();
                 Assert.Contains(sink.Writes, w => w.State.ToString() == "From startup");
             }
@@ -920,6 +922,7 @@ namespace Microsoft.AspNetCore.Hosting
 
             using (var host = (WebHost)builder.Build())
             {
+                host.Start();
                 var sink = host.Services.GetRequiredService<ITestSink>();
                 Assert.Contains(sink.Writes, w => w.Exception?.Message == "Startup exception");
             }
@@ -940,7 +943,7 @@ namespace Microsoft.AspNetCore.Hosting
                 })
                 .UseServer(new TestServer());
 
-            Assert.Throws<InvalidOperationException>(() => builder.Build());
+            Assert.Throws<InvalidOperationException>(() => builder.Build().Start());
 
             Assert.NotNull(testSink);
             Assert.Contains(testSink.Writes, w => w.Exception?.Message == "Startup exception");

--- a/test/Microsoft.AspNetCore.Hosting.Tests/WebHostTests.cs
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/WebHostTests.cs
@@ -759,6 +759,7 @@ namespace Microsoft.AspNetCore.Hosting
                 })
                 .Build())
             {
+                host.Start();
                 Assert.Equal(6, configureOrder);
             }
         }


### PR DESCRIPTION
#1263 Tools want to call Startup.ConfigureServices without resolving Kestrel options like loading server certs. Delay initializing the server until StartAsync. The catch is that we also have to delay Startup.Configure as the server features are available there.

The main consequence is that this delays many exceptions from Build to StartAsync. There is some amount of risk here for scenarios where those two aren't called together, but we don't have any examples of those scenarios.

TODO: Test this with Kestrel to make sure Kestrel's options are properly delayed.