### PR TITLE
Use dispose pattern in BackgroundService

### DIFF
--- a/src/Microsoft.Extensions.Hosting.Abstractions/BackgroundService.cs
+++ b/src/Microsoft.Extensions.Hosting.Abstractions/BackgroundService.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Extensions.Hosting
     /// </summary>
     public abstract class BackgroundService : IHostedService, IDisposable
     {
+        private bool disposed = false;
         private Task _executingTask;
         private readonly CancellationTokenSource _stoppingCts = new CancellationTokenSource();
 
@@ -67,9 +68,25 @@ namespace Microsoft.Extensions.Hosting
 
         }
 
-        public virtual void Dispose()
+        public void Dispose()
         {
-            _stoppingCts.Cancel();
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                _stoppingCts.Cancel();
+            }
+
+            disposed = true;
         }
     }
 }


### PR DESCRIPTION
BackgroundService implements IDiposable, but doesn't implement the dispose pattern. Since this type is new for 2.1, this should be fixed before release.