### PR TITLE
Make the RequestServicesContainerMiddleware thinner

### DIFF
--- a/korebuild-lock.txt
+++ b/korebuild-lock.txt
@@ -1,2 +1,2 @@
-version:2.1.0-preview2-15728
-commithash:393377068ddcf51dfee0536536d455f57a828b06
+version:2.1.0-preview3-15744
+commithash:b920ce6c433f8927c42109b21e72110068ee2c2e

--- a/src/Microsoft.AspNetCore.Hosting/Internal/RequestServicesContainerMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/RequestServicesContainerMiddleware.cs
@@ -40,20 +40,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             var replacementFeature = new RequestServicesFeature(httpContext, _scopeFactory);
 
             features.Set<IServiceProvidersFeature>(replacementFeature);
-            var task = _next.Invoke(httpContext);
-
-#if NETCOREAPP2_1
-            if (!task.IsCompletedSuccessfully)
-#else
-            if (task.Status != TaskStatus.RanToCompletion)
-#endif
-            {
-                return InvokeAsyncAwaited(task);
-            }
-
-            return Task.CompletedTask;
-
-            async Task InvokeAsyncAwaited(Task resultTask) => await resultTask;
+            return _next.Invoke(httpContext);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Hosting/Internal/RequestServicesContainerMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/RequestServicesContainerMiddleware.cs
@@ -37,9 +37,9 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             // local cache for virtual disptach result
             var features = httpContext.Features;
 
-            var replacementFeature = new RequestServicesFeature(httpContext, _scopeFactory);
+            var servicesFeature = new RequestServicesFeature(httpContext, _scopeFactory);
 
-            features.Set<IServiceProvidersFeature>(replacementFeature);
+            features.Set<IServiceProvidersFeature>(servicesFeature);
             return _next.Invoke(httpContext);
         }
     }

--- a/src/Microsoft.AspNetCore.Hosting/Internal/RequestServicesFeature.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/RequestServicesFeature.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -14,10 +15,12 @@ namespace Microsoft.AspNetCore.Hosting.Internal
         private IServiceProvider _requestServices;
         private IServiceScope _scope;
         private bool _requestServicesSet;
+        private HttpContext _context;
 
-        public RequestServicesFeature(IServiceScopeFactory scopeFactory)
+        public RequestServicesFeature(HttpContext context, IServiceScopeFactory scopeFactory)
         {
             Debug.Assert(scopeFactory != null);
+            _context = context;
             _scopeFactory = scopeFactory;
         }
 
@@ -30,6 +33,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                     _scope = _scopeFactory.CreateScope();
                     _requestServices = _scope.ServiceProvider;
                     _requestServicesSet = true;
+                    _context.Response.RegisterForDispose(this);
                 }
                 return _requestServices;
             }

--- a/src/Microsoft.AspNetCore.Hosting/Internal/RequestServicesFeature.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/RequestServicesFeature.cs
@@ -30,10 +30,10 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             {
                 if (!_requestServicesSet)
                 {
+                    _context.Response.RegisterForDispose(this);
                     _scope = _scopeFactory.CreateScope();
                     _requestServices = _scope.ServiceProvider;
                     _requestServicesSet = true;
-                    _context.Response.RegisterForDispose(this);
                 }
                 return _requestServices;
             }

--- a/src/Microsoft.AspNetCore.Hosting/Microsoft.AspNetCore.Hosting.csproj
+++ b/src/Microsoft.AspNetCore.Hosting/Microsoft.AspNetCore.Hosting.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>ASP.NET Core hosting infrastructure and startup logic for web applications.</Description>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netcoreapp2.1</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore;hosting</PackageTags>

--- a/src/Microsoft.AspNetCore.Hosting/Microsoft.AspNetCore.Hosting.csproj
+++ b/src/Microsoft.AspNetCore.Hosting/Microsoft.AspNetCore.Hosting.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>ASP.NET Core hosting infrastructure and startup logic for web applications.</Description>
-    <TargetFrameworks>netstandard2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore;hosting</PackageTags>


### PR DESCRIPTION
- Today the request services middleware is responsible for making sure there are request scoped sevices.
This PR tries introduces some breaking changes that are hopefully acceptable in order to gain some performance.
- Here are the assumptions this PR makes:
 - Since this middleware is first in the pipeline, the only thing that can
  set a default service provider would be the server itself. Since we have no servers that do that
  I removed that code that tries to noop if there's an existing service provider.
 - This PR no longer restores the previous service provider feature since it gets replaced every request
 anyways. Kestrel also clears out the feature on each request so it shouldn't be a problem (in theory).
 Once again, since this middleware is first, it is the last thing that runs before the server re-gains
 control on the way out so there's no need to restore anything.
 - We use the RegisterForDispose method to dispose of the IServiceProvider instead of doing it inline.

@Tratcher come at me bro 😄.

```
02:50:02.981] Using worker Wrk
[02:50:03.633] Running session '86d93bd805864be48327ffc1c344fb58' with description ''
[02:50:03.633] Starting scenario Plaintext on benchmark server...
[02:50:12.412] Warmup
[02:50:12.428] Starting scenario Plaintext on benchmark client...
[02:50:28.414] Scenario Plaintext completed on benchmark client
[02:50:28.417] Stopping scenario Plaintext on benchmark client...
[02:50:28.447] Starting scenario Plaintext on benchmark client...
[02:50:44.251] Scenario Plaintext completed on benchmark client
[02:50:44.251] Stopping scenario Plaintext on benchmark client...
[02:50:44.348] RequestsPerSecond:           1921644
[02:50:44.348] Latency on load (ms):        2.2
[02:50:44.348] Max CPU (%):                 92
[02:50:44.348] WorkingSet (MB):             374
[02:50:44.348] Startup Main (ms):           373
[02:50:44.348] First Request (ms):          149.3
[02:50:44.349] Latency (ms):                0.7
[02:50:44.349] Socket Errors:               0
[02:50:44.349] Bad Responses:               0
[02:50:44.349] SDK:                         2.2.0-preview1-007522
[02:50:44.349] Runtime:                     2.1.0-preview2-26314-02
[02:50:44.349] ASP.NET Core:                2.1.0-preview3-30384
```

/cc @DamianEdwards @benaadams @sebastienros 

Putting on my pedantic hat here's what can go wrong:
- If somebody replaces the IApplicationBuilderFactory, they can inject middleware before the RequestServicesContainerMiddleware middleware. They would still see the service providers feature added by the middleware.
- If somebody removes the IStartupFilter that adds this middleware and does their own thing, the middleware won't clean itself up so middleware that run after it will observe the service providers feature.
- If there's a bug in RegisterForDispose, then service providers won't get disposed. Well, and many other things that need to get disposed 😄.

PS: We have no tests for the things I removed. Ooops we have no tests at all https://github.com/aspnet/Hosting/search?utf8=%E2%9C%93&q=AutoRequestServicesStartupFilter&type=