### PR TITLE
Convert TestHost ResponseStream to use Pipes.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,8 @@
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition="'$(OS)' != 'Windows_NT'">true</PublicSign>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!-- https://github.com/aspnet/BuildTools/issues/592 -->
+    <EnableApiCheck>false</EnableApiCheck>
   </PropertyGroup>
 
 </Project>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -40,6 +40,7 @@
     <SerilogExtensionsLoggingPackageVersion>1.4.0</SerilogExtensionsLoggingPackageVersion>
     <SerilogSinksFilePackageVersion>3.2.0</SerilogSinksFilePackageVersion>
     <SystemDiagnosticsDiagnosticSourcePackageVersion>4.5.0-preview2-26224-02</SystemDiagnosticsDiagnosticSourcePackageVersion>
+    <SystemIOPipelinesPackageVersion>4.5.0-preview2-26224-02</SystemIOPipelinesPackageVersion>
     <SystemReflectionMetadataPackageVersion>1.6.0-preview2-26126-03</SystemReflectionMetadataPackageVersion>
     <SystemServiceProcessServiceControllerPackageVersion>4.5.0-preview2-26224-02</SystemServiceProcessServiceControllerPackageVersion>
     <XunitPackageVersion>2.3.1</XunitPackageVersion>

--- a/src/Microsoft.AspNetCore.TestHost/HttpContextBuilder.cs
+++ b/src/Microsoft.AspNetCore.TestHost/HttpContextBuilder.cs
@@ -90,14 +90,14 @@ namespace Microsoft.AspNetCore.TestHost
             {
                 _requestAbortedSource.Cancel();
             }
-            _responseStream.Complete();
+            _responseStream.CompleteWrites();
         }
 
         internal async Task CompleteResponseAsync()
         {
             _pipelineFinished = true;
             await ReturnResponseMessageAsync();
-            _responseStream.Complete();
+            _responseStream.CompleteWrites();
             await _responseFeature.FireOnResponseCompletedAsync();
         }
 

--- a/src/Microsoft.AspNetCore.TestHost/Microsoft.AspNetCore.TestHost.csproj
+++ b/src/Microsoft.AspNetCore.TestHost/Microsoft.AspNetCore.TestHost.csproj
@@ -18,4 +18,8 @@
     <ProjectReference Include="..\Microsoft.AspNetCore.Hosting\Microsoft.AspNetCore.Hosting.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.IO.Pipelines" Version="$(SystemIOPipelinesPackageVersion)" />
+  </ItemGroup>
+
 </Project>

--- a/test/Microsoft.AspNetCore.TestHost.Tests/TestClientTests.cs
+++ b/test/Microsoft.AspNetCore.TestHost.Tests/TestClientTests.cs
@@ -246,7 +246,7 @@ namespace Microsoft.AspNetCore.TestHost
                     var receiveArray = new byte[1024];
                     while (true)
                     {
-                        var receiveResult = await websocket.ReceiveAsync(new System.ArraySegment<byte>(receiveArray), CancellationToken.None);
+                        var receiveResult = await websocket.ReceiveAsync(new ArraySegment<byte>(receiveArray), CancellationToken.None);
                         if (receiveResult.MessageType == WebSocketMessageType.Close)
                         {
                             await websocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Normal Closure", CancellationToken.None);


### PR DESCRIPTION
TestHost has always used an in-memory write-through buffer stream so that a test app could write to the response body and the test code could consume that data asynchronously. Basically this was pipes five years before pipes was a thing.  Now I've converted it over to pipes as a way of testing the pipes API and functionality and reducing the internal code complexity.

Open issues:
https://github.com/dotnet/corefx/issues/27732 - FlushAsync completes ReadAsync with no data
https://github.com/aspnet/BuildTools/issues/592 - ApiCheck can't handle the new Memory<T> types.
Asymmetry - PipeWriter has a sync Write extension, but PipeReader does not have a sync Read extension.