### PR TITLE
[Fixes #1242] Moves IStartupConfigureServicesFilter and IStartupConfigureContainerFilter interfaces to the internal namespace

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/Internal/IStartupConfigureContainerFilter.cs
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/Internal/IStartupConfigureContainerFilter.cs
@@ -3,8 +3,12 @@
 
 using System;
 
-namespace Microsoft.AspNetCore.Hosting
+namespace Microsoft.AspNetCore.Hosting.Internal
 {
+    /// <summary>
+    /// This API supports the ASP.NET Core infrastructure and is not intended to be used
+    /// directly from your code. This API may change or be removed in future releases.
+    /// </summary>
     public interface IStartupConfigureContainerFilter<TContainerBuilder>
     {
         Action<TContainerBuilder> ConfigureContainer(Action<TContainerBuilder> container);

--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/Internal/IStartupConfigureServicesFilter.cs
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/Internal/IStartupConfigureServicesFilter.cs
@@ -4,8 +4,12 @@
 using System;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Microsoft.AspNetCore.Hosting
+namespace Microsoft.AspNetCore.Hosting.Internal
 {
+    /// <summary>
+    /// This API supports the ASP.NET Core infrastructure and is not intended to be used
+    /// directly from your code. This API may change or be removed in future releases.
+    /// </summary>
     public interface IStartupConfigureServicesFilter
     {
         Action<IServiceCollection> ConfigureServices(Action<IServiceCollection> next);

--- a/src/Microsoft.AspNetCore.TestHost/WebHostBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.TestHost/WebHostBuilderExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Linq;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Internal;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.TestHost


### PR DESCRIPTION
#1242