### PR TITLE
Add copy constructor to deployment parameters

### DIFF
--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting/Common/DeploymentParameters.cs
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting/Common/DeploymentParameters.cs
@@ -78,6 +78,27 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
             }
         }
 
+        public DeploymentParameters(DeploymentParameters parameters)
+        {
+            foreach (var propertyInfo in typeof(DeploymentParameters).GetProperties())
+            {
+                if (propertyInfo.CanWrite)
+                {
+                    propertyInfo.SetValue(this, propertyInfo.GetValue(parameters));
+                }
+            }
+
+            foreach (var kvp in parameters.EnvironmentVariables)
+            {
+                EnvironmentVariables.Add(kvp);
+            }
+
+            foreach (var kvp in parameters.PublishEnvironmentVariables)
+            {
+                PublishEnvironmentVariables.Add(kvp);
+            }
+        }
+
         public ServerType ServerType { get; set;  }
 
         public RuntimeFlavor RuntimeFlavor { get; set;  }


### PR DESCRIPTION
Uses reflection for now to copy all setable properties.