### PR TITLE
Added Ability to GenericHost to be run as Windows Service

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting.WindowsServices/GenericHostService.cs
+++ b/src/Microsoft.AspNetCore.Hosting.WindowsServices/GenericHostService.cs
@@ -1,0 +1,85 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.ServiceProcess;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Microsoft.AspNetCore.Hosting.WindowsServices
+{
+    /// <summary>
+    ///     Provides an implementation of a Windows service that hosts ASP.NET Core.
+    /// </summary>
+    public class GenericHostService : ServiceBase
+    {
+        private IHost _host;
+        private bool _stopRequestedByWindows;
+
+        /// <summary>
+        /// Creates an instance of <c>GenericHostService</c> which hosts the specified application.
+        /// </summary>
+        /// <param name="host">The configured generic host containing the application to run in the Windows service.</param>
+        public GenericHostService(IHost host)
+        {
+            _host = host ?? throw new ArgumentNullException(nameof(host));
+        }
+
+        protected sealed override void OnStart(string[] args)
+        {
+            OnStarting(args);
+
+            _host
+                .Services
+                .GetRequiredService<IApplicationLifetime>()
+                .ApplicationStopped
+                .Register(() =>
+                {
+                    if (!_stopRequestedByWindows)
+                    {
+                        Stop();
+                    }
+                });
+
+            _host.Start();
+
+            OnStarted();
+        }
+
+        protected sealed override void OnStop()
+        {
+            _stopRequestedByWindows = true;
+            OnStopping();
+            try
+            {
+                _host.StopAsync().GetAwaiter().GetResult();
+            }
+            finally
+            {
+                _host.Dispose();
+                OnStopped();
+            }
+        }
+
+        /// <summary>
+        /// Executes before ASP.NET Core starts.
+        /// </summary>
+        /// <param name="args">The command line arguments passed to the service.</param>
+        protected virtual void OnStarting(string[] args) { }
+
+        /// <summary>
+        /// Executes after ASP.NET Core starts.
+        /// </summary>
+        protected virtual void OnStarted() { }
+
+        /// <summary>
+        /// Executes before ASP.NET Core shuts down.
+        /// </summary>
+        protected virtual void OnStopping() { }
+
+        /// <summary>
+        /// Executes after ASP.NET Core shuts down.
+        /// </summary>
+        protected virtual void OnStopped() { }
+    }
+}

--- a/src/Microsoft.AspNetCore.Hosting.WindowsServices/WebHostWindowsServiceExtensions.cs
+++ b/src/Microsoft.AspNetCore.Hosting.WindowsServices/WebHostWindowsServiceExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.ServiceProcess;
+using Microsoft.Extensions.Hosting;
 
 namespace Microsoft.AspNetCore.Hosting.WindowsServices
 {
@@ -15,7 +16,7 @@ namespace Microsoft.AspNetCore.Hosting.WindowsServices
         /// </summary>
         /// <param name="host">An instance of the <see cref="IWebHost"/> to host in the Windows service.</param>
         /// <example>
-        ///     This example shows how to use <see cref="RunAsService"/>.
+        ///     This example shows how to use <see cref="RunAsService(IWebHost)"/>.
         ///     <code>
         ///         public class Program
         ///         {
@@ -37,6 +38,53 @@ namespace Microsoft.AspNetCore.Hosting.WindowsServices
         {
             var webHostService = new WebHostService(host);
             ServiceBase.Run(webHostService);
+        }
+
+        /// <summary>
+        ///     Runs the specified .net core application inside a Windows service and blocks until the service is stopped.
+        /// </summary>
+        /// <param name="host">An instance of the <see cref="IHost"/> to host in the Windows service.</param>
+        /// <example>
+        ///     This example shows how to use <see cref="RunAsService(IHost)"/>.
+        ///     <code>
+        ///         public class Program
+        ///         {
+        ///             public static void Main(string[] args)
+        ///             {
+        ///                 var host = new HostBuilder()
+        ///                     .ConfigureHostConfiguration(configHost =>
+        ///                     {
+        ///                         configHost.SetBasePath(Directory.GetCurrentDirectory());
+        ///                         configHost.AddEnvironmentVariables(prefix: "ASPNETCORE_");
+        ///                         configHost.AddCommandLine(args);
+        ///                     })
+        ///                     .ConfigureAppConfiguration((hostContext, configApp) =>
+        ///                     {
+        ///                         configApp.AddJsonFile("appsettings.json", optional: true);
+        ///                         configApp.AddEnvironmentVariables(prefix: "ASPNETCORE_");
+        ///                         configApp.AddCommandLine(args);
+        ///                     })
+        ///                     .ConfigureServices((hostContext, services) =>
+        ///                     {
+        ///                         services.AddLogging();               ///                       
+        ///                     })
+        ///                     .ConfigureLogging((hostContext, configLogging) =>
+        ///                     {
+        ///                         configLogging.AddConsole()        
+        ///                     })
+        ///                     .UseConsoleLifetime()
+        ///                     .Build();        
+        ///                  
+        ///                 // This call will block until the service is stopped.
+        ///                 host.RunAsService();
+        ///             }
+        ///         }
+        ///     </code>
+        /// </example> 
+        public static void RunAsService(this IHost host)
+        {
+            var genericHostService = new GenericHostService(host);
+            ServiceBase.Run(genericHostService);
         }
     }
 }


### PR DESCRIPTION
Added a new Copy of WebHostService and change it to accept IHost to be able to run with new Generic host feature. also updated WebHostWindowsServiceExtensions.cs and added an overload for RunAsService to extend IHost.