### PR TITLE
Fixed bug where 'ServerUrlsKeys' was not read from user configuration.

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting/WebHostBuilder.cs
+++ b/src/Microsoft.AspNetCore.Hosting/WebHostBuilder.cs
@@ -187,7 +187,7 @@ namespace Microsoft.AspNetCore.Hosting
                 applicationServices,
                 hostingServiceProvider,
                 _options,
-                _config,
+                _context.Configuration,
                 hostingStartupErrors);
             try
             {


### PR DESCRIPTION
There was no way to read URLs from 'appsettings.json' file because the configuration object passed to the WebHost was not the object the user built.