### PR TITLE
Use hierarchical Id from Activity for logging scope

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting/Internal/HostingApplicationDiagnostics.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/HostingApplicationDiagnostics.cs
@@ -77,11 +77,12 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                 // If the baggage includes the Id, then than is more correct as the root Id than the
                 // Activity.RootId in the case of a mixed hierarchical and non-hierarchical scenario.
                 var activityRootId = context.Activity.GetBaggageItem("Id") ?? context.Activity.RootId;
+                var requestId = context.Activity.Id;
 
                 // Scope may be relevant for a different level of logging, so we always create it
                 // see: https://github.com/aspnet/Hosting/pull/944
                 // Scope can be null if logging is not on.
-                context.Scope = _logger.RequestScope(httpContext, parentRequestId, activityRootId);
+                context.Scope = _logger.RequestScope(httpContext, requestId, parentRequestId, activityRootId);
 
                 if (_logger.IsEnabled(LogLevel.Information))
                 {

--- a/src/Microsoft.AspNetCore.Hosting/Internal/HostingApplicationDiagnostics.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/HostingApplicationDiagnostics.cs
@@ -55,14 +55,15 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             if (diagnosticListenerEnabled || loggingEnabled)
             {
                 httpContext.Request.Headers.TryGetValue(RequestIdHeaderName, out parentRequestId);
+
+                if (_diagnosticListener.IsEnabled(ActivityName, httpContext) || loggingEnabled)
+                {
+                    context.Activity = StartActivity(httpContext, parentRequestId);
+                }
             }
 
             if (diagnosticListenerEnabled)
             {
-                if (_diagnosticListener.IsEnabled(ActivityName, httpContext))
-                {
-                    context.Activity = StartActivity(httpContext, parentRequestId);
-                }
                 if (_diagnosticListener.IsEnabled(DeprecatedDiagnosticsBeginRequestKey))
                 {
                     startTimestamp = Stopwatch.GetTimestamp();

--- a/src/Microsoft.AspNetCore.Hosting/Internal/HostingApplicationDiagnostics.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/HostingApplicationDiagnostics.cs
@@ -74,10 +74,14 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             // To avoid allocation, return a null scope if the logger is not on at least to some degree.
             if (loggingEnabled)
             {
+                // If the baggage includes the Id, then than is more correct as the root Id than the
+                // Activity.RootId in the case of a mixed hierarchical and non-hierarchical scenario.
+                var activityRootId = context.Activity.GetBaggageItem("Id") ?? context.Activity.RootId;
+
                 // Scope may be relevant for a different level of logging, so we always create it
                 // see: https://github.com/aspnet/Hosting/pull/944
                 // Scope can be null if logging is not on.
-                context.Scope = _logger.RequestScope(httpContext, parentRequestId);
+                context.Scope = _logger.RequestScope(httpContext, parentRequestId, activityRootId);
 
                 if (_logger.IsEnabled(LogLevel.Information))
                 {

--- a/src/Microsoft.AspNetCore.Hosting/Internal/HostingApplicationDiagnostics.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/HostingApplicationDiagnostics.cs
@@ -137,13 +137,13 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                     }
 
                 }
+            }
 
-                var activity = context.Activity;
-                // Always stop activity if it was started
-                if (activity != null)
-                {
-                    StopActivity(httpContext, activity);
-                }
+            var activity = context.Activity;
+            // Always stop activity if it was started
+            if (activity != null)
+            {
+                StopActivity(httpContext, activity);
             }
 
             if (context.EventLogEnabled && exception != null)

--- a/src/Microsoft.AspNetCore.Hosting/Internal/HostingApplicationDiagnostics.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/HostingApplicationDiagnostics.cs
@@ -47,8 +47,6 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             var diagnosticListenerEnabled = _diagnosticListener.IsEnabled();
             var loggingEnabled = _logger.IsEnabled(LogLevel.Critical);
 
-            // If logging is enabled or the diagnostic listener is enabled, try to get the correlation
-            // id from the header
             if (diagnosticListenerEnabled || loggingEnabled)
             {
                 // Non-inline
@@ -135,6 +133,9 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             ref HostingApplication.Context context, bool loggingEnabled, bool diagnosticListenerEnabled)
         {
             long startTimestamp = 0;
+
+            // If logging is enabled or the diagnostic listener is enabled, try to get the correlation
+            // id from the header
             httpContext.Request.Headers.TryGetValue(RequestIdHeaderName, out StringValues parentRequestId);
 
             if (_diagnosticListener.IsEnabled(ActivityName, httpContext) || loggingEnabled)
@@ -154,7 +155,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             // To avoid allocation, return a null scope if the logger is not on at least to some degree.
             if (loggingEnabled)
             {
-                // If the baggage includes the Id, then than is more correct as the root Id than the
+                // If the baggage includes the Id, then it is more correct as the root Id than the
                 // Activity.RootId in the case of a mixed hierarchical and non-hierarchical scenario.
                 var activityRootId = context.Activity.GetBaggageItem("Id") ?? context.Activity.RootId;
                 var requestId = context.Activity.Id;

--- a/src/Microsoft.AspNetCore.Hosting/Internal/HostingLoggerExtensions.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/HostingLoggerExtensions.cs
@@ -13,9 +13,9 @@ namespace Microsoft.AspNetCore.Hosting.Internal
 {
     internal static class HostingLoggerExtensions
     {
-        public static IDisposable RequestScope(this ILogger logger, HttpContext httpContext, string correlationId)
+        public static IDisposable RequestScope(this ILogger logger, HttpContext httpContext, string parentRequestId)
         {
-            return logger.BeginScope(new HostingLogScope(httpContext, correlationId));
+            return logger.BeginScope(new HostingLogScope(httpContext, parentRequestId));
         }
 
         public static void ApplicationError(this ILogger logger, Exception exception)
@@ -95,7 +95,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
         private class HostingLogScope : IReadOnlyList<KeyValuePair<string, object>>
         {
             private readonly HttpContext _httpContext;
-            private readonly string _correlationId;
+            private readonly string _parentRequestId;
 
             private string _cachedToString;
 
@@ -121,17 +121,17 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                     }
                     else if (index == 2)
                     {
-                        return new KeyValuePair<string, object>("CorrelationId", _correlationId);
+                        return new KeyValuePair<string, object>("ParentRequestId", _parentRequestId);
                     }
 
                     throw new ArgumentOutOfRangeException(nameof(index));
                 }
             }
 
-            public HostingLogScope(HttpContext httpContext, string correlationId)
+            public HostingLogScope(HttpContext httpContext, string parentRequestId)
             {
                 _httpContext = httpContext;
-                _correlationId = correlationId;
+                _parentRequestId = parentRequestId;
             }
 
             public override string ToString()

--- a/src/Microsoft.AspNetCore.Hosting/Internal/HostingLoggerExtensions.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/HostingLoggerExtensions.cs
@@ -13,9 +13,10 @@ namespace Microsoft.AspNetCore.Hosting.Internal
 {
     internal static class HostingLoggerExtensions
     {
-        public static IDisposable RequestScope(this ILogger logger, HttpContext httpContext, string parentRequestId)
+        public static IDisposable RequestScope(this ILogger logger, HttpContext httpContext, string parentRequestId,
+            string activityRootId)
         {
-            return logger.BeginScope(new HostingLogScope(httpContext, parentRequestId));
+            return logger.BeginScope(new HostingLogScope(httpContext, parentRequestId, activityRootId));
         }
 
         public static void ApplicationError(this ILogger logger, Exception exception)
@@ -96,6 +97,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
         {
             private readonly HttpContext _httpContext;
             private readonly string _parentRequestId;
+            private readonly string _activityRootId;
 
             private string _cachedToString;
 
@@ -103,7 +105,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             {
                 get
                 {
-                    return 3;
+                    return 4;
                 }
             }
 
@@ -121,6 +123,10 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                     }
                     else if (index == 2)
                     {
+                        return new KeyValuePair<string, object>("CorrelationId", _activityRootId);
+                    }
+                    else if (index == 3)
+                    {
                         return new KeyValuePair<string, object>("ParentRequestId", _parentRequestId);
                     }
 
@@ -128,10 +134,11 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                 }
             }
 
-            public HostingLogScope(HttpContext httpContext, string parentRequestId)
+            public HostingLogScope(HttpContext httpContext, string parentRequestId, string activityRootId)
             {
                 _httpContext = httpContext;
                 _parentRequestId = parentRequestId;
+                _activityRootId = activityRootId;
             }
 
             public override string ToString()

--- a/src/Microsoft.AspNetCore.Hosting/Internal/HostingLoggerExtensions.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/HostingLoggerExtensions.cs
@@ -13,10 +13,12 @@ namespace Microsoft.AspNetCore.Hosting.Internal
 {
     internal static class HostingLoggerExtensions
     {
-        public static IDisposable RequestScope(this ILogger logger, HttpContext httpContext, string parentRequestId,
+        public static IDisposable RequestScope(this ILogger logger, HttpContext httpContext, 
+            string requestId,
+            string parentRequestId,
             string activityRootId)
         {
-            return logger.BeginScope(new HostingLogScope(httpContext, parentRequestId, activityRootId));
+            return logger.BeginScope(new HostingLogScope(httpContext, requestId, parentRequestId, activityRootId));
         }
 
         public static void ApplicationError(this ILogger logger, Exception exception)
@@ -96,6 +98,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
         private class HostingLogScope : IReadOnlyList<KeyValuePair<string, object>>
         {
             private readonly HttpContext _httpContext;
+            private readonly string _requestId;
             private readonly string _parentRequestId;
             private readonly string _activityRootId;
 
@@ -115,7 +118,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                 {
                     if (index == 0)
                     {
-                        return new KeyValuePair<string, object>("RequestId", _httpContext.TraceIdentifier);
+                        return new KeyValuePair<string, object>("RequestId", _requestId);
                     }
                     else if (index == 1)
                     {
@@ -134,9 +137,13 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                 }
             }
 
-            public HostingLogScope(HttpContext httpContext, string parentRequestId, string activityRootId)
+            public HostingLogScope(HttpContext httpContext, 
+                string requestId, 
+                string parentRequestId,
+                string activityRootId)
             {
                 _httpContext = httpContext;
+                _requestId = requestId;
                 _parentRequestId = parentRequestId;
                 _activityRootId = activityRootId;
             }

--- a/test/Microsoft.AspNetCore.Hosting.Tests/HostingApplicationTests.cs
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/HostingApplicationTests.cs
@@ -96,6 +96,24 @@ namespace Microsoft.AspNetCore.Hosting.Tests
         }
 
         [Fact]
+        public void CreateContextSetsRequestIdInScopeWithHierarchicalParentRequestId()
+        {
+            // Arrange
+            var logger = new LoggerWithScopes();
+            var hostingApplication = CreateApplication(out var features, logger: logger);
+            features.Get<IHttpRequestFeature>().Headers["Request-Id"] = "|Guid.1.da4e9679.";
+
+            // Act
+            var context = hostingApplication.CreateContext(features);
+
+            Assert.Single(logger.Scopes);
+            var pairs = ((IReadOnlyList<KeyValuePair<string, object>>)logger.Scopes[0]).ToDictionary(p => p.Key, p => p.Value);
+            var actualRequestId = pairs["RequestId"].ToString();
+            Assert.StartsWith("|Guid.1.da4e9679.", actualRequestId);
+            Assert.EndsWith("_", actualRequestId);
+        }
+
+        [Fact]
         public void CreateContextSetsCorrelationIdInScopeWithFlatParentRequestId()
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.Hosting.Tests/HostingApplicationTests.cs
+++ b/test/Microsoft.AspNetCore.Hosting.Tests/HostingApplicationTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Hosting.Tests
         }
 
         [Fact]
-        public void CreateContextSetsCorrelationIdInScope()
+        public void CreateContextSetsParentRequestIdInScope()
         {
             // Arrange
             var logger = new LoggerWithScopes();
@@ -44,7 +44,7 @@ namespace Microsoft.AspNetCore.Hosting.Tests
 
             Assert.Single(logger.Scopes);
             var pairs = ((IReadOnlyList<KeyValuePair<string, object>>)logger.Scopes[0]).ToDictionary(p => p.Key, p => p.Value);
-            Assert.Equal("some correlation id", pairs["CorrelationId"].ToString());
+            Assert.Equal("some correlation id", pairs["ParentRequestId"].ToString());
         }
 
         [Fact]


### PR DESCRIPTION
This addresses #1384 by using the `Activity` based hierarchical ids in the logger scope.

Using a structured logging framework is not synonymous with having a `DiagnosticListener` implemented.  So this pull request starts an `Activity` in the `HostingApplication.Context` if logging is enabled in addition to when the diagnostic listener is enabled.

Just searching the logs for `RequestId` starts with `|Guid.` wont work in mixed scenarios because a chain of services could start the `RequestId` hierarchical id over if the parent service only supports flat Ids.  The [spec suggests](https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.DiagnosticSource/src/FlatRequestId.md#mixed-hierarchical-and-non-hierarchical-scenario) also searching for `Correlation-Context: Id` like this:

```
CorrelationContext.Id == Guid || RequestId.startsWith('|Guid')
```

However, structured log providers don't necessarily destructure nested scope values (Serilog doesn't unless the name begins with "@") so to fully correlate a request in the logs, `CorrelationId` uses the `Correlation-Context: Id` header value if present, otherwise it uses the RootId that `Activity` pulls from a hierarchical ids.  (dotnet/corefx#29265 is related to updating the `RootId` for this reason).

Currently, if there is a customized version of `IHttpRequestIdentifierFeature` that is provided as a feature, then it's generated `TraceIdentifier` will no longer be part of the log scope.  I'm open to suggestions on how to make this customization.

This pull request would be less required to make hierarchical Id's work for logging if some of the above could be swapped out and resolved at the application level.  However `HostingApplication` doesn't allow enough customization and `new`s stuff up, including `HostingApplicationDiagnostics` and `HostingApplication.Context`  (`HostingApplication` is in turn is `new`ed by `WebHost`).