### PR TITLE
Delay process exit in ConsoleLifetime

### DIFF
--- a/samples/GenericHostSample/MyServiceB.cs
+++ b/samples/GenericHostSample/MyServiceB.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Hosting;
 
 namespace GenericHostSample
 {
-    public class MyServiceB : IHostedService
+    public class MyServiceB : IHostedService, IDisposable
     {
         private bool _stopping;
         private Task _backgroundTask;
@@ -37,6 +37,11 @@ namespace GenericHostSample
                 // TODO: cancellation
                 await _backgroundTask;
             }
+        }
+
+        public void Dispose()
+        {
+            Console.WriteLine("MyServiceB is disposing.");
         }
     }
 }


### PR DESCRIPTION
 #1329 ConsoleLifetime listens for the ProcessExit event but does not block it to allow for graceful shutdown. CTL+C works because we can cancel that event.

@robbieknuth @xqrzd I was able to reproduce the same issue on Windows by closing the console window.

Solution: Block ProcessExit until ConsoleLifetime is disposed (when the rest of the Host is disposed). This is pretty much the same as what WebHost does.
https://github.com/aspnet/Hosting/blob/dev/src/Microsoft.AspNetCore.Hosting/WebHostExtensions.cs#L43-L50 
