### PR TITLE
Delay resolution until after application services are built

### DIFF
--- a/src/Microsoft.AspNetCore.Hosting/WebHostBuilder.cs
+++ b/src/Microsoft.AspNetCore.Hosting/WebHostBuilder.cs
@@ -174,13 +174,6 @@ namespace Microsoft.AspNetCore.Hosting
                 }
             }
 
-            var logger = hostingServiceProvider.GetRequiredService<ILogger<WebHost>>();
-            // Warn about duplicate HostingStartupAssemblies
-            foreach (var assemblyName in _options.GetFinalHostingStartupAssemblies().GroupBy(a => a, StringComparer.OrdinalIgnoreCase).Where(g => g.Count() > 1))
-            {
-                logger.LogWarning($"The assembly {assemblyName} was specified multiple times. Hosting startup assemblies should only be specified once.");
-            }
-
             AddApplicationServices(applicationServices, hostingServiceProvider);
 
             var host = new WebHost(
@@ -192,6 +185,15 @@ namespace Microsoft.AspNetCore.Hosting
             try
             {
                 host.Initialize();
+
+                var logger = host.Services.GetRequiredService<ILogger<WebHost>>();
+
+                // Warn about duplicate HostingStartupAssemblies
+                foreach (var assemblyName in _options.GetFinalHostingStartupAssemblies().GroupBy(a => a, StringComparer.OrdinalIgnoreCase).Where(g => g.Count() > 1))
+                {
+                    logger.LogWarning($"The assembly {assemblyName} was specified multiple times. Hosting startup assemblies should only be specified once.");
+                }
+
 
                 return host;
             }
@@ -208,7 +210,7 @@ namespace Microsoft.AspNetCore.Hosting
                 var provider = collection.BuildServiceProvider();
                 var factory = provider.GetService<IServiceProviderFactory<IServiceCollection>>();
 
-                if (factory != null)
+                if (factory != null && !(factory is DefaultServiceProviderFactory))
                 {
                     using (provider)
                     {

--- a/src/Microsoft.AspNetCore.Hosting/WebHostBuilder.cs
+++ b/src/Microsoft.AspNetCore.Hosting/WebHostBuilder.cs
@@ -194,7 +194,6 @@ namespace Microsoft.AspNetCore.Hosting
                     logger.LogWarning($"The assembly {assemblyName} was specified multiple times. Hosting startup assemblies should only be specified once.");
                 }
 
-
                 return host;
             }
             catch


### PR DESCRIPTION
- Resolve the logger from the right service provider to log duplicate hosting startup assemblies.
- Don't create a 3rd `IServiceProvider` if we resolved the default implementation.

This fixes logger being resolved too early:

## Before 

Notice the 2 console logger threads.

![image](https://user-images.githubusercontent.com/95136/45924909-0879d300-bec0-11e8-99a4-933b84f674f8.png)

## After

![image](https://user-images.githubusercontent.com/95136/45925011-f436d580-bec1-11e8-8561-3e5e0ef8fe2b.png)

NOTE: This is still possible if you resolve the ILoggerFactory or ILogger from your Startup constructor.