### PR TITLE
Inherit web-specific IHostingEnvironment and IApplicationLifetime from the Generic Host ones

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/IApplicationLifetime.cs
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/IApplicationLifetime.cs
@@ -8,30 +8,7 @@ namespace Microsoft.AspNetCore.Hosting
     /// <summary>
     /// Allows consumers to perform cleanup during a graceful shutdown.
     /// </summary>
-    public interface IApplicationLifetime
+    public interface IApplicationLifetime : Extensions.Hosting.IApplicationLifetime
     {
-        /// <summary>
-        /// Triggered when the application host has fully started and is about to wait
-        /// for a graceful shutdown.
-        /// </summary>
-        CancellationToken ApplicationStarted { get; }
-
-        /// <summary>
-        /// Triggered when the application host is performing a graceful shutdown.
-        /// Requests may still be in flight. Shutdown will block until this event completes.
-        /// </summary>
-        CancellationToken ApplicationStopping { get; }
-
-        /// <summary>
-        /// Triggered when the application host is performing a graceful shutdown.
-        /// All requests should be complete at this point. Shutdown will block
-        /// until this event completes.
-        /// </summary>
-        CancellationToken ApplicationStopped { get; }
-
-        /// <summary>
-        /// Requests termination of the current application.
-        /// </summary>
-        void StopApplication();
     }
 }

--- a/src/Microsoft.AspNetCore.Hosting.Abstractions/IHostingEnvironment.cs
+++ b/src/Microsoft.AspNetCore.Hosting.Abstractions/IHostingEnvironment.cs
@@ -8,20 +8,8 @@ namespace Microsoft.AspNetCore.Hosting
     /// <summary>
     /// Provides information about the web hosting environment an application is running in.
     /// </summary>
-    public interface IHostingEnvironment
+    public interface IHostingEnvironment : Extensions.Hosting.IHostingEnvironment
     {
-        /// <summary>
-        /// Gets or sets the name of the environment. The host automatically sets this property to the value
-        /// of the "ASPNETCORE_ENVIRONMENT" environment variable, or "environment" as specified in any other configuration source.
-        /// </summary>
-        string EnvironmentName { get; set; }
-
-        /// <summary>
-        /// Gets or sets the name of the application. This property is automatically set by the host to the assembly containing
-        /// the application entry point.
-        /// </summary>
-        string ApplicationName { get; set; }
-
         /// <summary>
         /// Gets or sets the absolute path to the directory that contains the web-servable application content files.
         /// </summary>
@@ -31,15 +19,5 @@ namespace Microsoft.AspNetCore.Hosting
         /// Gets or sets an <see cref="IFileProvider"/> pointing at <see cref="WebRootPath"/>.
         /// </summary>
         IFileProvider WebRootFileProvider { get; set; }
-
-        /// <summary>
-        /// Gets or sets the absolute path to the directory that contains the application content files.
-        /// </summary>
-        string ContentRootPath { get; set; }
-
-        /// <summary>
-        /// Gets or sets an <see cref="IFileProvider"/> pointing at <see cref="ContentRootPath"/>.
-        /// </summary>
-        IFileProvider ContentRootFileProvider { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.Hosting/Internal/ApplicationLifetime.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/ApplicationLifetime.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
     /// <summary>
     /// Allows consumers to perform cleanup during a graceful shutdown.
     /// </summary>
-    public class ApplicationLifetime : IApplicationLifetime, Extensions.Hosting.IApplicationLifetime
+    public class ApplicationLifetime : IApplicationLifetime
     {
         private readonly CancellationTokenSource _startedSource = new CancellationTokenSource();
         private readonly CancellationTokenSource _stoppingSource = new CancellationTokenSource();

--- a/src/Microsoft.AspNetCore.Hosting/Internal/HostingEnvironment.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/HostingEnvironment.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.FileProviders;
 
 namespace Microsoft.AspNetCore.Hosting.Internal
 {
-    public class HostingEnvironment : IHostingEnvironment, Extensions.Hosting.IHostingEnvironment
+    public class HostingEnvironment : IHostingEnvironment
     {
         public string EnvironmentName { get; set; } = Hosting.EnvironmentName.Production;
 


### PR DESCRIPTION
Resolves #1447 and contributes to #1218.

/cc @davidfowl 