### PR TITLE
Make TestServer handle exceptions from OnStarting 

### DIFF
--- a/src/Microsoft.AspNetCore.TestHost/HttpContextBuilder.cs
+++ b/src/Microsoft.AspNetCore.TestHost/HttpContextBuilder.cs
@@ -109,7 +109,16 @@ namespace Microsoft.AspNetCore.TestHost
             if (!_responseFeature.HasStarted)
             {
                 // Sets HasStarted
-                await _responseFeature.FireOnSendingHeadersAsync();
+                try
+                {
+                    await _responseFeature.FireOnSendingHeadersAsync();
+                }
+                catch (Exception ex)
+                {
+                    Abort(ex);
+                    return;
+                }
+
                 // Copy the feature collection so we're not multi-threading on the same collection.
                 var newFeatures = new FeatureCollection();
                 foreach (var pair in _httpContext.Features)


### PR DESCRIPTION
#1594 Large exceptions would cause back-pressure and prevent the app from exiting. Abort the stream so no more writes are allowed and report the exception to the client.