### PR TITLE
Dereference the HttpContext when it's no longer needed

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting/Internal/RequestServicesFeature.cs
+++ b/src/Microsoft.AspNetCore.Hosting/Internal/RequestServicesFeature.cs
@@ -31,6 +31,8 @@ namespace Microsoft.AspNetCore.Hosting.Internal
                 if (!_requestServicesSet)
                 {
                     _context.Response.RegisterForDispose(this);
+                    // Don't hold onto the http context any longer than we need to
+                    _context = null;
                     _scope = _scopeFactory.CreateScope();
                     _requestServices = _scope.ServiceProvider;
                     _requestServicesSet = true;


### PR DESCRIPTION
- No need to hold onto it