### PR TITLE
Attempts to fix urls from appsettings.json, CLI

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting/Internal/WebHost.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/WebHost.cs
@@ -287,7 +287,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                 var addresses = serverAddressesFeature?.Addresses;
                 if (addresses != null && !addresses.IsReadOnly && addresses.Count == 0)
                 {
-                    var urls = _config[WebHostDefaults.ServerUrlsKey] ?? _config[DeprecatedServerUrlsKey];
+                    var urls = _startup.Configure.GetSection(WebHostDefaults.ServerUrlsKey).Get<String>() ?? _config[DeprecatedServerUrlsKey];
                     if (!string.IsNullOrEmpty(urls))
                     {
                         serverAddressesFeature.PreferHostingUrls = WebHostUtilities.ParseBool(_config, WebHostDefaults.PreferHostingUrlsKey);


### PR DESCRIPTION
WebHost checks _config for the deprecated "server.urls" key but it also checks _config for the new key . I believe it should use _startup.Configure for the new key. The ultimate problem I'm trying to solve is that:

WebHost.CreateDefaultBuilder(args)
                .UseStartup<Startup>()
                .Build();

...doesn't read the urls from appsettings.json or the command line. The builder pushes the values into the Startup constructor so they should be available via Startup.Configure.

I haven't tested this change--I'm editing via the GitHub web interface.