### PR TITLE
Make deployer handle ANCM V1 and V2

### DIFF
--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Common/ANCMVersion.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Common/ANCMVersion.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Server.IntegrationTesting
+{
+    public enum ANCMVersion
+    {
+        AspNetCoreModule,
+        AspNetCoreModuleV2
+    }
+}

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Common/DeploymentParameters.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Common/DeploymentParameters.cs
@@ -121,6 +121,12 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
         public HostingModel HostingModel { get; set; }
 
         /// <summary>
+        /// When using the IISExpressDeployer, determines whether to use the older or newer version
+        /// of ANCM.
+        /// </summary>
+        public ANCMVersion ANCMVersion { get; set; } = ANCMVersion.AspNetCoreModuleV2;
+
+        /// <summary>
         /// Environment variables to be set before starting the host.
         /// Not applicable for IIS Scenarios.
         /// </summary>

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Common/DeploymentParameters.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Common/DeploymentParameters.cs
@@ -124,7 +124,7 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
         /// When using the IISExpressDeployer, determines whether to use the older or newer version
         /// of ANCM.
         /// </summary>
-        public ANCMVersion ANCMVersion { get; set; } = ANCMVersion.AspNetCoreModuleV2;
+        public ANCMVersion ANCMVersion { get; set; } = ANCMVersion.AspNetCoreModule;
 
         /// <summary>
         /// Environment variables to be set before starting the host.

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/IISExpressDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/IISExpressDeployer.cs
@@ -106,7 +106,6 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
 
                         // Pass on the applicationhost.config to iis express. With this don't need to pass in the /path /port switches as they are in the applicationHost.config
                         // We take a copy of the original specified applicationHost.Config to prevent modifying the one in the repo.
-
                         if (serverConfig.Contains("[ANCMPath]"))
                         {
                             // We need to pick the bitness based the OS / IIS Express, not the application.
@@ -166,8 +165,9 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
 
                     if (DeploymentParameters.HostingModel == HostingModel.InProcess)
                     {
-                        ModifyWebConfigToInProcess();
+                        ModifyAspNetCoreSectionInWebConfig(key: "hostingModel", value: "inprocess");
                     }
+                    ModifyAspNetCoreSectionInWebConfig(key: "module", value: DeploymentParameters.ANCMVersion.ToString());
 
                     var parameters = string.IsNullOrWhiteSpace(DeploymentParameters.ServerConfigLocation) ?
                                     string.Format("/port:{0} /path:\"{1}\" /trace:error", uri.Port, contentRoot) :
@@ -319,12 +319,12 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
 
         // Transforms the web.config file to include the hostingModel="inprocess" element
         // and adds the server type = Microsoft.AspNetServer.IIS such that Kestrel isn't added again in ServerTests
-        private void ModifyWebConfigToInProcess()
+        private void ModifyAspNetCoreSectionInWebConfig(string key, string value)
         {
             var webConfigFile = $"{DeploymentParameters.PublishedApplicationRootPath}/web.config";
             var config = XDocument.Load(webConfigFile);
             var element = config.Descendants("aspNetCore").FirstOrDefault();
-            element.SetAttributeValue("hostingModel", "inprocess");
+            element.SetAttributeValue(key, value);
             config.Save(webConfigFile);
         }
     }

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/IISExpressDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/IISExpressDeployer.cs
@@ -167,7 +167,7 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
                     {
                         ModifyAspNetCoreSectionInWebConfig(key: "hostingModel", value: "inprocess");
                     }
-                    ModifyAspNetCoreSectionInWebConfig(key: "module", value: DeploymentParameters.ANCMVersion.ToString());
+                    ModifyAspNetCoreSectionInWebConfig(key: "modules", value: DeploymentParameters.ANCMVersion.ToString());
 
                     var parameters = string.IsNullOrWhiteSpace(DeploymentParameters.ServerConfigLocation) ?
                                     string.Format("/port:{0} /path:\"{1}\" /trace:error", uri.Port, contentRoot) :


### PR DESCRIPTION
Right now, in IISIntegration, we handle modifying the web.config file from modules="AspNetCoreModule" to "AspNetCoreModuleV2". Instead, we can use a property to modify it in the deployer.