### PR TITLE
Add try..finally around RunAsync and WaitForTokenShutdownAsync

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting/WebHostExtensions.cs
+++ b/src/Microsoft.AspNetCore.Hosting/WebHostExtensions.cs
@@ -45,8 +45,14 @@ namespace Microsoft.AspNetCore.Hosting
             {
                 AttachCtrlcSigtermShutdown(cts, done, shutdownMessage: string.Empty);
 
-                await host.WaitForTokenShutdownAsync(cts.Token);
-                done.Set();
+                try
+                {
+                    await host.WaitForTokenShutdownAsync(cts.Token);
+                }
+                finally
+                {
+                    done.Set();
+                }
             }
         }
 
@@ -80,8 +86,14 @@ namespace Microsoft.AspNetCore.Hosting
                 var shutdownMessage = host.Services.GetRequiredService<WebHostOptions>().SuppressStatusMessages ? string.Empty : "Application is shutting down...";
                 AttachCtrlcSigtermShutdown(cts, done, shutdownMessage: shutdownMessage);
 
-                await host.RunAsync(cts.Token, "Application started. Press Ctrl+C to shut down.");
-                done.Set();
+                try
+                {
+                    await host.RunAsync(cts.Token, "Application started. Press Ctrl+C to shut down.");
+                }
+                finally
+                {
+                    done.Set();
+                }
             }
         }
 
@@ -92,7 +104,6 @@ namespace Microsoft.AspNetCore.Hosting
                 await host.StartAsync(token);
 
                 var hostingEnvironment = host.Services.GetService<IHostingEnvironment>();
-                var applicationLifetime = host.Services.GetService<IApplicationLifetime>();
                 var options = host.Services.GetRequiredService<WebHostOptions>();
 
                 if (!options.SuppressStatusMessages)


### PR DESCRIPTION
The try..finally ensures that the ManualResetEventSlim which AttachCtrlcSigtermShutdown uses is set even when an exception occurs in these two methods.

Fixes #1194 

I also looked at if I could any tests to test this behavior (besides manually testing it with a repo sample project) and looked at https://github.com/aspnet/Hosting/blob/dev/test/Microsoft.AspNetCore.Hosting.FunctionalTests/ShutdownTests.cs but saw in the code that it was disabled because of #1214 and so I didn't add upon it. If anyone has any idea how to add tests for this behavior I am all ears and will add it to this PR.