### PR TITLE
Enable x86 testing

### DIFF
--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Common/DeploymentParameters.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Common/DeploymentParameters.cs
@@ -65,11 +65,6 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
                 throw new DirectoryNotFoundException(string.Format("Application path {0} does not exist.", applicationPath));
             }
 
-            if (runtimeArchitecture == RuntimeArchitecture.x86 && runtimeFlavor == RuntimeFlavor.CoreClr)
-            {
-                throw new NotSupportedException("32 bit deployment is not yet supported for CoreCLR. Don't remove the tests, just disable them for now.");
-            }
-
             ApplicationPath = applicationPath;
             ApplicationName = new DirectoryInfo(ApplicationPath).Name;
             ServerType = serverType;

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Common/DotNetCommands.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Common/DotNetCommands.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.AspNetCore.Server.IntegrationTesting.Common
+{
+    public static class DotNetCommands
+    {
+        private const string _dotnetFolderName = ".dotnet";
+
+        public static string DotNetHome { get; } = GetDotNetHome();
+
+        // Compare to https://github.com/aspnet/BuildTools/blob/314c98e4533217a841ff9767bb38e144eb6c93e4/tools/KoreBuild.Console/Commands/CommandContext.cs#L76
+        private static string GetDotNetHome()
+        {
+            var dotnetHome = Environment.GetEnvironmentVariable("DOTNET_HOME");
+            var userProfile = Environment.GetEnvironmentVariable("USERPROFILE");
+            var home = Environment.GetEnvironmentVariable("HOME");
+
+            var result = Path.Combine(Directory.GetCurrentDirectory(), _dotnetFolderName);
+            if (!string.IsNullOrEmpty(dotnetHome))
+            {
+                result = dotnetHome;
+            }
+            else if (!string.IsNullOrEmpty(userProfile))
+            {
+                result = Path.Combine(userProfile, _dotnetFolderName);
+            }
+            else if (!string.IsNullOrEmpty(home))
+            {
+                result = home;
+            }
+
+            return result;
+        }
+
+        public static string GetDotNetInstallDir(RuntimeArchitecture arch)
+        {
+            var dotnetDir = DotNetHome;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                dotnetDir = Path.Combine(dotnetDir, arch.ToString());
+            }
+
+            return dotnetDir;
+        }
+
+        public static string GetDotNetExecutable(RuntimeArchitecture arch)
+        {
+            var dotnetDir = GetDotNetInstallDir(arch);
+
+            var dotnetFile = "dotnet";
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                dotnetFile += ".exe";
+            }
+
+            return Path.Combine(dotnetDir, dotnetFile);
+        }
+
+        public static bool IsRunningX86OnX64(RuntimeArchitecture arch)
+        {
+            return (RuntimeInformation.OSArchitecture == Architecture.X64 || RuntimeInformation.OSArchitecture == Architecture.Arm64)
+                && arch == RuntimeArchitecture.x86;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/ApplicationDeployer.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Deployers/ApplicationDeployer.cs
@@ -47,11 +47,6 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
                 DeploymentParameters.RuntimeFlavor = GetRuntimeFlavor(DeploymentParameters.TargetFramework);
             }
 
-            if (DeploymentParameters.RuntimeArchitecture == RuntimeArchitecture.x86 && DeploymentParameters.RuntimeFlavor == RuntimeFlavor.CoreClr)
-            {
-                throw new NotSupportedException("32 bit deployment is not yet supported for CoreCLR. Don't remove the tests, just disable them for now.");
-            }
-
             if (string.IsNullOrEmpty(DeploymentParameters.ApplicationPath))
             {
                 throw new ArgumentException("ApplicationPath cannot be null.");

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/TestMatrix.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/TestMatrix.cs
@@ -246,9 +246,11 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
         {
             foreach (var arch in Architectures)
             {
+                var archSkip = skip ?? SkipIfArchitectureNotSupportedOnCurrentSystem(arch);
+
                 if (server == ServerType.IISExpress)
                 {
-                    VaryByAncmVersion(variants, server, tfm, type, arch, skip);
+                    VaryByAncmVersion(variants, server, tfm, type, arch, archSkip);
                 }
                 else
                 {
@@ -258,10 +260,23 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
                         Tfm = tfm,
                         ApplicationType = type,
                         Architecture = arch,
-                        Skip = skip,
+                        Skip = archSkip,
                     });
                 }
             }
+        }
+
+        private string SkipIfArchitectureNotSupportedOnCurrentSystem(RuntimeArchitecture arch)
+        {
+            if (arch == RuntimeArchitecture.x64)
+            {
+                // Can't run x64 on a x86 OS.
+                return (RuntimeInformation.OSArchitecture == Architecture.Arm || RuntimeInformation.OSArchitecture == Architecture.X86)
+                    ? $"Cannot run {arch} on your current system." : null;
+            }
+
+            // No x86 runtimes available on MacOS or Linux.
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? null : $"No {arch} available for non-Windows systems.";
         }
 
         private void VaryByAncmVersion(IList<TestVariant> variants, ServerType server, string tfm, ApplicationType type, RuntimeArchitecture arch, string skip)

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/TestVariant.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/TestVariant.cs
@@ -21,7 +21,13 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
         public override string ToString()
         {
             // For debug and test explorer view
-            return $"Server: {Server}, TFM: {Tfm}, Type: {ApplicationType}, Host: {HostingModel}, ANCM: {AncmVersion}, Arch: {Architecture}";
+            var description = $"Server: {Server}, TFM: {Tfm}, Type: {ApplicationType}, Arch: {Architecture}";
+            if (Server == ServerType.IISExpress)
+            {
+                var version = AncmVersion == AncmVersion.AspNetCoreModule ? "V1" : "V2";
+                description += $", ANCM: {version}, Host: {HostingModel}";
+            }
+            return description;
         }
 
         public void Serialize(IXunitSerializationInfo info)

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/xunit/SkipOn32BitOSAttribute.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/xunit/SkipOn32BitOSAttribute.cs
@@ -2,32 +2,21 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.IO;
+using System.Runtime.InteropServices;
 using Microsoft.AspNetCore.Testing.xunit;
 
 namespace Microsoft.AspNetCore.Server.IntegrationTesting
 {
     /// <summary>
-    /// Skips a 64 bit test if the current Windows OS is 32-bit.
+    /// Skips a 64 bit test if the current OS is 32-bit.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
     public class SkipOn32BitOSAttribute : Attribute, ITestCondition
     {
-        public bool IsMet
-        {
-            get
-            {
-                // Directory found only on 64-bit OS.
-                return Directory.Exists(Path.Combine(Environment.GetEnvironmentVariable("SystemRoot"), "SysWOW64"));
-            }
-        }
+        public bool IsMet =>
+            RuntimeInformation.OSArchitecture == Architecture.Arm64
+            || RuntimeInformation.OSArchitecture == Architecture.X64;
 
-        public string SkipReason
-        {
-            get
-            {
-                return "Skipping the x64 test since Windows is 32-bit";
-            }
-        }
+        public string SkipReason => "Skipping the x64 test since Windows is 32-bit";
     }
 }


### PR DESCRIPTION
 #949 The biggest task is to get the right dotnet.exe in all the right places.

Verified with ServerTests. Minimal changes are required in the consuming repos.

TODO: The one big item left is to figure out how to modify the build scripts to install the x86 sdk and runtimes for select repos. We already have the commands to do it manually, I just need to automate it.