### PR TITLE
Changes OS bitness check to Environment rather than System.Runtime.InteropServices.RuntimeInformation

### DIFF
--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/IISExpressDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/IISExpressDeployer.cs
@@ -47,12 +47,7 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
         {
             get
             {
-                var is64BitPropertyInfo = typeof(Environment).GetProperty("Is64BitOperatingSystem", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
-                if (is64BitPropertyInfo != null)
-                {
-                    return (bool)is64BitPropertyInfo.GetValue(null);
-                }
-                return false;
+                return Environment.Is64BitOperatingSystem;
             }
         }
 

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/IISExpressDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/IISExpressDeployer.cs
@@ -47,8 +47,12 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
         {
             get
             {
-                return RuntimeInformation.OSArchitecture == Architecture.X64
-                    || RuntimeInformation.OSArchitecture == Architecture.Arm64;
+                var is64BitPropertyInfo = typeof(Environment).GetProperty("Is64BitOperatingSystem", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
+                if (is64BitPropertyInfo != null)
+                {
+                    return (bool)is64BitPropertyInfo.GetValue(null);
+                }
+                return false;
             }
         }
 


### PR DESCRIPTION
Root issue: https://github.com/dotnet/corefx/issues/25706
For now, we can by using Environment.Is64BitOperatingSystem. This will fix many AppVeyor failures across the stack and Win10 build issues on the Fall Creator's update. This hopefully will be fixed via the net471 fix.

@pranavkm can I use the Environment directly here rather than using reflection?
cc/ @pakrym 