### PR TITLE
There should only be a single IHostLifetime in the service container.

### DIFF
--- a/src/Microsoft.Extensions.Hosting/HostingHostBuilderExtensions.cs
+++ b/src/Microsoft.Extensions.Hosting/HostingHostBuilderExtensions.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting.Internal;
 using Microsoft.Extensions.Logging;
 
@@ -116,7 +117,19 @@ namespace Microsoft.Extensions.Hosting
         /// <returns>The same instance of the <see cref="IHostBuilder"/> for chaining.</returns>
         public static IHostBuilder UseConsoleLifetime(this IHostBuilder hostBuilder)
         {
-            return hostBuilder.ConfigureServices((context, collection) => collection.AddSingleton<IHostLifetime, ConsoleLifetime>());
+            return hostBuilder.UseHostLifetime<ConsoleLifetime>();
+        }
+
+        /// <summary>
+        /// Replaces the registered <see cref="IHostLifetime"/> type in the service container with the specified <typeparamref name="TLifetime"/>.
+        /// </summary>
+        /// <typeparam name="TLifetime"></typeparam>
+        /// <param name="hostBuilder">The <see cref="IHostBuilder" /> to configure.</param>
+        /// <returns>The same instance of the <see cref="IHostBuilder"/> for chaining.</returns>
+        public static IHostBuilder UseHostLifetime<TLifetime>(this IHostBuilder hostBuilder)
+            where TLifetime : class, IHostLifetime
+        {
+            return hostBuilder.ConfigureServices((context, collection) => collection.Replace(ServiceDescriptor.Singleton<IHostLifetime, TLifetime>()));
         }
 
         /// <summary>

--- a/test/Microsoft.Extensions.Hosting.Tests/HostBuilderTests.cs
+++ b/test/Microsoft.Extensions.Hosting.Tests/HostBuilderTests.cs
@@ -4,10 +4,12 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting.Fakes;
+using Microsoft.Extensions.Hosting.Tests.Fakes;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Xunit;
@@ -457,6 +459,37 @@ namespace Microsoft.Extensions.Hosting
             hostBuilder.Properties.Add("key", "value");
 
             Assert.Equal("value", hostBuilder.Properties["key"]);
+
+            using (hostBuilder.Build()) { }
+        }
+
+
+        [Fact]
+        public void When_UseConsoleLifetime_Then_SingleHostLifetime()
+        {
+            var hostBuilder = new HostBuilder()
+                .UseConsoleLifetime();
+
+            hostBuilder.ConfigureContainer((HostBuilderContext hostContext, IServiceCollection services) =>
+            {
+                var count = services.Count(descriptor => descriptor.ServiceType == typeof(IHostLifetime));
+                Assert.Equal(1, count);
+            });
+
+            using (hostBuilder.Build()) { }
+        }
+
+        [Fact]
+        public void When_FakeHostLifetime_Then_SingleHostLifetime()
+        {
+            var hostBuilder = new HostBuilder()
+                .UseHostLifetime<FakeHostLifetime>();
+
+            hostBuilder.ConfigureContainer((HostBuilderContext hostContext, IServiceCollection services) =>
+            {
+                var count = services.Count(descriptor => descriptor.ServiceType == typeof(IHostLifetime));
+                Assert.Equal(1, count);
+            });
 
             using (hostBuilder.Build()) { }
         }


### PR DESCRIPTION
### Problem Statement
Currently both `HostBuilder.CreateServiceProvider` and `HostingHostBuilderExtensions.UseConsoleLifetime` add to the service collection which causes multiple registrations for the `IHostLifetime` singleton. When using the default service container, this is not a problem because only the last registration is used when creating singleton instances. But this may be a problem for other DI containers.

### Proposed Solution
When configuring the `IHostLifetime` service registration, use the `Replace` extension method for `IServiceCollection` instead of calling `Add`. I also added unit tests and a `UseHostLifetime` extension method for `IHostBuilder`.