### PR TITLE
Make the RequestServicesContainerMiddleware thinner (#1360)

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting/Internal/RequestServicesContainerMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/RequestServicesContainerMiddleware.cs
@@ -30,34 +30,17 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             _scopeFactory = scopeFactory;
         }
 
-        public async Task Invoke(HttpContext httpContext)
+        public Task Invoke(HttpContext httpContext)
         {
             Debug.Assert(httpContext != null);
 
             // local cache for virtual disptach result
             var features = httpContext.Features;
-            var existingFeature = features.Get<IServiceProvidersFeature>();
 
-            // All done if RequestServices is set
-            if (existingFeature?.RequestServices != null)
-            {
-                await _next.Invoke(httpContext);
-                return;
-            }
+            var servicesFeature = new RequestServicesFeature(httpContext, _scopeFactory);
 
-            var replacementFeature = new RequestServicesFeature(_scopeFactory);
-
-            try
-            {
-                features.Set<IServiceProvidersFeature>(replacementFeature);
-                await _next.Invoke(httpContext);
-            }
-            finally
-            {
-                replacementFeature.Dispose();
-                // Restore previous feature state
-                features.Set(existingFeature);
-            }
+            features.Set<IServiceProvidersFeature>(servicesFeature);
+            return _next.Invoke(httpContext);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Hosting/Internal/RequestServicesFeature.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/RequestServicesFeature.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -14,10 +15,12 @@ namespace Microsoft.AspNetCore.Hosting.Internal
         private IServiceProvider _requestServices;
         private IServiceScope _scope;
         private bool _requestServicesSet;
+        private HttpContext _context;
 
-        public RequestServicesFeature(IServiceScopeFactory scopeFactory)
+        public RequestServicesFeature(HttpContext context, IServiceScopeFactory scopeFactory)
         {
             Debug.Assert(scopeFactory != null);
+            _context = context;
             _scopeFactory = scopeFactory;
         }
 
@@ -27,6 +30,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             {
                 if (!_requestServicesSet)
                 {
+                    _context.Response.RegisterForDispose(this);
                     _scope = _scopeFactory.CreateScope();
                     _requestServices = _scope.ServiceProvider;
                     _requestServicesSet = true;


### PR DESCRIPTION
- Today the request services middleware is responsible for making sure there are request scoped services.
This PR tries introduces some breaking changes that are hopefully acceptable in order to gain some performance.
- Here are the assumptions this PR makes:
 - Since this middleware is first in the pipeline, the only thing that can
  set a default service provider would be the server itself. Since we have no servers that do that
  I removed that code that tries to noop if there's an existing service provider.
 - This PR no longer restores the previous service provider feature since it gets replaced every request
 anyways. Kestrel also clears out the feature on each request so it shouldn't be a problem (in theory).
 Once again, since this middleware is first, it is the last thing that runs before the server re-gains
 control on the way out so there's no need to restore anything.
 - We use the RegisterForDispose method to dispose of the IServiceProvider instead of doing it inline.