### PR TITLE
Move all request diagnostics into an IStartupFilter

### DIFF
--- a/samples/GenericWebHost/WebHostService.cs
+++ b/samples/GenericWebHost/WebHostService.cs
@@ -50,7 +50,7 @@ namespace GenericWebHost
             Options.ConfigureApp(HostBuilderContext, builder);
             var app = builder.Build();
 
-            var httpApp = new HostingApplication(app, Logger, DiagnosticListener, HttpContextFactory);
+            var httpApp = new HostingApplication(app, HttpContextFactory);
             return Server.StartAsync(httpApp, cancellationToken);
         }
 

--- a/src/Microsoft.AspNetCore.Hosting/Internal/HostingApplication.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/HostingApplication.cs
@@ -15,16 +15,10 @@ namespace Microsoft.AspNetCore.Hosting.Internal
     {
         private readonly RequestDelegate _application;
         private readonly IHttpContextFactory _httpContextFactory;
-        private HostingApplicationDiagnostics _diagnostics;
-
-        public HostingApplication(
-            RequestDelegate application,
-            ILogger logger,
-            DiagnosticListener diagnosticSource,
-            IHttpContextFactory httpContextFactory)
+        
+        public HostingApplication(RequestDelegate application, IHttpContextFactory httpContextFactory)
         {
             _application = application;
-            _diagnostics = new HostingApplicationDiagnostics(logger, diagnosticSource);
             _httpContextFactory = httpContextFactory;
         }
 
@@ -33,9 +27,6 @@ namespace Microsoft.AspNetCore.Hosting.Internal
         {
             var context = new Context();
             var httpContext = _httpContextFactory.Create(contextFeatures);
-
-            _diagnostics.BeginRequest(httpContext, ref context);
-
             context.HttpContext = httpContext;
             return context;
         }
@@ -50,9 +41,7 @@ namespace Microsoft.AspNetCore.Hosting.Internal
         public void DisposeContext(Context context, Exception exception)
         {
             var httpContext = context.HttpContext;
-            _diagnostics.RequestEnd(httpContext, exception, context);
             _httpContextFactory.Dispose(httpContext);
-            _diagnostics.ContextDisposed(context);
         }
 
         public struct Context

--- a/src/Microsoft.AspNetCore.Hosting/Internal/HostingApplicationDiagnostics.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/HostingApplicationDiagnostics.cs
@@ -154,17 +154,14 @@ namespace Microsoft.AspNetCore.Hosting.Internal
 
             // Logging Scope is finshed with
             context.Scope?.Dispose();
-        }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void ContextDisposed(HostingApplication.Context context)
-        {
             if (context.EventLogEnabled)
             {
                 // Non-inline
                 HostingEventSource.Log.RequestStop();
             }
         }
+
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         private void LogRequestStarting(HttpContext httpContext)
@@ -277,7 +274,14 @@ namespace Microsoft.AspNetCore.Hosting.Internal
         [MethodImpl(MethodImplOptions.NoInlining)]
         private void StopActivity(HttpContext httpContext, Activity activity)
         {
-            _diagnosticListener.StopActivity(activity, new { HttpContext = httpContext });
+            if (_diagnosticListener.IsEnabled(ActivityStartKey))
+            {
+                _diagnosticListener.StopActivity(activity, new { HttpContext = httpContext });
+            }
+            else 
+            {
+                activity.Stop();
+            }
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Hosting/Internal/HostingApplicationDiagnostics.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/HostingApplicationDiagnostics.cs
@@ -162,7 +162,6 @@ namespace Microsoft.AspNetCore.Hosting.Internal
             }
         }
 
-
         [MethodImpl(MethodImplOptions.NoInlining)]
         private void LogRequestStarting(HttpContext httpContext)
         {

--- a/src/Microsoft.AspNetCore.Hosting/Internal/RequestDiagnosticsMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/RequestDiagnosticsMiddleware.cs
@@ -1,0 +1,43 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Hosting.Internal
+{
+    public class RequestDiagnosticsMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private HostingApplicationDiagnostics _diagnostics;
+
+        public RequestDiagnosticsMiddleware(RequestDelegate next, DiagnosticListener diagnosticListener, ILogger logger)
+        {
+            _next = next;
+            _diagnostics = new HostingApplicationDiagnostics(logger, diagnosticListener);
+        }
+
+        public async Task Invoke(HttpContext httpContext)
+        {
+            var context = new HostingApplication.Context();
+            _diagnostics.BeginRequest(httpContext, ref context);
+
+            try
+            {
+                await _next.Invoke(httpContext);
+
+                _diagnostics.RequestEnd(httpContext, null, context);
+            }
+            catch (Exception exception)
+            {
+                _diagnostics.RequestEnd(httpContext, exception, context);
+                throw;
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Hosting/Internal/RequestDiagnosticsStartupFilter.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/RequestDiagnosticsStartupFilter.cs
@@ -1,0 +1,33 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Hosting.Internal
+{
+    public class RequestDiagnosticsStartupFilter : IStartupFilter
+    {
+        private readonly DiagnosticListener _diagnosticListener;
+        private readonly ILoggerFactory _loggerFactory;
+
+        public RequestDiagnosticsStartupFilter(DiagnosticListener diagnosticListener, ILoggerFactory loggerFactory)
+        {
+            _diagnosticListener = diagnosticListener;
+            _loggerFactory = loggerFactory;
+        }
+
+        public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
+        {
+            return builder =>
+            {
+                // This logging category is for compatibility
+                var logger = _loggerFactory.CreateLogger<WebHost>();
+                builder.UseMiddleware<RequestDiagnosticsMiddleware>(_diagnosticListener, logger);
+                next(builder);
+            };
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Hosting/Internal/WebHost.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/WebHost.cs
@@ -203,15 +203,8 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                 EnsureServer();
 
                 var builderFactory = _applicationServices.GetRequiredService<IApplicationBuilderFactory>();
-                var diagnosticSource = _applicationServices.GetRequiredService<DiagnosticListener>();
                 var builder = builderFactory.CreateBuilder(Server.Features);
                 builder.ApplicationServices = _applicationServices;
-
-                // Make sure the diagnostic middleware runs first. Ideally this would be a startup filter
-                // but at the moment it's possible to run code before those and that might break some scenarios
-                // We can move to an IStartupFilter in the next major but try to preserve as much
-                // here on by default.
-                builder.UseMiddleware<RequestDiagnosticsMiddleware>(_logger, diagnosticSource);
 
                 var startupFilters = _applicationServices.GetService<IEnumerable<IStartupFilter>>();
                 Action<IApplicationBuilder> configure = _startup.Configure;

--- a/src/Microsoft.AspNetCore.Hosting/WebHostBuilder.cs
+++ b/src/Microsoft.AspNetCore.Hosting/WebHostBuilder.cs
@@ -291,7 +291,8 @@ namespace Microsoft.AspNetCore.Hosting
             services.AddOptions();
             services.AddLogging();
 
-            // Conjure up a RequestServices
+            // Add default middleware to the pipeline
+            services.AddTransient<IStartupFilter, RequestDiagnosticsStartupFilter>();
             services.AddTransient<IStartupFilter, AutoRequestServicesStartupFilter>();
             services.AddTransient<IServiceProviderFactory<IServiceCollection>, DefaultServiceProviderFactory>();
 


### PR DESCRIPTION
- This should enable people to plug in a custom request ID, logging scope, or any other diagnostic thing, without adding extra extensibility.

The one potential breaking change is for things like Autofac.Multitenant (https://github.com/autofac/Autofac.AspNetCore.Multitenant/blob/6ab27ab5312159da2f50e4d8f88dfbca670fb09e/src/Autofac.Integration.AspNetCore.Multitenant/AutofacMultitenantWebHostBuilderExtensions.cs#L65). They inject themselves as the first Startup filter which means request diagnostics would run after instead of before. 

cc @tillig

There are probably other subtle changes to when things run but I'm hoping those specific details don't matter too much. This enables extensibility through existing mechanisms (like middleware) instead of adding more specific hooks to hosting.