### PR TITLE
Don't hold onto the HttpContext in the HostingLogScope

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting/Internal/HostingLoggerExtensions.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/HostingLoggerExtensions.cs
@@ -94,7 +94,8 @@ namespace Microsoft.AspNetCore.Hosting.Internal
 
         private class HostingLogScope : IReadOnlyList<KeyValuePair<string, object>>
         {
-            private readonly HttpContext _httpContext;
+            private readonly string _path;
+            private readonly string _traceIdentifier;
             private readonly string _correlationId;
 
             private string _cachedToString;
@@ -113,11 +114,11 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                 {
                     if (index == 0)
                     {
-                        return new KeyValuePair<string, object>("RequestId", _httpContext.TraceIdentifier);
+                        return new KeyValuePair<string, object>("RequestId", _traceIdentifier);
                     }
                     else if (index == 1)
                     {
-                        return new KeyValuePair<string, object>("RequestPath", _httpContext.Request.Path.ToString());
+                        return new KeyValuePair<string, object>("RequestPath", _path);
                     }
                     else if (index == 2)
                     {
@@ -130,7 +131,8 @@ namespace Microsoft.AspNetCore.Hosting.Internal
 
             public HostingLogScope(HttpContext httpContext, string correlationId)
             {
-                _httpContext = httpContext;
+                _traceIdentifier = httpContext.TraceIdentifier;
+                _path = httpContext.Request.Path.ToString();
                 _correlationId = correlationId;
             }
 
@@ -141,8 +143,8 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                     _cachedToString = string.Format(
                         CultureInfo.InvariantCulture,
                         "RequestId:{0} RequestPath:{1}",
-                        _httpContext.TraceIdentifier,
-                        _httpContext.Request.Path);
+                        _traceIdentifier,
+                        _path);
                 }
 
                 return _cachedToString;


### PR DESCRIPTION
- Multiple things capture the ExecutionContext, reduce the changes of improperly rooting the HttpContext when we only need a few properties from the request.

Intentional memory leak

```C#
using System.Threading;
using Microsoft.AspNetCore.Builder;
using Microsoft.AspNetCore.Hosting;
using Microsoft.AspNetCore.Http;
using Microsoft.Extensions.DependencyInjection;

namespace WebApplication23
{
    public class Startup
    {
        public void ConfigureServices(IServiceCollection services)
        {
            
        }

        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
        {
            var cts = new CancellationTokenSource();

            app.Run(async (context) =>
            {
                cts.Token.Register(() =>
                {

                });

                await context.Response.WriteAsync("Hello World!");
            });
        }
    }
}
```

This code will capture every HttpContext in the logging scope:

![image](https://user-images.githubusercontent.com/95136/44646009-8664c000-a98e-11e8-83a9-94f3cccaafcc.png)
![image](https://user-images.githubusercontent.com/95136/44646057-b44a0480-a98e-11e8-8814-65fd9a35ca87.png)

It's rooted by the scope which is being captured in the CancellationToken callback.

cc @benaadams 