### PR TITLE
Add test build targets to ensure version alignment

### DIFF
--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -1,0 +1,46 @@
+<Project>
+  <Import Project="..\Directory.Build.targets" />
+
+  <ItemGroup>
+    <None Include="$(TestProjectTemplateFile)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <TestProjectGenInputs Include="$(ProjectAssetsFile)" />
+    <TestProjectGenInputs Include="$(MSBuildAllProjects)" />
+    <TestProjectGenInputs Include="$(TestProjectTemplateFile)" />
+    <TestProjectGenInputs Include="$(MSBuildThisFileDirectory)..\build\dependencies.props" />
+    <TestProjectGenInputs Include="$(MSBuildThisFileDirectory)..\build\sources.props" />
+    <TestProjectGenInputs Include="$(DotNetPackageVersionPropsPath)" Condition=" '$(DotNetPackageVersionPropsPath)' != '' " />
+    <TestProjectGenInputs Include="$(DotNetRestoreSourcePropsPath)" Condition=" '$(DotNetRestoreSourcePropsPath)' != '' " />
+  </ItemGroup>
+
+  <Target Name="GenerateTestProject" BeforeTargets="CoreCompile" Inputs="@(TestProjectGenInputs)" Outputs="$(GeneratedTestProjectFile)">
+    <PropertyGroup>
+      <RestoreSources>
+        $(RestoreSources);
+        $(MSBuildThisFileDirectory)..\artifacts\build;
+      </RestoreSources>
+      <TestProjectProperties>
+        RestoreSources=$([MSBuild]::Escape($(RestoreSources.Trim())));
+        TargetFramework=$(TargetFramework);
+        MicrosoftNETCoreApp20PackageVersion=$(MicrosoftNETCoreApp20PackageVersion);
+        MicrosoftNETCoreApp21PackageVersion=$(MicrosoftNETCoreApp21PackageVersion);
+        MicrosoftNETCoreApp22PackageVersion=$(MicrosoftNETCoreApp22PackageVersion);
+        MicrosoftExtensionsConfigurationPackageVersion=$(MicrosoftExtensionsConfigurationPackageVersion);
+        MicrosoftExtensionsConfigurationCommandLinePackageVersion=$(MicrosoftExtensionsConfigurationCommandLinePackageVersion);
+        MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion=$(MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion);
+        MicrosoftExtensionsLoggingConsolePackageVersion=$(MicrosoftExtensionsLoggingConsolePackageVersion);
+      </TestProjectProperties>
+    </PropertyGroup>
+
+    <Sdk_GenerateFileFromTemplate
+      TemplateFile="$(TestProjectTemplateFile)"
+      Properties="$(TestProjectProperties)"
+      OutputPath="$(GeneratedTestProjectFile)">
+      <Output TaskParameter="OutputPath" ItemName="FileWrites" />
+      <Output TaskParameter="OutputPath" ItemName="Compile" />
+    </Sdk_GenerateFileFromTemplate>
+
+  </Target>
+</Project>

--- a/test/TestAssets/Directory.Build.targets
+++ b/test/TestAssets/Directory.Build.targets
@@ -1,0 +1,4 @@
+<Project>
+  <!-- Skip the targets for test projects -->
+  <Import Project="..\..\Directory.Build.targets" />
+</Project>


### PR DESCRIPTION
 #1503 Trying the pattern from scaffolding to force dependencies to stay in sync during a CI build.
https://github.com/aspnet/Scaffolding/blob/master/test/Directory.Build.targets

Unable to repro the failure locally, but this doesn't seem to make anything worse.