### PR TITLE
 Change SelfHostDeployer to use dynamic ports by default

### DIFF
--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Common/TestUriHelper.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Common/TestUriHelper.cs
@@ -25,10 +25,15 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting.Common
             {
                 if (statusMessagesEnabled)
                 {
+                    // Most functional tests use this codepath and should directly
+                    // bind to dynamic port "0" and scrape the assigned port
+                    // from the status message, which should be 100% reliable.
                     return new UriBuilder("http", "127.0.0.1", 0).Uri;
                 }
                 else
                 {
+                    // If status messages are disabled, the less reliable GetNextPort()
+                    // must be used.
                     return new UriBuilder("http", "localhost", GetNextPort()).Uri;
                 }
             }
@@ -37,16 +42,31 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting.Common
                 var uriHint = new Uri(hint);
                 if (uriHint.Port == 0)
                 {
+                    // Only a few tests use this codepath, so it's fine to use the less reliable
+                    // GetNextPort() for simplicity.  These tests could be improved to bind 
+                    // to dynamic port "0" (when status messages are enabled) but the hostname
+                    // would need to be "127.0.0.1" or "[::1]".  Binding to dynamic port "0" on
+                    // "localhost" is not supported in Kestrel.
                     return new UriBuilder(uriHint) { Port = GetNextPort() }.Uri;
                 }
                 else
                 {
+                    // If the hint contains a specific port, return it unchanged.
                     return uriHint;
                 }
             }
         }
 
         // Copied from https://github.com/aspnet/KestrelHttpServer/blob/47f1db20e063c2da75d9d89653fad4eafe24446c/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/AddressRegistrationTests.cs#L508
+        //
+        // This method is an attempt to safely get a free port from the OS.  Most of the time,
+        // when binding to dynamic port "0" the OS increments the assigned port, so it's safe
+        // to re-use the assigned port in another process.  However, occasionally the OS will reuse
+        // a recently assigned port instead of incrementing, which causes flaky tests with AddressInUse
+        // exceptions.  This method should only be used when the application itself cannot use
+        // dynamic port "0" (e.g. IISExpress).  Most functional tests using raw Kestrel
+        // (with status messages enabled) should directly bind to dynamic port "0" and scrape 
+        // the assigned port from the status message, which should be 100% reliable.
         public static int GetNextPort()
         {
             using (var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Common/TestUriHelper.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Common/TestUriHelper.cs
@@ -11,14 +11,26 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting.Common
     {
         public static Uri BuildTestUri()
         {
-            return new UriBuilder("http", "localhost", GetNextPort()).Uri;
+            return BuildTestUri(null);
         }
 
         public static Uri BuildTestUri(string hint)
         {
+            return BuildTestUri(hint, statusMessagesEnabled: false);
+        }
+
+        public static Uri BuildTestUri(string hint, bool statusMessagesEnabled)
+        {
             if (string.IsNullOrEmpty(hint))
             {
-                return BuildTestUri();
+                if (statusMessagesEnabled)
+                {
+                    return new UriBuilder("http", "127.0.0.1", 0).Uri;
+                }
+                else
+                {
+                    return new UriBuilder("http", "localhost", GetNextPort()).Uri;
+                }
             }
             else
             {

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Common/TestUriHelper.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Common/TestUriHelper.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting.Common
             return BuildTestUri(hint, statusMessagesEnabled: false);
         }
 
-        public static Uri BuildTestUri(string hint, bool statusMessagesEnabled)
+        internal static Uri BuildTestUri(string hint, bool statusMessagesEnabled)
         {
             if (string.IsNullOrEmpty(hint))
             {

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/SelfHostDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/SelfHostDeployer.cs
@@ -41,7 +41,8 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
                     DotnetPublish();
                 }
 
-                var hintUrl = TestUriHelper.BuildTestUri(DeploymentParameters.ApplicationBaseUriHint);
+                var hintUrl = TestUriHelper.BuildTestUri(
+                    DeploymentParameters.ApplicationBaseUriHint, DeploymentParameters.StatusMessagesEnabled);
 
                 // Launch the host process.
                 var (actualUrl, hostExitToken) = await StartSelfHostAsync(hintUrl);

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/SelfHostDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/SelfHostDeployer.cs
@@ -42,7 +42,9 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
                 }
 
                 var hintUrl = TestUriHelper.BuildTestUri(
-                    DeploymentParameters.ApplicationBaseUriHint, DeploymentParameters.StatusMessagesEnabled);
+                    DeploymentParameters.ApplicationBaseUriHint,
+                    DeploymentParameters.ServerType,
+                    DeploymentParameters.StatusMessagesEnabled);
 
                 // Launch the host process.
                 var (actualUrl, hostExitToken) = await StartSelfHostAsync(hintUrl);


### PR DESCRIPTION
* Should significantly reduce flaky test failures due to AddressInUse exceptions
* Addresses https://github.com/aspnet/Hosting/issues/1296