### PR TITLE
Remove unneeded Skip conditions

### DIFF
--- a/test/Microsoft.AspNetCore.Hosting.Tests/HostingEnvironmentExtensionsTests.cs
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/HostingEnvironmentExtensionsTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Hosting.Tests
         {
             var env = new HostingEnvironment();
 
-            env.Initialize(Path.GetFullPath("."), new WebHostOptions(){ WebRoot = "testroot" });
+            env.Initialize(Path.GetFullPath("."), new WebHostOptions() { WebRoot = "testroot" });
 
             Assert.Equal(Path.GetFullPath("."), env.ContentRootPath);
             Assert.Equal(Path.GetFullPath("testroot"), env.WebRootPath);
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Hosting.Tests
             Assert.IsAssignableFrom<PhysicalFileProvider>(env.WebRootFileProvider);
         }
 
-        [Fact(Skip = "Missing content publish property")]
+        [Fact]
         public void DefaultsToWwwrootSubdir()
         {
             var env = new HostingEnvironment();
@@ -55,7 +55,7 @@ namespace Microsoft.AspNetCore.Hosting.Tests
             var env = new HostingEnvironment();
             env.EnvironmentName = "SomeName";
 
-            env.Initialize(Path.GetFullPath("."), new WebHostOptions(){ Environment = "NewName" });
+            env.Initialize(Path.GetFullPath("."), new WebHostOptions() { Environment = "NewName" });
 
             Assert.Equal("NewName", env.EnvironmentName);
         }

--- a/test/Microsoft.AspNetCore.Hosting.Tests/WebHostTests.cs
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/WebHostTests.cs
@@ -822,7 +822,7 @@ namespace Microsoft.AspNetCore.Hosting
             }
         }
 
-        [Fact(Skip = "Missing content publish property")]
+        [Fact]
         public void WebRootCanBeResolvedFromTheConfig()
         {
             var vals = new Dictionary<string, string>

--- a/test/Microsoft.AspNetCore.TestHost.Tests/TestClientTests.cs
+++ b/test/Microsoft.AspNetCore.TestHost.Tests/TestClientTests.cs
@@ -21,8 +21,7 @@ namespace Microsoft.AspNetCore.TestHost
 {
     public class TestClientTests
     {
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
+        [Fact]
         public async Task GetAsyncWorks()
         {
             // Arrange
@@ -40,8 +39,7 @@ namespace Microsoft.AspNetCore.TestHost
             Assert.Equal(expected, actual);
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
+        [Fact]
         public async Task NoTrailingSlash_NoPathBase()
         {
             // Arrange
@@ -63,8 +61,7 @@ namespace Microsoft.AspNetCore.TestHost
             Assert.Equal(expected, actual);
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
+        [Fact]
         public async Task SingleTrailingSlash_NoPathBase()
         {
             // Arrange
@@ -86,8 +83,7 @@ namespace Microsoft.AspNetCore.TestHost
             Assert.Equal(expected, actual);
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
+        [Fact]
         public async Task PutAsyncWorks()
         {
             // Arrange
@@ -105,8 +101,7 @@ namespace Microsoft.AspNetCore.TestHost
             Assert.Equal("Hello world PUT Response", await response.Content.ReadAsStringAsync());
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
+        [Fact]
         public async Task PostAsyncWorks()
         {
             // Arrange
@@ -167,8 +162,7 @@ namespace Microsoft.AspNetCore.TestHost
             }
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
+        [Fact]
         public async Task WebSocketWorks()
         {
             // Arrange
@@ -297,8 +291,7 @@ namespace Microsoft.AspNetCore.TestHost
             }
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
+        [Fact]
         public async Task WebSocketDisposalThrowsOnPeer()
         {
             // Arrange
@@ -325,8 +318,7 @@ namespace Microsoft.AspNetCore.TestHost
             clientSocket.Dispose();
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
+        [Fact]
         public async Task WebSocketTinyReceiveGeneratesEndOfMessage()
         {
             // Arrange
@@ -370,8 +362,7 @@ namespace Microsoft.AspNetCore.TestHost
             clientSocket.Dispose();
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
+        [Fact]
         public async Task ClientDisposalAbortsRequest()
         {
             // Arrange
@@ -405,8 +396,7 @@ namespace Microsoft.AspNetCore.TestHost
             var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await tcs.Task);
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
+        [Fact]
         public async Task ClientCancellationAbortsRequest()
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.TestHost.Tests/TestServerTests.cs
+++ b/test/Microsoft.AspNetCore.TestHost.Tests/TestServerTests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.AspNetCore.TestHost
         public async Task ServicesCanBeOverridenForTestingAsync()
         {
             var builder = new WebHostBuilder()
-                .ConfigureServices(s => s.AddSingleton<IServiceProviderFactory<ThirdPartyContainer>,ThirdPartyContainerServiceProviderFactory>())
+                .ConfigureServices(s => s.AddSingleton<IServiceProviderFactory<ThirdPartyContainer>, ThirdPartyContainerServiceProviderFactory>())
                 .UseStartup<ThirdPartyContainerStartup>()
                 .ConfigureTestServices(services => services.AddSingleton(new SimpleService { Message = "OverridesConfigureServices" }))
                 .ConfigureTestContainer<ThirdPartyContainer>(container => container.Services.AddSingleton(new TestService { Message = "OverridesConfigureContainer" }));
@@ -66,7 +66,7 @@ namespace Microsoft.AspNetCore.TestHost
             public void ConfigureContainer(ThirdPartyContainer container) =>
                 container.Services.AddSingleton(new TestService { Message = "ConfigureContainer" });
 
-            public void Configure(IApplicationBuilder app) => 
+            public void Configure(IApplicationBuilder app) =>
                 app.Use((ctx, next) => ctx.Response.WriteAsync(
                     $"{ctx.RequestServices.GetRequiredService<SimpleService>().Message}, {ctx.RequestServices.GetRequiredService<TestService>().Message}"));
         }
@@ -112,8 +112,7 @@ namespace Microsoft.AspNetCore.TestHost
             Assert.Equal(testService, server.Host.Services.GetRequiredService<TestService>());
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
+        [Fact]
         public async Task RequestServicesAutoCreated()
         {
             var builder = new WebHostBuilder().Configure(app =>
@@ -149,8 +148,7 @@ namespace Microsoft.AspNetCore.TestHost
 
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
+        [Fact]
         public async Task CustomServiceProviderSetsApplicationServices()
         {
             var builder = new WebHostBuilder().UseStartup<CustomContainerStartup>();
@@ -225,8 +223,7 @@ namespace Microsoft.AspNetCore.TestHost
             }
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
+        [Fact]
         public async Task ExistingRequestServicesWillNotBeReplaced()
         {
             var builder = new WebHostBuilder().Configure(app =>
@@ -247,8 +244,7 @@ namespace Microsoft.AspNetCore.TestHost
             Assert.Equal("Found:True", result);
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
+        [Fact]
         public async Task CanSetCustomServiceProvider()
         {
             var builder = new WebHostBuilder().Configure(app =>
@@ -296,8 +292,7 @@ namespace Microsoft.AspNetCore.TestHost
             }
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
+        [Fact]
         public async Task ExistingServiceProviderFeatureWillNotBeReplaced()
         {
             var appServices = new ServiceCollection().BuildServiceProvider();
@@ -339,8 +334,7 @@ namespace Microsoft.AspNetCore.TestHost
             }
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
+        [Fact]
         public async Task WillReplaceServiceProviderFeatureWithNullRequestServices()
         {
             var builder = new WebHostBuilder().Configure(app =>
@@ -361,8 +355,7 @@ namespace Microsoft.AspNetCore.TestHost
             Assert.Equal("Success", result);
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
+        [Fact]
         public async Task CanAccessLogger()
         {
             var builder = new WebHostBuilder().Configure(app =>
@@ -379,8 +372,7 @@ namespace Microsoft.AspNetCore.TestHost
             Assert.Equal("FoundLogger:True", result);
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
+        [Fact]
         public async Task CanAccessHttpContext()
         {
             var builder = new WebHostBuilder().Configure(app =>
@@ -411,8 +403,7 @@ namespace Microsoft.AspNetCore.TestHost
             public IHttpContextAccessor Accessor { get; set; }
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
+        [Fact]
         public async Task CanAddNewHostServices()
         {
             var builder = new WebHostBuilder().Configure(app =>
@@ -434,8 +425,7 @@ namespace Microsoft.AspNetCore.TestHost
             Assert.Equal("HasContext:True", result);
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
+        [Fact]
         public async Task CreateInvokesApp()
         {
             var builder = new WebHostBuilder().Configure(app =>
@@ -451,8 +441,7 @@ namespace Microsoft.AspNetCore.TestHost
             Assert.Equal("CreateInvokesApp", result);
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
+        [Fact]
         public async Task DisposeStreamIgnored()
         {
             var builder = new WebHostBuilder().Configure(app =>
@@ -470,8 +459,7 @@ namespace Microsoft.AspNetCore.TestHost
             Assert.Equal("Response", await result.Content.ReadAsStringAsync());
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
+        [Fact]
         public async Task DisposedServerThrows()
         {
             var builder = new WebHostBuilder().Configure(app =>
@@ -490,8 +478,7 @@ namespace Microsoft.AspNetCore.TestHost
             await Assert.ThrowsAsync<ObjectDisposedException>(() => server.CreateClient().GetAsync("/"));
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
+        [Fact]
         public async Task CancelAborts()
         {
             var builder = new WebHostBuilder()
@@ -509,8 +496,7 @@ namespace Microsoft.AspNetCore.TestHost
             await Assert.ThrowsAsync<TaskCanceledException>(async () => { string result = await server.CreateClient().GetStringAsync("/path"); });
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
+        [Fact]
         public async Task CanCreateViaStartupType()
         {
             var builder = new WebHostBuilder()
@@ -521,8 +507,7 @@ namespace Microsoft.AspNetCore.TestHost
             Assert.Equal("FoundService:True", await result.Content.ReadAsStringAsync());
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
+        [Fact]
         public async Task CanCreateViaStartupTypeAndSpecifyEnv()
         {
             var builder = new WebHostBuilder()
@@ -535,8 +520,7 @@ namespace Microsoft.AspNetCore.TestHost
             Assert.Equal("FoundFoo:False", await result.Content.ReadAsStringAsync());
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
+        [Fact]
         public async Task BeginEndDiagnosticAvailable()
         {
             DiagnosticListener diagnosticListener = null;
@@ -565,8 +549,7 @@ namespace Microsoft.AspNetCore.TestHost
             Assert.Null(listener.UnhandledException);
         }
 
-        [ConditionalFact]
-        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Hangs randomly (issue #507)")]
+        [Fact]
         public async Task ExceptionDiagnosticAvailable()
         {
             DiagnosticListener diagnosticListener = null;


### PR DESCRIPTION
#507 is closed because we don't test against mono anymore, and the `Missing content publish property` tests pass fine.