### PR TITLE
Set the default deploy configuration based on compilation configuration

### DIFF
--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Common/DeploymentParameters.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Common/DeploymentParameters.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 
 namespace Microsoft.AspNetCore.Server.IntegrationTesting
@@ -45,6 +46,8 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
             ServerType = serverType;
             RuntimeFlavor = runtimeFlavor;
             EnvironmentVariables["ASPNETCORE_DETAILEDERRORS"] = "true";
+
+            SetDefaultConfig();
         }
 
         public ServerType ServerType { get; }
@@ -81,7 +84,7 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
         /// <summary>
         /// Configuration under which to build (ex: Release or Debug)
         /// </summary>
-        public string Configuration { get; set; } = "Debug";
+        public string Configuration { get; set; }
 
         /// <summary>
         /// Space separated command line arguments to be passed to dotnet-publish
@@ -133,6 +136,24 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
                     RuntimeArchitecture,
                     ApplicationBaseUriHint,
                     PublishApplicationBeforeDeployment);
+        }
+
+        private void SetDefaultConfig()
+        {
+            SetConfigIfDebug();
+            SetConfigIfRelease();
+        }
+
+        [Conditional("DEBUG")]
+        private void SetConfigIfDebug()
+        {
+            Configuration = "Debug";
+        }
+
+        [Conditional("RELEASE")]
+        private void SetConfigIfRelease()
+        {
+            Configuration = "Release";
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Hosting.FunctionalTests/DeploymentParametersTest.cs
+++ b/test/Microsoft.AspNetCore.Hosting.FunctionalTests/DeploymentParametersTest.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Server.IntegrationTesting;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Hosting.FunctionalTests
+{
+    public class DeploymentParametersTest
+    {
+        [Fact]
+        public void ItPicksDefaultConfigBasedOnCompilationCondition()
+        {
+#if DEBUG
+            const string config = "Debug";
+#else
+            const string config = "Release";
+#endif
+
+            Assert.Equal(config, new DeploymentParameters(AppContext.BaseDirectory, ServerType.Kestrel, RuntimeFlavor.CoreClr, RuntimeArchitecture.x64).Configuration);
+        }
+    }
+}


### PR DESCRIPTION
Currently tests always run in "Debug". This changes the default deployment config to match the test project's compilation config.