### PR TITLE
Run self-host tests with no-build

### DIFF
--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Common/DeploymentParameters.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Common/DeploymentParameters.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 
 namespace Microsoft.AspNetCore.Server.IntegrationTesting
 {
@@ -45,6 +46,12 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
             ServerType = serverType;
             RuntimeFlavor = runtimeFlavor;
             EnvironmentVariables["ASPNETCORE_DETAILEDERRORS"] = "true";
+
+            var configAttribute = Assembly.GetCallingAssembly().GetCustomAttribute<AssemblyConfigurationAttribute>();
+            if (configAttribute != null && !string.IsNullOrEmpty(configAttribute.Configuration))
+            {
+                Configuration = configAttribute.Configuration;
+            }
         }
 
         public ServerType ServerType { get; }

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/SelfHostDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/SelfHostDeployer.cs
@@ -97,9 +97,7 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
                     var targetFramework = DeploymentParameters.TargetFramework ?? (DeploymentParameters.RuntimeFlavor == RuntimeFlavor.Clr ? "net461" : "netcoreapp2.0");
 
                     executableName = DotnetCommandName;
-                    // Set VerifyMatchingImplicitPackageVersion to disable errors when Microsoft.NETCore.App's version is overridden externally
-                    // This verification doesn't matter if we are skipping restore during tests.
-                    executableArgs = $"run --no-restore --framework {targetFramework} /p:VerifyMatchingImplicitPackageVersion=false {DotnetArgumentSeparator}";
+                    executableArgs = $"run --no-build -c {DeploymentParameters.Configuration} --framework {targetFramework} {DotnetArgumentSeparator}";
                 }
 
                 executableArgs += $" --server.urls {hintUrl} "

--- a/test/TestAssets/IStartupInjectionAssemblyName/Program.cs
+++ b/test/TestAssets/IStartupInjectionAssemblyName/Program.cs
@@ -13,13 +13,16 @@ namespace IStartupInjectionAssemblyName
     {
         public static void Main(string[] args)
         {
-            var server = new TestServer(CreateWebHostBuilder(args));
-
-            Task.Run(async () => Console.WriteLine(await server.CreateClient().GetStringAsync(""))).GetAwaiter().GetResult();
+            var webHost = CreateWebHostBuilder(args).Build();
+            var applicationName = webHost.Services.GetRequiredService<IHostingEnvironment>().ApplicationName;
+            Console.WriteLine(applicationName);
+            Console.ReadKey();
         }
 
         // Do not change the signature of this method. It's used for tests.
         private static IWebHostBuilder CreateWebHostBuilder(string [] args) =>
-            new WebHostBuilder().SuppressStatusMessages(true).ConfigureServices(services => services.AddSingleton<IStartup, Startup>());
+            new WebHostBuilder()
+            .SuppressStatusMessages(true)
+            .ConfigureServices(services => services.AddSingleton<IStartup, Startup>());
     }
 }

--- a/test/TestAssets/IStartupInjectionAssemblyName/Startup.cs
+++ b/test/TestAssets/IStartupInjectionAssemblyName/Startup.cs
@@ -11,11 +11,6 @@ namespace IStartupInjectionAssemblyName
     {
         public void Configure(IApplicationBuilder app)
         {
-            var applicationName = app.ApplicationServices.GetRequiredService<IHostingEnvironment>().ApplicationName;
-            app.Run(context =>
-            {
-                return context.Response.WriteAsync(applicationName);
-            });
         }
 
         public IServiceProvider ConfigureServices(IServiceCollection services)


### PR DESCRIPTION
#1399 The CI test passes build the whole repo before running tests, so we shouldn't need to rebuild the test sites before deploying them. I tested this privately with ServerTests without issue, but it's hard to replicate the CI testing environment to make sure it fixes the nuget warning we only see there.