### PR TITLE
 Always check if ANCM is in the base output folder.

### DIFF
--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/IISExpressDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/IISExpressDeployer.cs
@@ -106,36 +106,9 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
 
                         // Pass on the applicationhost.config to iis express. With this don't need to pass in the /path /port switches as they are in the applicationHost.config
                         // We take a copy of the original specified applicationHost.Config to prevent modifying the one in the repo.
-                        if (serverConfig.Contains("[ANCMPath]"))
-                        {
-                            // We need to pick the bitness based the OS / IIS Express, not the application.
-                            // We'll eventually add support for choosing which IIS Express bitness to run: https://github.com/aspnet/Hosting/issues/880
-                            var ancmFile = Path.Combine(contentRoot, Is64BitHost ? @"x64\aspnetcore.dll" : @"x86\aspnetcore.dll");
-                            // Bin deployed by Microsoft.AspNetCore.AspNetCoreModule.nupkg
+                        ModifyANCMPathInConfig(replaceFlag: "[ANCMPath]", dllName: "aspnetcore.dll", serverConfig, contentRoot);
 
-                            if (!File.Exists(Environment.ExpandEnvironmentVariables(ancmFile)))
-                            {
-                                throw new FileNotFoundException("AspNetCoreModule could not be found.", ancmFile);
-                            }
-
-                            Logger.LogDebug("Writing ANCMPath '{ancmFile}' to config", ancmFile);
-                            serverConfig =
-                                serverConfig.Replace("[ANCMPath]", ancmFile);
-                        }
-
-                        if (serverConfig.Contains("[ANCMV2Path]"))
-                        {
-                            var ancmFile = Path.Combine(contentRoot, Is64BitHost ? @"x64\aspnetcorev2.dll" : @"x86\aspnetcorev2.dll");
-
-                            if (!File.Exists(Environment.ExpandEnvironmentVariables(ancmFile)))
-                            {
-                                throw new FileNotFoundException("AspNetCoreModuleV2 could not be found.", ancmFile);
-                            }
-
-                            Logger.LogDebug("Writing ANCMV2Path '{ancmFile}' to config", ancmFile);
-                            serverConfig =
-                                serverConfig.Replace("[ANCMV2Path]", ancmFile);
-                        }
+                        ModifyANCMPathInConfig(replaceFlag: "[ANCMV2Path]", dllName: "aspnetcorev2.dll", serverConfig, contentRoot);
 
                         Logger.LogDebug("Writing ApplicationPhysicalPath '{applicationPhysicalPath}' to config", contentRoot);
                         Logger.LogDebug("Writing Port '{port}' to config", port);
@@ -262,6 +235,26 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
                 var message = $"Failed to initialize IIS Express after {MaximumAttempts} attempts to select a port";
                 Logger.LogError(message);
                 throw new TimeoutException(message);
+            }
+        }
+
+        private void ModifyANCMPathInConfig(string replaceFlag, string dllName, string serverConfig, string contentRoot)
+        {
+            if (serverConfig.Contains(replaceFlag))
+            {
+                var ancmFile = Path.Combine(contentRoot, Is64BitHost ? $@"x64\{dllName}" : $@"x86\{dllName}");
+                if (!File.Exists(Environment.ExpandEnvironmentVariables(ancmFile)))
+                {
+                    ancmFile = Path.Combine(contentRoot, Is64BitHost ? $@"{dllName}" : $@"{dllName}");
+                    if (!File.Exists(Environment.ExpandEnvironmentVariables(ancmFile)))
+                    {
+                        throw new FileNotFoundException("AspNetCoreModule could not be found.", ancmFile);
+                    }
+                }
+
+                Logger.LogDebug($"Writing '{replaceFlag}' '{ancmFile}' to config");
+                serverConfig =
+                    serverConfig.Replace(replaceFlag, ancmFile);
             }
         }
 

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/IISExpressDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/IISExpressDeployer.cs
@@ -243,10 +243,9 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
             if (serverConfig.Contains(replaceFlag))
             {
                 var ancmFile = Path.Combine(contentRoot, Is64BitHost ? $@"x64\{dllName}" : $@"x86\{dllName}");
-                var p = Environment.ExpandEnvironmentVariables(ancmFile);
                 if (!File.Exists(Environment.ExpandEnvironmentVariables(ancmFile)))
                 {
-                    ancmFile = Path.Combine(contentRoot, $@"{dllName}");
+                    ancmFile = Path.Combine(contentRoot, dllName);
                     if (!File.Exists(Environment.ExpandEnvironmentVariables(ancmFile)))
                     {
                         throw new FileNotFoundException("AspNetCoreModule could not be found.", ancmFile);

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/IISExpressDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/IISExpressDeployer.cs
@@ -243,9 +243,10 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
             if (serverConfig.Contains(replaceFlag))
             {
                 var ancmFile = Path.Combine(contentRoot, Is64BitHost ? $@"x64\{dllName}" : $@"x86\{dllName}");
+                var p = Environment.ExpandEnvironmentVariables(ancmFile);
                 if (!File.Exists(Environment.ExpandEnvironmentVariables(ancmFile)))
                 {
-                    ancmFile = Path.Combine(contentRoot, Is64BitHost ? $@"{dllName}" : $@"{dllName}");
+                    ancmFile = Path.Combine(contentRoot, $@"{dllName}");
                     if (!File.Exists(Environment.ExpandEnvironmentVariables(ancmFile)))
                     {
                         throw new FileNotFoundException("AspNetCoreModule could not be found.", ancmFile);

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/IISExpressDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/IISExpressDeployer.cs
@@ -106,9 +106,9 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
 
                         // Pass on the applicationhost.config to iis express. With this don't need to pass in the /path /port switches as they are in the applicationHost.config
                         // We take a copy of the original specified applicationHost.Config to prevent modifying the one in the repo.
-                        ModifyANCMPathInConfig(replaceFlag: "[ANCMPath]", dllName: "aspnetcore.dll", serverConfig, contentRoot);
+                        serverConfig = ModifyANCMPathInConfig(replaceFlag: "[ANCMPath]", dllName: "aspnetcore.dll", serverConfig, contentRoot);
 
-                        ModifyANCMPathInConfig(replaceFlag: "[ANCMV2Path]", dllName: "aspnetcorev2.dll", serverConfig, contentRoot);
+                        serverConfig = ModifyANCMPathInConfig(replaceFlag: "[ANCMV2Path]", dllName: "aspnetcorev2.dll", serverConfig, contentRoot);
 
                         Logger.LogDebug("Writing ApplicationPhysicalPath '{applicationPhysicalPath}' to config", contentRoot);
                         Logger.LogDebug("Writing Port '{port}' to config", port);
@@ -238,7 +238,7 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
             }
         }
 
-        private void ModifyANCMPathInConfig(string replaceFlag, string dllName, string serverConfig, string contentRoot)
+        private string ModifyANCMPathInConfig(string replaceFlag, string dllName, string serverConfig, string contentRoot)
         {
             if (serverConfig.Contains(replaceFlag))
             {
@@ -253,9 +253,9 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
                 }
 
                 Logger.LogDebug($"Writing '{replaceFlag}' '{ancmFile}' to config");
-                serverConfig =
-                    serverConfig.Replace(replaceFlag, ancmFile);
+                return serverConfig.Replace(replaceFlag, ancmFile);
             }
+            return serverConfig;
         }
 
         private string GetIISExpressPath()


### PR DESCRIPTION
Fix for https://github.com/aspnet/IISIntegration/issues/831.
For standalone coreclr applications, the aspnetcorerh.dll will be put in the app root folder rather than the (Bitness)/aspnetcorerh.dll folder. Instead of special casing for deployment type, we will check the app root too. 